### PR TITLE
fix: iOS home hero layout, player toolbar controls, keyboard type, re…

### DIFF
--- a/Cinemax.xcodeproj/project.pbxproj
+++ b/Cinemax.xcodeproj/project.pbxproj
@@ -150,7 +150,7 @@
 		71EDA47106672004DE07BDCF /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		7574F55BA72A352BA19F86E0 /* MediaDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDetailViewModel.swift; sourceTree = "<group>"; };
 		78377E8E832D65F7226A2A06 /* AppNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNavigation.swift; sourceTree = "<group>"; };
-		7D88DF3FEF51CF7E5E1C948A /* Cinemax.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Cinemax.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7D88DF3FEF51CF7E5E1C948A /* Cinemax.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Cinemax.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8324C15002E8D55B4849D71F /* MediaDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDetailScreen.swift; sourceTree = "<group>"; };
 		8AD54DA146623D212A6F5AFE /* TVPlayerHostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVPlayerHostViewController.swift; sourceTree = "<group>"; };
 		8AE5FB096BB1BE0581798DFD /* PosterCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PosterCard.swift; sourceTree = "<group>"; };
@@ -716,6 +716,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -791,6 +792,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Shared/DesignSystem/Components/ContentRow.swift
+++ b/Shared/DesignSystem/Components/ContentRow.swift
@@ -15,6 +15,7 @@ struct ContentRow<Content: View>: View {
                 Text(title)
                     .font(CinemaFont.headline(.large))
                     .foregroundStyle(CinemaColor.onSurface)
+                    .lineLimit(1)
                     .accessibilityAddTraits(.isHeader)
 
                 Spacer()

--- a/Shared/DesignSystem/Components/GlassTextField.swift
+++ b/Shared/DesignSystem/Components/GlassTextField.swift
@@ -7,6 +7,9 @@ struct GlassTextField: View {
     var placeholder: String = ""
     var icon: String? = nil
     var isSecure: Bool = false
+    #if os(iOS)
+    var keyboardType: UIKeyboardType = .default
+    #endif
 
     @FocusState private var isFocused: Bool
 
@@ -94,6 +97,7 @@ struct GlassTextField: View {
                     .font(.system(size: 18, weight: .medium))
                     .foregroundStyle(CinemaColor.onSurface)
                     .tint(themeManager.accent)
+                    .keyboardType(keyboardType)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
             }

--- a/Shared/DesignSystem/LocalizationManager.swift
+++ b/Shared/DesignSystem/LocalizationManager.swift
@@ -9,7 +9,10 @@ final class LocalizationManager {
     private var _revision: Int = 0
 
     var languageCode: String {
-        get { _languageCode }
+        get {
+            _ = _revision
+            return _languageCode
+        }
         set {
             _languageCode = newValue
             _bundle = nil

--- a/Shared/DesignSystem/ThemeManager.swift
+++ b/Shared/DesignSystem/ThemeManager.swift
@@ -16,7 +16,10 @@ final class ThemeManager {
     @AppStorage("accentColor") private var _accentColorKey: String = "blue"
 
     var accentColorKey: String {
-        get { _accentColorKey }
+        get {
+            _ = _accentRevision
+            return _accentColorKey
+        }
         set {
             _accentColorKey = newValue
             _accentRevision += 1

--- a/Shared/Screens/HomeScreen.swift
+++ b/Shared/Screens/HomeScreen.swift
@@ -29,7 +29,7 @@ struct HomeScreen: View {
 
     private var content: some View {
         ScrollView {
-            LazyVStack(spacing: CinemaSpacing.spacing6) {
+            LazyVStack(alignment: .leading, spacing: CinemaSpacing.spacing6) {
                 // Hero
                 if let hero = viewModel.heroItem {
                     heroSection(hero)
@@ -90,7 +90,8 @@ struct HomeScreen: View {
                     .textCase(.uppercase)
                     .lineLimit(2)
 
-                // Overview
+                // Overview — hidden on iOS to keep hero compact
+                #if os(tvOS)
                 if let overview = item.overview {
                     Text(overview)
                         .font(.system(size: overviewFontSize))
@@ -98,6 +99,7 @@ struct HomeScreen: View {
                         .lineLimit(3)
                         .frame(maxWidth: maxOverviewWidth, alignment: .leading)
                 }
+                #endif
 
                 // Action buttons
                 HStack(spacing: 12) {
@@ -162,8 +164,10 @@ struct HomeScreen: View {
                     }
                 }
             }
-            .padding(heroPadding)
-            .padding(.bottom, CinemaSpacing.spacing6)
+            .padding(.horizontal, heroPadding)
+            .padding(.top, heroPadding)
+            .padding(.bottom, heroPadding + CinemaSpacing.spacing6)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .frame(maxWidth: .infinity)
         .frame(height: heroHeight)
@@ -286,7 +290,7 @@ struct HomeScreen: View {
         #if os(tvOS)
         820
         #else
-        500
+        360
         #endif
     }
 
@@ -294,7 +298,7 @@ struct HomeScreen: View {
         #if os(tvOS)
         72
         #else
-        40
+        20
         #endif
     }
 

--- a/Shared/Screens/LoginScreen.swift
+++ b/Shared/Screens/LoginScreen.swift
@@ -171,7 +171,8 @@ struct LoginScreen: View {
                             label: "",
                             text: $viewModel.username,
                             placeholder: loc.localized("login.username"),
-                            icon: "person"
+                            icon: "person",
+                            keyboardType: .asciiCapable
                         )
 
                         GlassTextField(

--- a/Shared/Screens/VideoPlayerView.swift
+++ b/Shared/Screens/VideoPlayerView.swift
@@ -51,43 +51,6 @@ struct VideoPlayerView: View {
             if let player {
                 VideoPlayer(player: player)
                     .ignoresSafeArea()
-                    .overlay(alignment: .topTrailing) {
-                        HStack(spacing: 0) {
-                            if let prev = currentPrevEpisode, episodeNavigator != nil {
-                                Button { navigateToEpisode(prev) } label: {
-                                    Image(systemName: "backward.end.fill")
-                                        .font(.title2)
-                                        .foregroundStyle(.white)
-                                        .shadow(radius: 4)
-                                        .padding(12)
-                                }
-                                .accessibilityLabel(loc.localized("accessibility.previousEpisode"))
-                                .accessibilityHint(prev.title)
-                            }
-                            if let next = currentNextEpisode, episodeNavigator != nil {
-                                Button { navigateToEpisode(next) } label: {
-                                    Image(systemName: "forward.end.fill")
-                                        .font(.title2)
-                                        .foregroundStyle(.white)
-                                        .shadow(radius: 4)
-                                        .padding(12)
-                                }
-                                .accessibilityLabel(loc.localized("accessibility.nextEpisode"))
-                                .accessibilityHint(next.title)
-                            }
-                            if let info = playbackInfo, info.audioTracks.count > 1 || !info.subtitleTracks.isEmpty {
-                                Button { showTrackPicker = true } label: {
-                                    Image(systemName: "ellipsis.circle.fill")
-                                        .font(.title2)
-                                        .foregroundStyle(.white)
-                                        .shadow(radius: 4)
-                                        .padding(12)
-                                }
-                                .accessibilityLabel(loc.localized("accessibility.trackOptions"))
-                            }
-                        }
-                        .padding(.trailing, 4)
-                    }
                     .sheet(isPresented: $showTrackPicker) {
                         if let info = playbackInfo {
                             TrackPickerSheet(info: info) { audioIdx, subtitleIdx in
@@ -129,11 +92,42 @@ struct VideoPlayerView: View {
         }
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .tabBar)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 Text(currentTitle)
                     .font(CinemaFont.label(.large))
                     .foregroundStyle(CinemaColor.onSurface)
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                HStack(spacing: 4) {
+                    if let prev = currentPrevEpisode, episodeNavigator != nil {
+                        Button { navigateToEpisode(prev) } label: {
+                            Image(systemName: "backward.end.fill")
+                                .font(.system(size: 17, weight: .semibold))
+                                .foregroundStyle(CinemaColor.onSurface)
+                        }
+                        .accessibilityLabel(loc.localized("accessibility.previousEpisode"))
+                        .accessibilityHint(prev.title)
+                    }
+                    if let next = currentNextEpisode, episodeNavigator != nil {
+                        Button { navigateToEpisode(next) } label: {
+                            Image(systemName: "forward.end.fill")
+                                .font(.system(size: 17, weight: .semibold))
+                                .foregroundStyle(CinemaColor.onSurface)
+                        }
+                        .accessibilityLabel(loc.localized("accessibility.nextEpisode"))
+                        .accessibilityHint(next.title)
+                    }
+                    if let info = playbackInfo, info.audioTracks.count > 1 || !info.subtitleTracks.isEmpty {
+                        Button { showTrackPicker = true } label: {
+                            Image(systemName: "ellipsis.circle")
+                                .font(.system(size: 17, weight: .semibold))
+                                .foregroundStyle(CinemaColor.onSurface)
+                        }
+                        .accessibilityLabel(loc.localized("accessibility.trackOptions"))
+                    }
+                }
             }
         }
         #endif


### PR DESCRIPTION
…activity fixes

- HomeScreen: reduce hero height/padding on iOS, hide overview text, fix LazyVStack leading alignment
- VideoPlayerView: move episode nav + track picker from custom overlay into native toolbar; hide tab bar during playback
- GlassTextField: add keyboardType param (iOS); set .asciiCapable on login username field
- ThemeManager/LocalizationManager: fix @Observable reactivity by accessing revision counter in getter
- ContentRow: clamp section title to 1 line to prevent wrapping
- project.pbxproj: set DEVELOPMENT_TEAM + explicitFileType for iOS target