### PR TITLE
feat: audit batch 2 — discovery, playback polish, multi-user, setting…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build artifacts
 .build/
+build/
 DerivedData/
 
 # Xcode

--- a/Audit.md
+++ b/Audit.md
@@ -183,7 +183,8 @@ tvShows.title
 | 7 | Fix season selection race condition | Performance | 30 min | **DONE** (audit 1.1) |
 | 8 | Cancel previous task in `VideoPlayerCoordinator.play()` | Performance | 15 min | **DONE** (audit 1.1.1) |
 | 9 | Remove 33 unused localization keys | Dead code | 15 min | **DONE** (audit 1.1) |
-| 10 | Extract large files into focused components | Refactoring | 4-6 hr | Open |
+| 10 | Extract large files into focused components | Refactoring | 4-6 hr | **PARTIAL** (2026-04-17) — conservative first pass: `JellyfinError` + `MediaTrackInfo` lifted to their own files; `IOSAppearanceDetailView` moved from `SettingsScreen+iOS.swift` (now 489 lines) into `SettingsAppearanceView+iOS.swift`. `NativeVideoPresenter` (~1,300 lines) and `MovieLibraryScreen` (~1,000 lines) not yet split — deferred since a robust extraction needs promoting many `private` members to `internal` and introducing delegate protocols; higher regression risk than this first-pass warranted |
+| 11 | Skip Intro / Credits overlay (Intro Skipper plugin) | Feature | 2 hr | **DONE** — needs testing with Intro Skipper plugin |
 
 ---
 
@@ -208,10 +209,94 @@ tvShows.title
 
 | # | Action | Priority |
 |---|--------|----------|
-| 1 | Respect iOS Dynamic Type settings | Medium |
+| 1 | Respect iOS Dynamic Type settings | Medium — **DONE** (2026-04-17) — `.dynamicTypeSize(.xSmall...accessibility2)` cap at `AppNavigation` root; new `CinemaFont.dynamicBody / dynamicBodyLarge / dynamicLabel(_:)` variants use `UIFontMetrics` so final size = `baseSize × appScale × dynamicTypeMultiplier`; applied to reading-heavy surfaces (MediaDetail overview, episode-card overviews, iOS toggle row labels). Hero/display fonts stay fixed to protect layouts |
 | 2 | Configure App Store distribution signing | Required |
 | 3 | Prepare demo Jellyfin server for App Review | Required |
 | 4 | App Store metadata + screenshots | Required |
 | 5 | Replace force unwraps with safe unwrapping in URL construction | Low |
 
 See `APP_STORE_AUDIT.md` for full audit and future roadmap.
+
+---
+
+## 7. Feature & UX Improvements (2026-04-16)
+
+### UX Friction & Polish
+
+| # | Feature | Description | Effort | Status |
+|---|---------|-------------|--------|--------|
+| 1 | Empty states everywhere | Library with no results, Home with no resume items, series with 0 episodes — show illustration + message instead of silent empty sections | 2 hr | **DONE** (2026-04-17) — `EmptyStateView` component (icon + title + subtitle + optional action); filtered library shows "No matches" with Clear filters action; Home shows "Library is empty" with Refresh |
+| 2 | Toast / snackbar feedback | Visual confirmation on actions (playback started, error, episode navigated). Silent failures confuse users | 3 hr | **DONE** (2026-04-17) — `ToastCenter` + `ToastOverlay` with success/error/info levels; wired to "Surprise Me" failure; injected at `AppNavigation` root |
+| 3 | Pull-to-refresh (iOS) / refresh button (tvOS) | No way to refresh content without killing the app. New items added to Jellyfin don't appear until relaunch | 1 hr | **DONE** (2026-04-16) |
+| 4 | "You finished the series" end screen | When last episode ends and auto-play has nowhere to go, show a completion screen instead of just stopping | 1 hr | **DONE** (2026-04-17) — `showFinishedSeriesOverlay` blur card with green checkmark + series name; `currentSeriesName` captured during chapter fetch; triggered by `itemEndObserver` when autoplay is on and no next episode exists |
+| 5 | Remaining time on episode rows | Episode cards show runtime but not "12 min left" for partially-watched episodes — the thin progress bar isn't enough context | 30 min | **DONE** (2026-04-17) |
+
+### Discovery & Browsing
+
+| # | Feature | Description | Effort | Status |
+|---|---------|-------------|--------|--------|
+| 6 | Genre-based Home rows | Home only has 2 rows (resume + recently added). Add dynamic rows like "Action Movies", "Recent Comedies" using `getItems(genreIds:sortBy:limit:)` | 3 hr | **DONE** (2026-04-16) |
+| 7 | "Surprise me" / Random pick | One tap → play something random. Jellyfin supports `sortBy: Random, limit: 1`. Solves decision paralysis on large libraries | 1 hr | **DONE** (2026-04-17) |
+| 8 | Alphabetical jump bar (iOS library) | Scrolling through 500+ movies with no way to jump to a letter is painful. Side index like Contacts.app | 2 hr | **DONE** (2026-04-17) — `AlphabeticalJumpBar` (iOS-only, Contacts-style capsule index with drag-slide + haptics); only rendered when sort = name ascending and >20 items loaded; uses `ScrollViewReader` to jump to first matching id |
+| 9 | Filter by unwatched only | Most common practical filter — "show me what I haven't seen." Simple toggle next to existing sort/genre controls | 1 hr | **DONE** (2026-04-16) |
+| 10 | Year / decade filter in library | Genre is the only filter axis. "Show me 80s movies" is a real use case for movie collectors | 1 hr | **DONE** (2026-04-17) — decade chips (1950s–2020s) in iOS sort/filter sheet and tvOS inline filter bar; `LibrarySortFilterState.selectedDecades` expanded to `years` parameter on `getItems` |
+
+### Playback Quality of Life
+
+| # | Feature | Description | Effort | Status |
+|---|---------|-------------|--------|--------|
+| 11 | "Resume at X:XX" vs "Play from beginning" | Currently only resume is offered. Sometimes users want to restart. Offer both options | 1 hr | **DONE** (2026-04-16) |
+| 12 | Sleep timer | 30/60/90 min timer that pauses playback. Essential for watching in bed | 2 hr | **DONE** (2026-04-17) — `SleepTimerOption` enum (Off/15/30/45/60/90); Settings > Interface row (iOS Menu, tvOS confirmationDialog) backed by `@AppStorage("sleepTimerDefaultMinutes")`; `NativeVideoPresenter` shows a moon-icon blur pill bottom-left counting down `mm:ss`; on fire, pauses + shows centered card "Still watching?" with "Keep watching" (restarts timer) / "Stop playback" (dismisses player); timer restarts on episode navigation |
+| 13 | Chapter support in scrubber | Jellyfin exposes chapter markers with thumbnails. Display them in the player scrubber for context when seeking | 3 hr | **DONE — tvOS only** (2026-04-17) — `ImageURLBuilder.chapterImageURL`, parallel image fetch via `URLSession` with auth header, `AVNavigationMarkersGroup` applied to `AVPlayerItem.navigationMarkerGroups`. iOS `AVPlayerViewController` has no native chapter UI so this is a tvOS feature (iOS would need a custom scrubber) |
+| 14 | Playback error recovery with guidance | Transcoding failures are silent or cryptic. Show actionable messages like "This file couldn't be played — try enabling transcoding in server settings" | 2 hr | **DONE** (2026-04-17) — `showPlaybackErrorAlert` presents a native `UIAlertController` when all retries are exhausted; error codes mapped to targeted messages (`-12881` transcode, `-12938/-1009/etc.` network, fallback generic); Close button dismisses player |
+
+### Information Density
+
+| # | Feature | Description | Effort | Status |
+|---|---------|-------------|--------|--------|
+| 15 | Video/audio codec badges on detail screen | "4K HDR · Dolby Atmos · HEVC" badges from `MediaSources[0].MediaStreams`. Self-hosted users care deeply about media quality | 2 hr | **DONE** (2026-04-16) — `MediaQualityBadges` view |
+| 16 | Studio / Network label | Jellyfin provides studio info — showing "A24" or "HBO" adds browsable context | 1 hr | **DONE** (2026-04-17) — `studioLine` on `MediaDetailScreen` below overview (shows up to 2 studio names; label reads "Network" for series, "Studio" for movies) |
+| 17 | External ratings (audience + critics) | Jellyfin stores `CommunityRating` and `CriticRating`. Showing both helps users decide what to watch | 1 hr | **DONE** (2026-04-17) — `ratingsRow` on backdrop shows yellow-star community rating + Rotten-Tomatoes-style critic rating (green ≥60, red otherwise) |
+| 18 | Episode air dates on episode cards | Helps users know if they've missed episodes of an ongoing series | 30 min | **DONE** (2026-04-17) |
+
+### Multi-User & Social
+
+| # | Feature | Description | Effort | Status |
+|---|---------|-------------|--------|--------|
+| 19 | "Currently watching" indicator | Show when another server user is watching something (Jellyfin Sessions API). Makes the app feel alive | 2 hr | **DONE** (2026-04-17) — new `getActiveSessions` protocol method; `HomeViewModel.activeSessions` filters out the current user + idle sessions; "Watching Now" row on Home with a red LIVE pill overlay on each card; toggleable in Settings > Home Page |
+| 20 | Quick user switch | Families share a TV. Tap avatar → pick user → PIN → done, without full server re-entry | 3 hr | **DONE** (2026-04-17) — new `UserSwitchSheet` (grid of user avatars → password prompt → re-auth keeping serverURL); wired into Settings > Account row on both iOS and tvOS; success emits a toast and closes the sheet; errors keep the sheet open for retry |
+
+### Prioritized Top 10
+
+| # | Feature | Category | Effort | Impact | Status |
+|---|---------|----------|--------|--------|--------|
+| 1 | Genre-based Home rows | Discovery | 3 hr | **High** — transforms Home from bare to rich | **DONE** (2026-04-16) — user-configurable via Settings > Interface > Home Page |
+| 2 | Pull-to-refresh / refresh | UX Polish | 1 hr | **High** — basic hygiene, absence is immediately noticeable | **DONE** (2026-04-16) |
+| 3 | "Resume" vs "Play from beginning" | Playback | 1 hr | **High** — daily friction for every partially-watched item | **DONE** (2026-04-16) |
+| 4 | Filter by unwatched | Discovery | 1 hr | **High** — most useful filter for repeat library visits | **DONE** (2026-04-16) |
+| 5 | Codec / quality badges | Information | 2 hr | **High** — differentiator for self-hosted audience | **DONE** (2026-04-16) — toggleable via Settings > Interface > Detail Page |
+| 6 | Empty states everywhere | UX Polish | 2 hr | **Medium** — builds trust, removes confusion | **DONE** (2026-04-17) |
+| 7 | "Surprise me" random pick | Discovery | 1 hr | **Medium** — fun, solves decision paralysis | **DONE → relocated** (2026-04-17) — initially on Home, then moved to **SearchScreen** empty state. Two distinct pills (`Surprise movie` / `Surprise series`) feel more natural where users go when they don't know what to watch. Pushes `MediaDetailScreen` via `navigationDestination(item:)` |
+| 8 | Remaining time on episode rows | UX Polish | 30 min | **Medium** — quick win, better resume context | **DONE** (2026-04-17) — partial episodes show "Xm remaining" via shared `episodeMetadataLine` helper on both platforms |
+| 9 | Chapter support in scrubber | Playback | 3 hr | **Medium** — valuable for long movies | **DONE — tvOS** (2026-04-17) |
+| 10 | Episode air dates | Information | 30 min | **Medium** — quick win for ongoing series | **DONE** (2026-04-17) — `premiereDate` rendered in the shared `episodeMetadataLine` helper, combined with runtime/remaining on one line |
+
+---
+
+## 8. UX Refinements & Debug Tooling (2026-04-17)
+
+### Refresh & Surprise relocation
+
+| # | Change | Description |
+|---|--------|-------------|
+| 1 | Surprise-me moved from Home → Search | Two pills (Surprise movie / Surprise series) in `SearchScreen`'s "search your library" empty state. Removed iOS toolbar dice + tvOS pill from Home. Search is where users go when they don't know what to watch — better discovery context. |
+| 2 | Refresh buttons removed | Removed the tvOS Refresh pill from Home and from the `MediaLibraryScreen` filter bar. iOS pull-to-refresh remains. |
+| 3 | "Refresh Catalogue" added to Settings → Server | Single user-driven catalogue refresh. Calls `apiClient.clearCache()` and posts `.cinemaxShouldRefreshCatalogue`; Home and Library `.onReceive` reload. Toast confirms. New `clearCache()` on `APIClientProtocol`. |
+
+### Debug tooling
+
+| # | Feature | Description |
+|---|---------|-------------|
+| 1 | Debug section in Settings → Interface | Two `@AppStorage`-backed toggles (`debug.fastSleepTimer`, `debug.showSkipToEnd`); always visible (not gated by `#if DEBUG`) so QA / power users can reach them without a special build. Orange icon to signal "developer territory". |
+| 2 | Fast sleep timer (15 s override) | New `SleepTimerOption.currentDefaultSeconds` returns 15 seconds when `debug.fastSleepTimer` is on; `NativeVideoPresenter.startSleepTimerIfNeeded` uses this helper instead of reading the option directly. Lets you preview the "Still watching?" prompt after only 15 s of playback. |
+| 3 | Skip-to-end button in player HUD | When `debug.showSkipToEnd` is on, `NativeVideoPresenter` paints a small purple `⏭ End` chip top-right of the player. Seeks to `(duration − 15 s)` so you can verify the end-of-series completion overlay without watching a full episode. Hidden by default. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,26 @@ Native Jellyfin media streaming client for iOS 18+ and tvOS 26+. Uses a "Cinema 
 - **Swift 6** strict concurrency
 - **JellyfinClient** wrapped with `NSLock` + `nonisolated(unsafe)` for Sendable conformance
 
+### Modern API requirements (iOS 18 / tvOS 26)
+
+The project's deployment targets are iOS 18 and tvOS 26. Avoid pre-iOS-15 APIs that the compiler has now deprecated.
+
+- **`UIButton`**: never use `UIButton(type:)` + `setTitle` / `setTitleColor` / `titleLabel?.font` / `backgroundColor` / `contentEdgeInsets`. Build buttons with `UIButton.Configuration`:
+  ```swift
+  var config = UIButton.Configuration.plain()
+  var attrTitle = AttributedString("Hello")
+  attrTitle.font = .systemFont(ofSize: 17, weight: .semibold)
+  attrTitle.foregroundColor = UIColor.white
+  config.attributedTitle = attrTitle
+  config.contentInsets = NSDirectionalEdgeInsets(top: 14, leading: 24, bottom: 14, trailing: 24)
+  config.background.backgroundColor = .systemBlue
+  config.background.cornerRadius = 12
+  // Frosted background is supported via `config.background.customView = UIVisualEffectView(...)`
+  let button = UIButton(configuration: config, primaryAction: UIAction { _ in ... })
+  ```
+- **Free SwiftUI helpers**: free functions returning `some View` that touch SwiftUI types (`PrimitiveButtonStyle.plain`, `Font`, etc.) must be `@MainActor`. Under Swift 6 strict concurrency, those types are main-actor-isolated and the compiler raises "Main actor-isolated static property X can not be referenced from a nonisolated context" otherwise. The shared `iOSToggleRow` / `iOSSettingsRow` helpers in `SettingsRowHelpers.swift` follow this pattern.
+- **iPad multitasking**: `UIRequiresFullScreen: true` is set in `project.yml` for the iOS target. Cinemax is a video player — split view would interrupt playback and break hero/backdrop layouts, and the flag also satisfies Xcode's "all interface orientations must be supported unless the app requires full screen" warning. Don't change this without a strong reason; if the app ever needs split view, the iPhone orientation list must be expanded to include `UIInterfaceOrientationPortraitUpsideDown` (currently omitted on iPhone).
+
 **Dependencies**: `jellyfin-sdk-swift` v0.6.0, `Nuke`/`NukeUI` v12.9.0, `AVKit`/`AVPlayer`
 
 **Playback reporting**: `APIClientProtocol` defines `reportPlaybackStart`, `reportPlaybackProgress`, `reportPlaybackStopped`. `NativeVideoPresenter` (both platforms) calls these on start, every 10 s, and on dismiss/disappear. Without these calls Jellyfin never updates `playbackPositionTicks` / `isPlayed`, so `getNextUp` and resume data stay stale.
@@ -22,7 +42,7 @@ Shared/
     Components/     CinemaLazyImage, ProgressBarView, RatingBadge, LoadingStateView, ErrorStateView, PosterCard, WideCard, ContentRow, CinemaButton, FlowLayout
   Navigation/       AppNavigation (auth routing), MainTabView (tab bar/sidebar)
   Screens/          HomeScreen, LoginScreen, ServerSetupScreen, SearchScreen, MediaDetailScreen,
-                    MovieLibraryScreen, LibrarySortFilterSheet, TVSeriesScreen,
+                    MovieLibraryScreen, LibrarySortFilterSheet, TVSeriesScreen, MediaQualityBadges,
                     VideoPlayerView, NativeVideoPresenter, HLSManifestLoader, PlayLink, TrackPickerSheet,
                     SettingsScreen (+iOS, +tvOS platform variants), SettingsRowHelpers
   ViewModels/       HomeViewModel, LoginViewModel, SearchViewModel, ServerSetupViewModel,
@@ -64,13 +84,21 @@ Unified screen parameterized by `BaseItemKind` (movies or series).
 
 **Sort & Filter state** (`LibrarySortFilterState`):
 - Default: `dateCreated` descending. `isNonDefault` is true when sort or filter differs from default
-- `isFiltered` is true only when genre chips are selected
-- **Browse vs filtered**: show browse view (genre rows) whenever `isFiltered == false`, regardless of sort. Only a genre chip selection switches to the flat filtered grid
-- **Title count**: uses `isFiltered` (not `isNonDefault`) — sort-only changes don't affect total count, only genre filtering does. Shows `filteredTotalCount` when filtered, `totalCount` otherwise
-- Sort change triggers `reloadGenreItems` (genre rows respect current sort); genre selection triggers `applyFilter` (flat paginated list)
-- `loadInitial` guarded by `hasLoaded` — prevents re-randomization on tab switch
+- `isFiltered` is true when genre chips are selected OR `showUnwatchedOnly == true` OR `selectedDecades` non-empty
+- **Browse vs filtered**: show browse view (genre rows) whenever `isFiltered == false`, regardless of sort. Genre chip / unwatched toggle / decade chip switches to the flat filtered grid
+- **Title count**: uses `isFiltered` (not `isNonDefault`) — sort-only changes don't affect total count. Shows `filteredTotalCount` when filtered, `totalCount` otherwise
+- Sort change triggers `reloadGenreItems` (genre rows respect current sort); filter change triggers `applyFilter` (flat paginated list)
+- `loadInitial` guarded by `hasLoaded` — prevents re-randomization on tab switch. `reload(using:)` bypasses the guard and re-runs the full load. Triggered by pull-to-refresh on iOS and by `.cinemaxShouldRefreshCatalogue` notification from Settings → Server → Refresh Catalogue on both platforms
 
-**tvOS filter bar**: inline (not modal) — sort pills (horizontal scroll) + genre chips (`FlowLayout`, multi-line) + reset button. `TVFilterChipButtonStyle` for chip focus.
+**Filters**:
+- Unwatched: iOS sort sheet `unwatchedSection` + tvOS inline Watch Status chip → `LibrarySortFilterState.showUnwatchedOnly` → `filters: [.isUnplayed]` on `getItems`
+- Decade: `LibrarySortFilterState.selectedDecades: Set<Int>` (stored as the starting year, e.g. `1980`). `expandedYears` explodes the set into every concrete year and passes to `getItems(years:)`. UI: chips for 1950s–2020s in both iOS sort sheet and tvOS inline bar
+
+**Refresh**: `.refreshable { reload() }` on iOS. On both platforms, observes `.cinemaxShouldRefreshCatalogue` (posted by Settings → Server → Refresh Catalogue, which also calls `apiClient.clearCache()`). No in-page refresh button — the global Settings action is the single source of truth.
+
+**tvOS filter bar**: inline (not modal) — sort pills (horizontal scroll) + watch-status chip + decade chips + genre chips (`FlowLayout`, multi-line) + Reset button only. `TVFilterChipButtonStyle` for chip focus.
+
+**iOS alphabetical jump bar**: `AlphabeticalJumpBar` (Contacts-style capsule, ultraThinMaterial background, right edge of filtered view). Tap or drag to scroll the grid. Uses `ScrollViewReader` + `proxy.scrollTo(firstItemID(for: letter))` and `UISelectionFeedbackGenerator` for per-letter haptics. Only rendered when `sortBy == .sortName && sortAscending && items.count > 20` — other sorts aren't alphabetically meaningful.
 
 ## Video Playback
 
@@ -99,10 +127,27 @@ Both iOS and tvOS use native `AVPlayerViewController` presented via UIKit modal 
 
 **Episode navigation**: `MPRemoteCommandCenter` prev/next track commands on both platforms. `EpisodeRef` + `EpisodeNavigator` + `buildEpisodeNavigation` (shared free function in `PlayLink.swift`). `PlayLink` carries `previousEpisode`, `nextEpisode`, `episodeNavigator`; passes through `VideoPlayerCoordinator` (tvOS) or `VideoPlayerView` (iOS) → `NativeVideoPresenter`
 
-**Playback reporting**: `reportPlaybackStart`, `reportPlaybackProgress` (10 s loop), `reportPlaybackStopped` — called on start, periodically, and on dismiss/episode-nav
+**Playback reporting**: `reportPlaybackStart`, `reportPlaybackProgress`, `reportPlaybackStopped` — called on start, periodically (via shared 1 s time observer, reports every ~10 s), and on dismiss/episode-nav
 
 **Auto-play next episode**: `AVPlayerItem.didPlayToEndTime` observer → `navigateToEpisode(next)` when `autoPlayNextEpisode` setting is on
 
+**Skip Intro / Credits**: Requires the **Intro Skipper** plugin (or similar) on the Jellyfin server. On playback start (and episode navigation), `NativeVideoPresenter` fetches media segments via `getMediaSegments(itemId:includeSegmentTypes: [.intro, .outro])`. A single `addPeriodicTimeObserver` (1 s interval) handles both segment detection and progress reporting. Visibility is **pure time-based**: `checkSegments` shows/hides based on whether `currentTime ∈ [segment.start, segment.end)`. Re-entry works naturally — rewinding back into a segment re-shows the button. Click action seeks to `segment.end`; no manual hide call, the next observer tick detects we're outside the segment and clears the button. Localization keys: `player.skipIntro`, `player.skipCredits`.
+
+Rendering is platform-split:
+- **iOS**: a floating `UIButton` (with `UIBlurEffect` background, bottom-right corner of the player) added directly to `AVPlayerViewController.view`. Direct touch.
+- **tvOS**: native `AVPlayerViewController.contextualActions = [UIAction(…)]`. This is the only mechanism that produces a focusable action button coexisting with `AVPlayerViewController`'s transport-bar focus context. **Custom subviews / overlay modals / subclass `preferredFocusEnvironments` overrides cannot be focused on tvOS while AVPlayerViewController is on screen** — the player owns and locks its focus environment. Do not attempt to reintroduce a floating pill on tvOS; it will appear but be unreachable by the Siri Remote. Same rule applies to any future "in-player" affordance (next-episode card, chapter menu, etc.) — use `contextualActions` or other native player APIs rather than arbitrary subviews.
+
+**Chapters** (tvOS only): built from `BaseItemDto.chapters` and applied via `AVPlayerItem.navigationMarkerGroups = [AVNavigationMarkersGroup(title:timedNavigationMarkers:)]`. Each marker carries `commonIdentifierTitle` + optional `commonIdentifierArtwork` (JPEG thumbnail fetched from `ImageURLBuilder.chapterImageURL(itemId:imageIndex:)` with the Jellyfin auth token). `AVNavigationMarkersGroup` lives in AVKit on tvOS only; iOS `AVPlayerViewController` has no native chapter scrubber so the iOS path is a scoped `#if os(tvOS)` no-op.
+
+**Sleep timer**: `SleepTimerOption` enum (`Off` / 15 / 30 / 45 / 60 / 90 minutes) backed by `@AppStorage("sleepTimerDefaultMinutes")`. `SleepTimerOption.currentDefaultSeconds` returns 15 s when `debug.fastSleepTimer` is on (Settings → Interface → Debug), otherwise the stored option in seconds. `NativeVideoPresenter.startSleepTimerIfNeeded` runs on playback start and episode navigation — displays a moon-icon blur pill countdown indicator (`mm:ss`) bottom-left of the player, pauses + shows a "Still watching?" prompt when the timer fires. The prompt uses `UIAlertController` on tvOS (focus-friendly) and a custom blur card on iOS; "Keep watching" restarts the timer, "Stop playback" dismisses the player.
+
+**End-of-series completion**: When `AVPlayerItemDidPlayToEndTime` fires with autoplay on, no next episode, and `episodeNavigator != nil`, shows a centered "You finished {Series Name}" overlay. `currentSeriesName` is captured opportunistically from the same `getItem` call that fetches chapters. tvOS uses `UIAlertController`, iOS uses a custom blur card — same focus-context reason as the sleep prompt.
+
+**Playback error recovery**: `showPlaybackErrorAlert(error:)` presents a native `UIAlertController` with error-code-specific messages. `-12881 / -12886 / -16170` → transcode guidance, `-12938 / -1001 / -1004 / -1005 / -1009` → network guidance, fallback → generic. On iOS the alert only fires after the `retryWithDirectURL` fallback itself fails (so we don't interrupt the silent first-try recovery). `isShowingErrorAlert` flag prevents stacking.
+
+**Debug tooling** (Settings → Interface → Debug, always visible not gated by `#if DEBUG`):
+- `debug.fastSleepTimer` — overrides sleep duration to 15 s
+- `debug.showSkipToEnd` — on iOS paints a purple "End" pill top-right of the player that seeks to `(duration − 15 s)`; on tvOS injects the action into `transportBarCustomMenuItems`. Useful for previewing the end-of-series overlay without sitting through an episode.
 
 ## Settings Screen
 
@@ -140,9 +185,26 @@ Both iOS and tvOS use native `AVPlayerViewController` presented via UIKit modal 
 | `forceSubtitles` | `false` | Auto-selects first `.legible` track; disables `appliesMediaSelectionCriteriaAutomatically` |
 | `render4K` | `true` | `maxBitrate` 120 Mbps (on) / 20 Mbps (off) |
 | `autoPlayNextEpisode` | `true` | Auto-navigates to next episode via `AVPlayerItem.didPlayToEndTime` in `NativeVideoPresenter` (both platforms) |
+| `sleepTimerDefaultMinutes` | `0` (Off) | Duration for the sleep timer that starts on playback. Options: 0 / 15 / 30 / 45 / 60 / 90 min via `SleepTimerOption` |
 | `uiScale` | `1.0` | Font scale 80–130%. Bumps `ThemeManager._accentRevision` to force re-render |
 | `darkMode` | `true` | **Must be toggled via `themeManager.darkModeEnabled`**, not directly — direct writes don't bump `_accentRevision` |
 | `accentColor` | `"blue"` | Set via `themeManager.accentColorKey` for same reason |
+| `home.showContinueWatching` | `true` | Toggles the Continue Watching row on Home |
+| `home.showRecentlyAdded` | `true` | Toggles the Recently Added row on Home |
+| `home.showGenreRows` | `true` | Toggles the 4 dynamic genre rows on Home |
+| `home.showWatchingNow` | `true` | Toggles the Watching Now row on Home |
+| `detail.showQualityBadges` | `true` | Toggles the resolution/HDR/codec/audio pill row on `MediaDetailScreen` |
+| `debug.fastSleepTimer` | `false` | Overrides sleep duration to 15 s — for testing the "Still watching?" prompt |
+| `debug.showSkipToEnd` | `false` | Shows an "End" button in the player that seeks to `(duration − 15 s)` — for testing end-of-series overlay |
+
+### Quick user switch
+`UserSwitchSheet` (launched from Settings → Account) — two-step flow: grid of server users with their primary images → password prompt → re-auth. Updates `AppState.accessToken` / `currentUserId` and calls `apiClient.reconnect(url:accessToken:)` without clearing the server URL, then emits a success toast and dismisses. Errors stay inline so the user can retry.
+
+### Refresh Catalogue
+Settings → Server has a "Refresh Catalogue" row that calls `apiClient.clearCache()` and posts `.cinemaxShouldRefreshCatalogue`. `HomeScreen` and `MediaLibraryScreen` observe this notification and reload. Fires a success toast. Single source of truth for forcing a re-fetch — no per-page refresh buttons.
+
+### Debug section
+Settings → Interface → Debug holds testing toggles. Always visible (not gated by `#if DEBUG`) so QA / power users don't need a custom build. Icons are orange to signal developer territory.
 
 ## MediaDetailScreen
 
@@ -155,12 +217,32 @@ Both iOS and tvOS use native `AVPlayerViewController` presented via UIKit modal 
 **Resume / next-up logic in `actionButtons`**:
 - Movie with `playbackPositionTicks > 0` and not `isPlayed`: shows progress bar (accent fill, `playButtonWidth` wide) + remaining time text (`home.remainingTime.*` keys) + "Lecture" button that resumes at saved position via `PlayLink(startTime:)`
 - Series: uses `viewModel.nextUpEpisode` (from `getNextUp`). In-progress episode → progress bar + remaining time + resume button. Finished/next episode → episode label + regular play button. Falls back to series-level play if no next-up
+- **Play from beginning**: when `showResume` is true, a secondary ghost-styled `PlayLink` button (`detail.playFromBeginning`, SF Symbol `backward.end.fill`) is rendered under the resume button with `startTime: nil`. Only shown when a resume position exists — otherwise the single primary button already starts from 0
 - `userData.playbackPositionTicks` and `runTimeTicks` are both `Int?` (not `Int64`); `isPlayed` is `userData.isPlayed: Bool?`
 - Episode rows show a thin accent progress bar overlay at the bottom of the thumbnail for partially-watched episodes
+
+**Quality badges** (`MediaQualityBadges.swift`):
+- Horizontal pill row between `actionButtons` and overview text. Gated on `@AppStorage("detail.showQualityBadges")` (default `true`, toggleable in Settings > Interface > Detail Page)
+- Derived from `item.mediaSources?.first` — first `.video` stream for resolution/HDR/video codec, default audio stream (`defaultAudioStreamIndex`) for audio format/channels
+- Resolution: height thresholds → "4K" / "1080p" / "720p" / "SD"
+- HDR: `VideoRangeType` maps to "Dolby Vision" (any `dovi*` case), "HDR10+", "HDR10", "HDR" (for `hlg`); `VideoRange.hdr` as fallback. No badge for SDR
+- Video codec: "HEVC" (hevc/h265), "H.264", "AV1", "VP9", else uppercased raw codec
+- Audio format: first-hit priority — Atmos (from `profile`/`displayTitle`), TrueHD, "Dolby Digital+" (EAC3), "Dolby Digital" (AC3), DTS, AAC, FLAC, Opus, MP3, else uppercased raw codec
+- Channels: `channelLayout` uppercased (Stereo/Mono title-cased); fallback from `channels` count (8→"7.1", 6→"5.1", 2→"Stereo", 1→"Mono")
+- View returns `EmptyView()` when no streams produce any badges
 
 **Episode navigation wiring**:
 - `episodeNavigation(for:)` — O(1) lookup from precomputed `viewModel.episodeNavigationMap` (current season) or `viewModel.nextUpNavigationMap` (cross-season next-up). Maps are rebuilt in `MediaDetailViewModel` whenever episodes change
 - Both `actionButtons` (next-up episode) and each `episodeRow` pass `previousEpisode`, `nextEpisode`, `episodeNavigator` to `PlayLink`
+
+**Ratings row** (`ratingsRow`): backdrop-adjacent. Shows `communityRating` (yellow star + `%.1f`) and `criticRating` (Rotten-Tomatoes-style icon — green if ≥ 60, red otherwise — + `%d%%`). Either or both may be absent.
+
+**Studio / Network label** (`studioLine`): below the overview. Up to 2 names from `item.studios`. Label reads "STUDIO" for movies, "NETWORK" for series. Returns `EmptyView` when the array is empty.
+
+**Episode metadata line** (`episodeMetadataLine`): shared helper used by both the tvOS `episodeRow` and iOS `iOSEpisodeCard`. Combines with ` • ` separator:
+- If in-progress (not `isPlayed`, `playbackPositionTicks > 0`, remaining > 0): "Xm remaining" via `home.remainingTime.*` keys
+- Else if `runTimeTicks > 0`: total runtime via `detail.runtime.min`
+- Plus `premiereDate` formatted as `.dateTime.month(.abbreviated).day().year()` when present
 
 ## HomeScreen
 
@@ -171,12 +253,60 @@ Both iOS and tvOS use native `AVPlayerViewController` presented via UIKit modal 
   - `startTime` — from `playbackPositionTicks / 10_000_000` (nil for items with no progress)
   - `previousEpisode`, `nextEpisode`, `episodeNavigator` — looked up from `resumeNavigation[id]` (nil for movies)
 
+**Genre rows**: `HomeViewModel.genreRows: [(genre, items)]` — after loading resume/latest, fetches all genres via `getGenres(userId:includeItemTypes: [.movie, .series])`, shuffles and picks 4. Each genre's items are fetched in parallel via `TaskGroup` using `getItems(sortBy: [.random], genres: [genre], limit: 10, includeItemTypes: [.movie, .series])`. Empty genres are skipped; the 4 picks' order is preserved. Rendered as `ContentRow`s using `PosterCard` inside `NavigationLink` to `MediaDetailScreen`.
+
+**Watching Now row**: `HomeViewModel.activeSessions` — fetched via `getActiveSessions(activeWithinSeconds: 60)`, filtered to drop the current user and sessions with no `nowPlayingItem`. Rendered with `WideCard` + a red "LIVE" pill overlay, navigates to the item's `MediaDetailScreen` on tap.
+
+**Configurable layout** (`@AppStorage`, declared in `SettingsScreen.swift`, UI in Settings > Interface > Home Page):
+| Key | Default | Row |
+|-----|---------|-----|
+| `home.showContinueWatching` | `true` | Continue Watching |
+| `home.showRecentlyAdded` | `true` | Recently Added |
+| `home.showGenreRows` | `true` | All 4 genre rows (block-level toggle) |
+| `home.showWatchingNow` | `true` | Watching Now (other users) |
+
+Hero is never gated — always renders when `heroItem` is non-nil.
+
+**Refresh**: `.refreshable { await viewModel.reload(using: appState) }` on iOS. Both platforms observe `.cinemaxShouldRefreshCatalogue` (posted by Settings → Server → Refresh Catalogue) and call `viewModel.reload`. No in-page refresh pill — Settings is the single trigger. `HomeViewModel.reload(using:)` repopulates everything including genre rows, active sessions, and `resumeNavigation` (cleared before rebuild to avoid stale prev/next refs).
+
+**Empty state**: when `heroItem`, `resumeItems`, `latestItems` and `genreRows` are all empty, renders `EmptyStateView` with a "Your library is empty" message and a Refresh action wrapped in a `ScrollView` so pull-to-refresh still works.
+
+**Scroll-to-top on reappearance (tvOS)**: content is wrapped in `ScrollViewReader` with a zero-height `.id("home.top")` sentinel at the top. `.onAppear` fires `proxy.scrollTo("home.top", anchor: .top)` whenever the screen re-appears (after a deep nav pop or tab switch). This surfaces the system top tab bar which can otherwise stay hidden behind scrolled content. Same pattern applies in `MovieLibraryScreen`, `SearchScreen`, and Settings tvOS landing.
+
+## SearchScreen
+
+- `SearchViewModel.search(using:)` debounces by 400 ms then calls `searchItems(userId:searchTerm:limit:30)`
+- iOS: microphone button launches `SpeechRecognitionHelper` (SFSpeechRecognizer + AVAudioEngine wrapper) for voice search
+- **Surprise Me**: two pills ("Surprise movie" / "Surprise series") in the search empty state. Backed by `fetchRandomMovie(using:)` / `fetchRandomSeries(using:)` which call `getItems(includeItemTypes: [.movie or .series], sortBy: [.random], limit: 1)`. Two separate methods (not one parameterized) because Swift 6 strict concurrency flags a `[BaseItemKind]` array built from a function parameter as non-Sendable when crossing to the API actor — literal `[.movie]` / `[.series]` arrays work fine. On success pushes `MediaDetailScreen` via `navigationDestination(item:)`; on empty library emits an error toast
+- **tvOS scroll-to-top**: wrapped in `ScrollViewReader` with a sentinel, `.onAppear` scrolls to top so the system tab bar resurfaces after a deep-nav pop
+
 ## Localization
 
 - `LocalizationManager` (`@Observable`, injected from `AppNavigation`). Default: French (`fr`), also English (`en`)
 - All strings via `loc.localized("key")` or `loc.localized("key", args...)` — never hardcoded
 - Strings at `Resources/{lang}.lproj/Localizable.strings`
 - Reactivity: `@ObservationIgnored` + `@AppStorage` + `_revision` counter pattern (same as `ThemeManager`)
+
+## Toasts
+
+- `ToastCenter` (`@Observable`, injected at `AppNavigation` root) — single-toast queue with auto-dismiss
+- `ToastOverlay` renders a top-anchored glass pill (level-tinted SF Symbol + title + optional message) that slides in from the top safe area
+- API: `.success(_:)`, `.error(_:)`, `.info(_:)`, all with optional `message:` and `duration:` parameters
+- Use for: action feedback (Refresh Catalogue, user switch success), recoverable error surfaces. Do NOT use for critical errors that need user decision — use `UIAlertController` instead
+
+## Empty states
+
+- `EmptyStateView` (icon + title + optional subtitle + optional action button)
+- Used by:
+  - Home when `heroItem` / resume / latest / genre rows are all empty
+  - Filtered library grid when sort + filter yields no results (offers "Clear filters" action that resets `LibrarySortFilterState()`)
+  - `UserSwitchSheet` when user list is empty
+
+## Dynamic Type (iOS)
+
+- `.dynamicTypeSize(.xSmall ... .accessibility2)` applied at `AppNavigation` root — honors the user's OS-level text-size preference while capping below accessibility sizes that would break hero/tab-bar layouts
+- `CinemaFont.dynamicBody / dynamicBodyLarge / dynamicLabel(_:)` variants use `UIFontMetrics(forTextStyle:).scaledValue(for:)` so the final size is `baseSize × CinemaScale.factor (app uiScale) × dynamicTypeMultiplier (OS)`
+- Apply dynamic variants only to reading-heavy surfaces (overviews, settings rows, list cells). Hero / display / headline titles keep the fixed `CinemaFont.body` / `.headline()` variants to protect layout
 
 ## Image Patterns
 

--- a/Cinemax.xcodeproj/project.pbxproj
+++ b/Cinemax.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		082182AE9E94BB018DAD024D /* SettingsRowHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4049AE456C81ACB9DD77BA6B /* SettingsRowHelpers.swift */; };
+		0A06186102AA10D92923583B /* AlphabeticalJumpBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9B086604524FCFB71F0E15 /* AlphabeticalJumpBar.swift */; };
 		0C4FDF863DEADECFEBABE17B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 653AA083295D61DCACCEC0A1 /* PrivacyInfo.xcprivacy */; };
 		0E09FF53825D339001BB6137 /* VideoPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97F65D618EBC05344F98AD7 /* VideoPlayerView.swift */; };
 		0E89D264CCF6B086910782A7 /* ServerSetupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0A552AFA2A46BB879FE87B /* ServerSetupViewModel.swift */; };
@@ -16,18 +17,21 @@
 		130625B99997A1EAB31AF7C9 /* CinemaxKit in Frameworks */ = {isa = PBXBuildFile; productRef = 9741846667BDD8F1C021426D /* CinemaxKit */; };
 		1695AF73A0D756A11490FF4B /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611E44F72064D91AE6DBCC6C /* SearchViewModel.swift */; };
 		172A4AE31E117BAB19C89CA6 /* PosterCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE5FB096BB1BE0581798DFD /* PosterCard.swift */; };
+		173F19747EE155F10F3B6115 /* AlphabeticalJumpBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9B086604524FCFB71F0E15 /* AlphabeticalJumpBar.swift */; };
 		18D5366C4AD5FA663CF6EC03 /* TVButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4ACBF04D222D92DA5953B /* TVButtonStyles.swift */; };
 		18D85464EB601F8113743C4D /* ProgressBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DF8C441837A8A10C480077 /* ProgressBarView.swift */; };
 		1B6075E5B54067D4015EC06F /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D37B5166A4FB48D21B2F845 /* LoginViewModel.swift */; };
 		1F8DDF74B6AA98658B045CF5 /* MovieLibraryScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A30840A8AEBE5AA59B722F /* MovieLibraryScreen.swift */; };
 		276021C21CB270437185ACF2 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1B61BF8E4B4D7BFFEEDF40 /* MainTabView.swift */; };
 		2795FD90A8FA67405535C2B7 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 653AA083295D61DCACCEC0A1 /* PrivacyInfo.xcprivacy */; };
+		28247D55CC29D95670733239 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81F4A35762E8619A3D24747 /* EmptyStateView.swift */; };
 		2853B78C03BA5522E348B212 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 280786386ED204F8AAAF36B6 /* Assets.xcassets */; };
 		28909321B0A490C0E70342E4 /* GlassTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59CE3A78C397CC15A81F1635 /* GlassTextField.swift */; };
 		289B6BE095E7F76554DAE841 /* TrackPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5D31C0A9CB664FEB840DA3 /* TrackPickerSheet.swift */; };
 		28A82A58BDED7ACD5B9221F8 /* HomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D8CB8B2A5B48928CFF4A61 /* HomeScreen.swift */; };
 		2BC23AB09D961A04A91415F7 /* AppNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78377E8E832D65F7226A2A06 /* AppNavigation.swift */; };
 		2D505F5E99229EC948F2A7E0 /* TVSeriesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0A181A9E709E7700EC2E95 /* TVSeriesScreen.swift */; };
+		2E1A085843FA335D04A9B52B /* ToastCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5610FD34CD71B2F9E4D65FC6 /* ToastCenter.swift */; };
 		2FA1FE57761F94C1764861F9 /* LocalizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32016E5B7B38AFDEB6E75857 /* LocalizationManager.swift */; };
 		2FA754E7C1024D2E05A46524 /* ErrorStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929537FA4254CCBD87E276B3 /* ErrorStateView.swift */; };
 		2FE40D74DA7EDE3249D0D17B /* CinemaGlassTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF56288932318BE6C754F7B /* CinemaGlassTheme.swift */; };
@@ -37,6 +41,7 @@
 		3674658960C75FB68F6576B9 /* CinemaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD86E8274D7D248752E886F /* CinemaButton.swift */; };
 		389E81F4513E0CE8A622D08F /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1B61BF8E4B4D7BFFEEDF40 /* MainTabView.swift */; };
 		38D0284F287A35C7FC3D4858 /* PlayLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA4717DCFEE46C5BE3F4787 /* PlayLink.swift */; };
+		390666CDBDB35103BE1D0246 /* ToastOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E5C1E6AA06EF0B35E4B4CD2 /* ToastOverlay.swift */; };
 		3B587F7E3960823F29F25C26 /* FlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB88BD157A83540E8C49B329 /* FlowLayout.swift */; };
 		4134A3AE6228FC62801C9E93 /* CinemaxKit in Frameworks */ = {isa = PBXBuildFile; productRef = CC223F1A46FB5458A8F326AD /* CinemaxKit */; };
 		43C558D639F56A03ABE38F41 /* SettingsScreen+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E9157A106817FC0C04B450 /* SettingsScreen+tvOS.swift */; };
@@ -46,6 +51,7 @@
 		473F59EC7FA3CB025D4F5D35 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EAA0B8314F73A80686E650D /* SettingsScreen.swift */; };
 		4BE51C7C783DC5665E32AB27 /* MediaDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD57D8126029102A7AE191CF /* MediaDetailViewModel.swift */; };
 		4E6ACB12C22F88F40EF8DC8A /* ContentRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BAFD25D98FA0E18A0F441F5 /* ContentRow.swift */; };
+		575A596CB9AB11EAB858E4F5 /* SleepTimerOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB0CBCFC322E533A14A4EBB /* SleepTimerOption.swift */; };
 		5782D05B40C908DB8241AAE6 /* CinemaxApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A70C2603459BCEE70535BB4 /* CinemaxApp.swift */; };
 		57D52614B1AC3B7D6A3847D8 /* MediaDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD57D8126029102A7AE191CF /* MediaDetailViewModel.swift */; };
 		5F7645BF5DDCF276733DD2AB /* GlassModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A353B49C5117D5F686F07B /* GlassModifiers.swift */; };
@@ -54,7 +60,9 @@
 		629034F00C9B9A91F1DFDFAF /* ContentRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BAFD25D98FA0E18A0F441F5 /* ContentRow.swift */; };
 		64406006E2A4AB13FDE38E19 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = AF177D070920EC62E7827637 /* Localizable.strings */; };
 		649F44415009AA3AFB1D1FE3 /* CinemaxKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223258AFA0F2668369423520 /* CinemaxKitTests.swift */; };
+		68A6C69AD81208E75BA03CF8 /* UserSwitchSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF66FBCB52822C36CFD91DA /* UserSwitchSheet.swift */; };
 		6A6800B822850477D1905491 /* GlassTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59CE3A78C397CC15A81F1635 /* GlassTextField.swift */; };
+		6C352D20CBB608900B97932C /* SettingsAppearanceView+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44CF59AA409F235181A7D841 /* SettingsAppearanceView+iOS.swift */; };
 		6D40EAF27B0800AE33161733 /* WideCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0B2775D4776FF99A90FB12 /* WideCard.swift */; };
 		6F9AEB4561324499DA1F1F4E /* NativeVideoPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FE737816B4F86FC1A9D144 /* NativeVideoPresenter.swift */; };
 		70247C5A32673CC464D68A32 /* LocalizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32016E5B7B38AFDEB6E75857 /* LocalizationManager.swift */; };
@@ -64,10 +72,12 @@
 		74CBBF39B6E72933460424C5 /* ProgressBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DF8C441837A8A10C480077 /* ProgressBarView.swift */; };
 		775886D386630AB477D44DBD /* LicensesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21750E7690B40CFD3168FACA /* LicensesView.swift */; };
 		7CF24A796713A4992BC74C3B /* RatingBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C632FC97E86299EBCAA2CA /* RatingBadge.swift */; };
+		7D2D1CAAA138FF339ED93EFF /* SleepTimerOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB0CBCFC322E533A14A4EBB /* SleepTimerOption.swift */; };
 		7F6D160EABA133540130AABC /* MediaLibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7B27B99DB58FF2CAC5D765 /* MediaLibraryViewModel.swift */; };
 		7F7723CF469BF94B2314A645 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EAA0B8314F73A80686E650D /* SettingsScreen.swift */; };
 		7FB1C0EDE50B3335093F475C /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61944A0EB692FE3706F500B /* ThemeManager.swift */; };
 		8408A487C19DAB3D82498B24 /* RatingBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C632FC97E86299EBCAA2CA /* RatingBadge.swift */; };
+		84668E94D3ACB7EA30769308 /* ToastOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E5C1E6AA06EF0B35E4B4CD2 /* ToastOverlay.swift */; };
 		850FA2A4714148E59074CC92 /* PosterCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE5FB096BB1BE0581798DFD /* PosterCard.swift */; };
 		8B0BC8C9E0D75F440ACBD95A /* LoginViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D07FDBA8B067335CB393D9 /* LoginViewModelTests.swift */; };
 		8BEED9AD5A4971DD030806F0 /* CastCircle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6663B7C168DECE8F2BAC327 /* CastCircle.swift */; };
@@ -91,10 +101,14 @@
 		A5BDB9B097C212892B4AEB36 /* BaseItemDto+Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BDB8AB3BF62513D67C2E16 /* BaseItemDto+Metadata.swift */; };
 		AE92C836D641772893016E26 /* SettingsRowHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4049AE456C81ACB9DD77BA6B /* SettingsRowHelpers.swift */; };
 		B17B6055000707C83658C8DF /* LoginScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE7C8046FBDB91EFDDC0805 /* LoginScreen.swift */; };
+		B69DEDB39F1ACCA6FBE1EFAC /* SettingsAppearanceView+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44CF59AA409F235181A7D841 /* SettingsAppearanceView+iOS.swift */; };
 		B80500609E8D56844738FB4A /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611E44F72064D91AE6DBCC6C /* SearchViewModel.swift */; };
+		B8D3F4C802A068C1080367C5 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81F4A35762E8619A3D24747 /* EmptyStateView.swift */; };
 		BB60281C449D13F7F5398F6F /* CinemaLazyImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F3D66A0647688B34958DEF /* CinemaLazyImage.swift */; };
 		C394E04E4C329F99F29E70D6 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = AF177D070920EC62E7827637 /* Localizable.strings */; };
 		C66DEBC7160DF78205F50CAB /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D37B5166A4FB48D21B2F845 /* LoginViewModel.swift */; };
+		CD85F537174AA67172420BF1 /* MediaQualityBadges.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4426FD8BE586CC3296B2698 /* MediaQualityBadges.swift */; };
+		CE17365839F203B1BB0A34F9 /* ToastCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5610FD34CD71B2F9E4D65FC6 /* ToastCenter.swift */; };
 		CECD6F0550D4470ABD17BD82 /* HomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FA0DC94A5D41FE4D6DC0A2 /* HomeViewModelTests.swift */; };
 		CF9AC2FE2683ACF8F970C686 /* VideoPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97F65D618EBC05344F98AD7 /* VideoPlayerView.swift */; };
 		D18BC3D9D5BA81F6EBB57830 /* HLSManifestLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25B07319865E0C6A31D44ED /* HLSManifestLoader.swift */; };
@@ -109,6 +123,8 @@
 		EF860827AC026C15AEF6574B /* LoadingStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A863021FF6B842EE2A0E27CA /* LoadingStateView.swift */; };
 		F253F28BCDA12B2EC62BE33E /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61944A0EB692FE3706F500B /* ThemeManager.swift */; };
 		F3341F518AE1332B113E44DD /* LibrarySortFilterSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BB9B833D705FD5AFFFB56B /* LibrarySortFilterSheet.swift */; };
+		F37C01D4300852FD249D5ED8 /* MediaQualityBadges.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4426FD8BE586CC3296B2698 /* MediaQualityBadges.swift */; };
+		F7B273773AA4C5CAA1D8BD3F /* UserSwitchSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF66FBCB52822C36CFD91DA /* UserSwitchSheet.swift */; };
 		F7B67A97F9967068E9FDA7A1 /* SettingsScreen+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E9157A106817FC0C04B450 /* SettingsScreen+tvOS.swift */; };
 		F9F825B65BAE3868DDB5E7E6 /* SettingsScreen+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275DFD6B409E3B37C05FD3FB /* SettingsScreen+iOS.swift */; };
 		FA853F39728C4E3652D2C5E5 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C346F0B7AFF504DA6593370E /* HomeViewModel.swift */; };
@@ -129,6 +145,8 @@
 
 /* Begin PBXFileReference section */
 		07FE737816B4F86FC1A9D144 /* NativeVideoPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeVideoPresenter.swift; sourceTree = "<group>"; };
+		0BB0CBCFC322E533A14A4EBB /* SleepTimerOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepTimerOption.swift; sourceTree = "<group>"; };
+		0E5C1E6AA06EF0B35E4B4CD2 /* ToastOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastOverlay.swift; sourceTree = "<group>"; };
 		0F5616DF4D32335730006F23 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		171E69387E1D6BAAB538ECA0 /* ServerSetupScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSetupScreen.swift; sourceTree = "<group>"; };
 		19C632FC97E86299EBCAA2CA /* RatingBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingBadge.swift; sourceTree = "<group>"; };
@@ -138,14 +156,17 @@
 		275DFD6B409E3B37C05FD3FB /* SettingsScreen+iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsScreen+iOS.swift"; sourceTree = "<group>"; };
 		280786386ED204F8AAAF36B6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2BAFD25D98FA0E18A0F441F5 /* ContentRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentRow.swift; sourceTree = "<group>"; };
+		2BF66FBCB52822C36CFD91DA /* UserSwitchSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSwitchSheet.swift; sourceTree = "<group>"; };
 		2C408AFB766D464538419F25 /* CinemaxTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = CinemaxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		31D07FDBA8B067335CB393D9 /* LoginViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModelTests.swift; sourceTree = "<group>"; };
 		32016E5B7B38AFDEB6E75857 /* LocalizationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationManager.swift; sourceTree = "<group>"; };
 		3A70C2603459BCEE70535BB4 /* CinemaxApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CinemaxApp.swift; sourceTree = "<group>"; };
 		3D4F7E03E3AA68A284C0FD7E /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4049AE456C81ACB9DD77BA6B /* SettingsRowHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRowHelpers.swift; sourceTree = "<group>"; };
+		44CF59AA409F235181A7D841 /* SettingsAppearanceView+iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsAppearanceView+iOS.swift"; sourceTree = "<group>"; };
 		48BB9B833D705FD5AFFFB56B /* LibrarySortFilterSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySortFilterSheet.swift; sourceTree = "<group>"; };
 		4D37B5166A4FB48D21B2F845 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
+		5610FD34CD71B2F9E4D65FC6 /* ToastCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastCenter.swift; sourceTree = "<group>"; };
 		58BDB8AB3BF62513D67C2E16 /* BaseItemDto+Metadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BaseItemDto+Metadata.swift"; sourceTree = "<group>"; };
 		59CE3A78C397CC15A81F1635 /* GlassTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassTextField.swift; sourceTree = "<group>"; };
 		5BF56288932318BE6C754F7B /* CinemaGlassTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CinemaGlassTheme.swift; sourceTree = "<group>"; };
@@ -158,6 +179,7 @@
 		7D88DF3FEF51CF7E5E1C948A /* Cinemax.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Cinemax.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8324C15002E8D55B4849D71F /* MediaDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDetailScreen.swift; sourceTree = "<group>"; };
 		8AE5FB096BB1BE0581798DFD /* PosterCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PosterCard.swift; sourceTree = "<group>"; };
+		8E9B086604524FCFB71F0E15 /* AlphabeticalJumpBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlphabeticalJumpBar.swift; sourceTree = "<group>"; };
 		929537FA4254CCBD87E276B3 /* ErrorStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorStateView.swift; sourceTree = "<group>"; };
 		A0F3D66A0647688B34958DEF /* CinemaLazyImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CinemaLazyImage.swift; sourceTree = "<group>"; };
 		A25B07319865E0C6A31D44ED /* HLSManifestLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HLSManifestLoader.swift; sourceTree = "<group>"; };
@@ -169,6 +191,7 @@
 		AEA4717DCFEE46C5BE3F4787 /* PlayLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayLink.swift; sourceTree = "<group>"; };
 		B01CD5F39E429B665FA12B0C /* ServerSetupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSetupViewModelTests.swift; sourceTree = "<group>"; };
 		B14D3FE509DDFB9EA6569161 /* VideoPlayerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerCoordinator.swift; sourceTree = "<group>"; };
+		B4426FD8BE586CC3296B2698 /* MediaQualityBadges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaQualityBadges.swift; sourceTree = "<group>"; };
 		BA0B2775D4776FF99A90FB12 /* WideCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WideCard.swift; sourceTree = "<group>"; };
 		BCC43AE61EC4C83ED88C63C1 /* CinemaxTV.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = CinemaxTV.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0E9157A106817FC0C04B450 /* SettingsScreen+tvOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsScreen+tvOS.swift"; sourceTree = "<group>"; };
@@ -189,6 +212,7 @@
 		DDE7C8046FBDB91EFDDC0805 /* LoginScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginScreen.swift; sourceTree = "<group>"; };
 		DE7B27B99DB58FF2CAC5D765 /* MediaLibraryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLibraryViewModel.swift; sourceTree = "<group>"; };
 		E61944A0EB692FE3706F500B /* ThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
+		E81F4A35762E8619A3D24747 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		E9A353B49C5117D5F686F07B /* GlassModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassModifiers.swift; sourceTree = "<group>"; };
 		F5015BA3559E63C6E9845F2B /* PlayMethodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayMethodTests.swift; sourceTree = "<group>"; };
 		FF0A552AFA2A46BB879FE87B /* ServerSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSetupViewModel.swift; sourceTree = "<group>"; };
@@ -293,17 +317,20 @@
 				21750E7690B40CFD3168FACA /* LicensesView.swift */,
 				DDE7C8046FBDB91EFDDC0805 /* LoginScreen.swift */,
 				8324C15002E8D55B4849D71F /* MediaDetailScreen.swift */,
+				B4426FD8BE586CC3296B2698 /* MediaQualityBadges.swift */,
 				A6A30840A8AEBE5AA59B722F /* MovieLibraryScreen.swift */,
 				07FE737816B4F86FC1A9D144 /* NativeVideoPresenter.swift */,
 				AEA4717DCFEE46C5BE3F4787 /* PlayLink.swift */,
 				C144D0A57021E0A0A783977B /* SearchScreen.swift */,
 				171E69387E1D6BAAB538ECA0 /* ServerSetupScreen.swift */,
+				44CF59AA409F235181A7D841 /* SettingsAppearanceView+iOS.swift */,
 				4049AE456C81ACB9DD77BA6B /* SettingsRowHelpers.swift */,
 				6EAA0B8314F73A80686E650D /* SettingsScreen.swift */,
 				275DFD6B409E3B37C05FD3FB /* SettingsScreen+iOS.swift */,
 				C0E9157A106817FC0C04B450 /* SettingsScreen+tvOS.swift */,
 				DB5D31C0A9CB664FEB840DA3 /* TrackPickerSheet.swift */,
 				AA0A181A9E709E7700EC2E95 /* TVSeriesScreen.swift */,
+				2BF66FBCB52822C36CFD91DA /* UserSwitchSheet.swift */,
 				D97F65D618EBC05344F98AD7 /* VideoPlayerView.swift */,
 			);
 			path = Screens;
@@ -362,7 +389,9 @@
 				D657D13170DAA4F01D4B99E8 /* FocusScaleModifier.swift */,
 				E9A353B49C5117D5F686F07B /* GlassModifiers.swift */,
 				32016E5B7B38AFDEB6E75857 /* LocalizationManager.swift */,
+				0BB0CBCFC322E533A14A4EBB /* SleepTimerOption.swift */,
 				E61944A0EB692FE3706F500B /* ThemeManager.swift */,
+				5610FD34CD71B2F9E4D65FC6 /* ToastCenter.swift */,
 				C7F4ACBF04D222D92DA5953B /* TVButtonStyles.swift */,
 			);
 			path = DesignSystem;
@@ -379,10 +408,12 @@
 		F701053A07C8B6B1D912E9E6 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				8E9B086604524FCFB71F0E15 /* AlphabeticalJumpBar.swift */,
 				A6663B7C168DECE8F2BAC327 /* CastCircle.swift */,
 				CCD86E8274D7D248752E886F /* CinemaButton.swift */,
 				A0F3D66A0647688B34958DEF /* CinemaLazyImage.swift */,
 				2BAFD25D98FA0E18A0F441F5 /* ContentRow.swift */,
+				E81F4A35762E8619A3D24747 /* EmptyStateView.swift */,
 				929537FA4254CCBD87E276B3 /* ErrorStateView.swift */,
 				CB88BD157A83540E8C49B329 /* FlowLayout.swift */,
 				59CE3A78C397CC15A81F1635 /* GlassTextField.swift */,
@@ -390,6 +421,7 @@
 				8AE5FB096BB1BE0581798DFD /* PosterCard.swift */,
 				D3DF8C441837A8A10C480077 /* ProgressBarView.swift */,
 				19C632FC97E86299EBCAA2CA /* RatingBadge.swift */,
+				0E5C1E6AA06EF0B35E4B4CD2 /* ToastOverlay.swift */,
 				BA0B2775D4776FF99A90FB12 /* WideCard.swift */,
 			);
 			path = Components;
@@ -533,6 +565,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				173F19747EE155F10F3B6115 /* AlphabeticalJumpBar.swift in Sources */,
 				2BC23AB09D961A04A91415F7 /* AppNavigation.swift in Sources */,
 				A5BDB9B097C212892B4AEB36 /* BaseItemDto+Metadata.swift in Sources */,
 				8BEED9AD5A4971DD030806F0 /* CastCircle.swift in Sources */,
@@ -541,6 +574,7 @@
 				EA0632228FDBF2CE744BDE18 /* CinemaLazyImage.swift in Sources */,
 				99AD4FD1823DDEAE384019A4 /* CinemaxTVApp.swift in Sources */,
 				4E6ACB12C22F88F40EF8DC8A /* ContentRow.swift in Sources */,
+				B8D3F4C802A068C1080367C5 /* EmptyStateView.swift in Sources */,
 				A457ECA5B1E6FC13546B3306 /* ErrorStateView.swift in Sources */,
 				11F80B56F68EB0BCA6D405AE /* FlowLayout.swift in Sources */,
 				994A2F644CC4E532760D0A0D /* FocusScaleModifier.swift in Sources */,
@@ -559,6 +593,7 @@
 				5FD3234EE63A765E0C82E5C7 /* MediaDetailScreen.swift in Sources */,
 				57D52614B1AC3B7D6A3847D8 /* MediaDetailViewModel.swift in Sources */,
 				D204B5A74016A5CBB00FE986 /* MediaLibraryViewModel.swift in Sources */,
+				F37C01D4300852FD249D5ED8 /* MediaQualityBadges.swift in Sources */,
 				1F8DDF74B6AA98658B045CF5 /* MovieLibraryScreen.swift in Sources */,
 				FB6FC7ADD24BFD093F9D6098 /* NativeVideoPresenter.swift in Sources */,
 				D64C3AD31EC5F1CC8C2197F7 /* PlayLink.swift in Sources */,
@@ -569,14 +604,19 @@
 				B80500609E8D56844738FB4A /* SearchViewModel.swift in Sources */,
 				97AF9B841BA015AD94A9B390 /* ServerSetupScreen.swift in Sources */,
 				0E89D264CCF6B086910782A7 /* ServerSetupViewModel.swift in Sources */,
+				6C352D20CBB608900B97932C /* SettingsAppearanceView+iOS.swift in Sources */,
 				082182AE9E94BB018DAD024D /* SettingsRowHelpers.swift in Sources */,
 				9150233715D09CEFDBC66E64 /* SettingsScreen+iOS.swift in Sources */,
 				43C558D639F56A03ABE38F41 /* SettingsScreen+tvOS.swift in Sources */,
 				473F59EC7FA3CB025D4F5D35 /* SettingsScreen.swift in Sources */,
+				7D2D1CAAA138FF339ED93EFF /* SleepTimerOption.swift in Sources */,
 				18D5366C4AD5FA663CF6EC03 /* TVButtonStyles.swift in Sources */,
 				A3B5BCE46E4207582861DBBE /* TVSeriesScreen.swift in Sources */,
 				F253F28BCDA12B2EC62BE33E /* ThemeManager.swift in Sources */,
+				CE17365839F203B1BB0A34F9 /* ToastCenter.swift in Sources */,
+				390666CDBDB35103BE1D0246 /* ToastOverlay.swift in Sources */,
 				289B6BE095E7F76554DAE841 /* TrackPickerSheet.swift in Sources */,
+				F7B273773AA4C5CAA1D8BD3F /* UserSwitchSheet.swift in Sources */,
 				735403600F051C38E050FBDE /* VideoPlayerCoordinator.swift in Sources */,
 				CF9AC2FE2683ACF8F970C686 /* VideoPlayerView.swift in Sources */,
 				91132D1D741BF7CEFF44DBE3 /* WideCard.swift in Sources */,
@@ -587,6 +627,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A06186102AA10D92923583B /* AlphabeticalJumpBar.swift in Sources */,
 				8CE621C8D3CAD1DE98B6CA11 /* AppNavigation.swift in Sources */,
 				E71BC25CBB98F5DF97065B98 /* BaseItemDto+Metadata.swift in Sources */,
 				DDE0943D46488F809421872D /* CastCircle.swift in Sources */,
@@ -595,6 +636,7 @@
 				BB60281C449D13F7F5398F6F /* CinemaLazyImage.swift in Sources */,
 				5782D05B40C908DB8241AAE6 /* CinemaxApp.swift in Sources */,
 				629034F00C9B9A91F1DFDFAF /* ContentRow.swift in Sources */,
+				28247D55CC29D95670733239 /* EmptyStateView.swift in Sources */,
 				2FA754E7C1024D2E05A46524 /* ErrorStateView.swift in Sources */,
 				3B587F7E3960823F29F25C26 /* FlowLayout.swift in Sources */,
 				73713753B981A3971272B7E3 /* FocusScaleModifier.swift in Sources */,
@@ -613,6 +655,7 @@
 				100AA327B088A392E7732C98 /* MediaDetailScreen.swift in Sources */,
 				4BE51C7C783DC5665E32AB27 /* MediaDetailViewModel.swift in Sources */,
 				7F6D160EABA133540130AABC /* MediaLibraryViewModel.swift in Sources */,
+				CD85F537174AA67172420BF1 /* MediaQualityBadges.swift in Sources */,
 				FF21EDCBFAE6F61736975202 /* MovieLibraryScreen.swift in Sources */,
 				6F9AEB4561324499DA1F1F4E /* NativeVideoPresenter.swift in Sources */,
 				38D0284F287A35C7FC3D4858 /* PlayLink.swift in Sources */,
@@ -623,14 +666,19 @@
 				1695AF73A0D756A11490FF4B /* SearchViewModel.swift in Sources */,
 				91ED326A57E034CF33FCA565 /* ServerSetupScreen.swift in Sources */,
 				5FA751E81BBEE26DE820FA36 /* ServerSetupViewModel.swift in Sources */,
+				B69DEDB39F1ACCA6FBE1EFAC /* SettingsAppearanceView+iOS.swift in Sources */,
 				AE92C836D641772893016E26 /* SettingsRowHelpers.swift in Sources */,
 				F9F825B65BAE3868DDB5E7E6 /* SettingsScreen+iOS.swift in Sources */,
 				F7B67A97F9967068E9FDA7A1 /* SettingsScreen+tvOS.swift in Sources */,
 				7F7723CF469BF94B2314A645 /* SettingsScreen.swift in Sources */,
+				575A596CB9AB11EAB858E4F5 /* SleepTimerOption.swift in Sources */,
 				FC977C55710C5DEB48C5A122 /* TVButtonStyles.swift in Sources */,
 				2D505F5E99229EC948F2A7E0 /* TVSeriesScreen.swift in Sources */,
 				7FB1C0EDE50B3335093F475C /* ThemeManager.swift in Sources */,
+				2E1A085843FA335D04A9B52B /* ToastCenter.swift in Sources */,
+				84668E94D3ACB7EA30769308 /* ToastOverlay.swift in Sources */,
 				3251D64F042EEB176008DAB9 /* TrackPickerSheet.swift in Sources */,
+				68A6C69AD81208E75BA03CF8 /* UserSwitchSheet.swift in Sources */,
 				9D7DC4B535360291C3465976 /* VideoPlayerCoordinator.swift in Sources */,
 				0E09FF53825D339001BB6137 /* VideoPlayerView.swift in Sources */,
 				6D40EAF27B0800AE33161733 /* WideCard.swift in Sources */,

--- a/Packages/CinemaxKit/Sources/CinemaxKit/Models/MediaTrackInfo.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Models/MediaTrackInfo.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// A single audio or subtitle track from a Jellyfin media source.
+///
+/// The `id` maps to Jellyfin's `AudioStreamIndex` / `SubtitleStreamIndex` — used when
+/// requesting a new `PlaybackInfo` to switch the active track server-side.
+public struct MediaTrackInfo: Identifiable, Equatable, Sendable {
+    public let id: Int          // stream index (AudioStreamIndex / SubtitleStreamIndex)
+    public let label: String    // Jellyfin DisplayTitle, e.g. "English - AAC - Stereo"
+    public let isDefault: Bool
+    public let isForced: Bool
+
+    public init(id: Int, label: String, isDefault: Bool, isForced: Bool) {
+        self.id = id
+        self.label = label
+        self.isDefault = isDefault
+        self.isForced = isForced
+    }
+}

--- a/Packages/CinemaxKit/Sources/CinemaxKit/Networking/APIClientProtocol.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Networking/APIClientProtocol.swift
@@ -15,6 +15,12 @@ public protocol APIClientProtocol: Sendable {
     func authenticate(username: String, password: String) async throws -> UserSession
     func getPublicUsers() async throws -> [UserDto]
     func getUsers() async throws -> [UserDto]
+    func getActiveSessions(activeWithinSeconds: Int) async throws -> [SessionInfoDto]
+
+    // MARK: - Cache
+
+    /// Drops every cached response (used by Settings → Server → Refresh Catalogue).
+    func clearCache()
 
     // MARK: - Media Queries
 
@@ -29,6 +35,7 @@ public protocol APIClientProtocol: Sendable {
         genres: [String]?,
         years: [Int]?,
         isFavorite: Bool?,
+        filters: [ItemFilter]?,
         limit: Int?,
         startIndex: Int?
     ) async throws -> (items: [BaseItemDto], totalCount: Int)
@@ -43,6 +50,10 @@ public protocol APIClientProtocol: Sendable {
     func getSeasons(seriesId: String, userId: String) async throws -> [BaseItemDto]
     func getEpisodes(seriesId: String, seasonId: String, userId: String) async throws -> [BaseItemDto]
     func getNextUp(seriesId: String, userId: String) async throws -> BaseItemDto?
+
+    // MARK: - Media Segments
+
+    func getMediaSegments(itemId: String, includeSegmentTypes: [MediaSegmentType]?) async throws -> [MediaSegmentDto]
 
     // MARK: - Playback
 
@@ -82,13 +93,14 @@ public extension APIClientProtocol {
         genres: [String]? = nil,
         years: [Int]? = nil,
         isFavorite: Bool? = nil,
+        filters: [ItemFilter]? = nil,
         limit: Int? = nil,
         startIndex: Int? = nil
     ) async throws -> (items: [BaseItemDto], totalCount: Int) {
         try await getItems(
             userId: userId, parentId: parentId, includeItemTypes: includeItemTypes,
             sortBy: sortBy, sortOrder: sortOrder, genres: genres, years: years,
-            isFavorite: isFavorite, limit: limit, startIndex: startIndex
+            isFavorite: isFavorite, filters: filters, limit: limit, startIndex: startIndex
         )
     }
     func getGenres(userId: String, includeItemTypes: [BaseItemKind]? = nil) async throws -> [String] {
@@ -97,8 +109,14 @@ public extension APIClientProtocol {
     func getSimilarItems(itemId: String, userId: String, limit: Int = 12) async throws -> [BaseItemDto] {
         try await getSimilarItems(itemId: itemId, userId: userId, limit: limit)
     }
+    func getActiveSessions(activeWithinSeconds: Int = 60) async throws -> [SessionInfoDto] {
+        try await getActiveSessions(activeWithinSeconds: activeWithinSeconds)
+    }
     func searchItems(userId: String, searchTerm: String, limit: Int = 20) async throws -> [BaseItemDto] {
         try await searchItems(userId: userId, searchTerm: searchTerm, limit: limit)
+    }
+    func getMediaSegments(itemId: String, includeSegmentTypes: [MediaSegmentType]? = nil) async throws -> [MediaSegmentDto] {
+        try await getMediaSegments(itemId: itemId, includeSegmentTypes: includeSegmentTypes)
     }
     func getPlaybackInfo(
         itemId: String,

--- a/Packages/CinemaxKit/Sources/CinemaxKit/Networking/ImageURLBuilder.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Networking/ImageURLBuilder.swift
@@ -43,6 +43,25 @@ public struct ImageURLBuilder: Sendable {
         #endif
     }
 
+    /// Builds the URL for a chapter thumbnail. Jellyfin exposes chapter images at
+    /// `/Items/{id}/Images/Chapter/{index}` (0-based index into the chapter list).
+    public func chapterImageURL(itemId: String, imageIndex: Int, tag: String? = nil, maxWidth: Int? = nil) -> URL {
+        var components = URLComponents(url: serverURL, resolvingAgainstBaseURL: false)!
+        components.path = "/Items/\(itemId)/Images/Chapter/\(imageIndex)"
+
+        var queryItems: [URLQueryItem] = []
+        if let maxWidth {
+            queryItems.append(URLQueryItem(name: "maxWidth", value: String(maxWidth)))
+        }
+        if let tag {
+            queryItems.append(URLQueryItem(name: "tag", value: tag))
+        }
+        queryItems.append(URLQueryItem(name: "quality", value: "85"))
+        components.queryItems = queryItems.isEmpty ? nil : queryItems
+
+        return components.url!
+    }
+
     public func userImageURL(userId: String, tag: String? = nil, maxWidth: Int? = nil) -> URL {
         var components = URLComponents(url: serverURL, resolvingAgainstBaseURL: false)!
         components.path = "/Users/\(userId)/Images/Primary"

--- a/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient.swift
@@ -13,14 +13,6 @@ func debugLog(_ message: String) {
 }
 #endif
 
-/// A single audio or subtitle track from a Jellyfin media source.
-public struct MediaTrackInfo: Identifiable, Equatable, Sendable {
-    public let id: Int        // stream index (AudioStreamIndex / SubtitleStreamIndex)
-    public let label: String  // Jellyfin DisplayTitle, e.g. "English - AAC - Stereo"
-    public let isDefault: Bool
-    public let isForced: Bool
-}
-
 public final class JellyfinAPIClient: Sendable {
     // JellyfinClient is not Sendable, so we protect it with a lock
     private let lock = NSLock()
@@ -148,6 +140,15 @@ public final class JellyfinAPIClient: Sendable {
         return response.value
     }
 
+    /// Returns all active sessions on the server. Used by the "Currently watching" indicator
+    /// on Home to show what other users are streaming right now.
+    public func getActiveSessions(activeWithinSeconds: Int = 60) async throws -> [SessionInfoDto] {
+        guard let client = getClient() else { throw JellyfinError.notConnected }
+        let params = Paths.GetSessionsParameters(activeWithinSeconds: activeWithinSeconds)
+        let response = try await client.send(Paths.getSessions(parameters: params))
+        return response.value
+    }
+
     // MARK: - Media Queries
 
     public func getResumeItems(userId: String, limit: Int = 10) async throws -> [BaseItemDto] {
@@ -195,6 +196,7 @@ public final class JellyfinAPIClient: Sendable {
         genres: [String]? = nil,
         years: [Int]? = nil,
         isFavorite: Bool? = nil,
+        filters: [ItemFilter]? = nil,
         limit: Int? = nil,
         startIndex: Int? = nil
     ) async throws -> (items: [BaseItemDto], totalCount: Int) {
@@ -207,6 +209,7 @@ public final class JellyfinAPIClient: Sendable {
             sortOrder: sortOrder,
             parentID: parentId,
             includeItemTypes: includeItemTypes,
+            filters: filters,
             sortBy: sortBy,
             genres: genres,
             years: years
@@ -294,6 +297,14 @@ public final class JellyfinAPIClient: Sendable {
         )
         let response = try await client.send(Paths.getNextUp(parameters: params))
         return response.value.items?.first
+    }
+
+    // MARK: - Media Segments
+
+    public func getMediaSegments(itemId: String, includeSegmentTypes: [JellyfinAPI.MediaSegmentType]? = nil) async throws -> [MediaSegmentDto] {
+        guard let client = getClient() else { throw JellyfinError.notConnected }
+        let response = try await client.send(Paths.getItemSegments(itemID: itemId, includeSegmentTypes: includeSegmentTypes))
+        return response.value.items ?? []
     }
 
     // MARK: - Playback
@@ -716,6 +727,13 @@ public final class JellyfinAPIClient: Sendable {
         )
     }
 
+    /// Invalidates every cached response (resume items, latest media, genres, etc.).
+    /// Called by Settings → Server → Refresh Catalogue so that the next fetch hits
+    /// the server rather than returning stale cached data.
+    public func clearCache() {
+        cache.clear()
+    }
+
     public func reconnect(url: URL, accessToken: String) {
         cache.clear()
         let client = JellyfinClient(
@@ -750,18 +768,3 @@ public final class JellyfinAPIClient: Sendable {
     }
 }
 
-public enum JellyfinError: LocalizedError, Sendable {
-    case notConnected
-    case authenticationFailed
-    case invalidURL
-    case playbackFailed(String)
-
-    public var errorDescription: String? {
-        switch self {
-        case .notConnected: "Not connected to a server"
-        case .authenticationFailed: "Authentication failed"
-        case .invalidURL: "Invalid server URL"
-        case .playbackFailed(let reason): "Playback failed: \(reason)"
-        }
-    }
-}

--- a/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinError.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinError.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Domain errors surfaced by `JellyfinAPIClient`. Conforms to `LocalizedError` so that
+/// `error.localizedDescription` is meaningful when surfaced in the UI.
+public enum JellyfinError: LocalizedError, Sendable {
+    case notConnected
+    case authenticationFailed
+    case invalidURL
+    case playbackFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notConnected:            "Not connected to a server"
+        case .authenticationFailed:    "Authentication failed"
+        case .invalidURL:              "Invalid server URL"
+        case .playbackFailed(let reason): "Playback failed: \(reason)"
+        }
+    }
+}

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -22,10 +22,15 @@
 "action.clear" = "Clear";
 "action.logOut" = "Log Out";
 "action.viewAll" = "View All";
+"action.refresh" = "Refresh";
+"action.surpriseMe" = "Surprise Me";
 
 // MARK: - Home Screen
 
 "home.continueWatching" = "Continue Watching";
+"home.watchingNow" = "Watching Now";
+"home.watchingNow.playing" = "%@ is watching";
+"settings.homePage.watchingNow" = "Watching Now";
 "home.recentlyAdded" = "Recently Added";
 "home.remainingTime.hours" = "%dh %dm remaining";
 "home.remainingTime.minutes" = "%dm remaining";
@@ -46,6 +51,10 @@
 "sort.rating" = "Rating";
 "sort.runtime" = "Runtime";
 "filter.byGenre" = "Genre";
+"filter.watchStatus" = "Watch status";
+"filter.unwatchedOnly" = "Unwatched only";
+"filter.byDecade" = "Decade";
+"filter.decade" = "%ds";
 
 // MARK: - TV Series
 
@@ -63,10 +72,57 @@
 "search.placeholder" = "Search movies, shows...";
 "search.listening" = "Listening...";
 "search.noResults" = "No results found";
+"empty.library.filtered.title" = "No matches";
+"empty.library.filtered.subtitle" = "Try adjusting your filters or clearing them.";
+"empty.library.filtered.action" = "Clear filters";
+"empty.library.title" = "No titles here yet";
+"empty.library.subtitle" = "Add content to your Jellyfin server to get started.";
+"empty.home.title" = "Your library is empty";
+"empty.home.subtitle" = "Add movies or TV shows to your Jellyfin server and pull down to refresh.";
+"empty.series.title" = "No episodes yet";
+
+// MARK: - Sleep Timer
+
+"settings.sleepTimer" = "Sleep Timer";
+"sleep.disabled" = "Off";
+"sleep.15" = "15 minutes";
+"sleep.30" = "30 minutes";
+"sleep.45" = "45 minutes";
+"sleep.60" = "1 hour";
+"sleep.90" = "1 hour 30 minutes";
+"sleep.indicator" = "Sleep in %@";
+"sleep.prompt.title" = "Still watching?";
+"sleep.prompt.subtitle" = "Your sleep timer ended.";
+"sleep.prompt.keepWatching" = "Keep watching";
+"sleep.prompt.stop" = "Stop playback";
+
+// MARK: - Playback Errors
+
+"playback.error.title" = "Couldn't play this video";
+"playback.error.generic" = "Something went wrong while loading the stream. Try again or check your Jellyfin server.";
+"playback.error.network" = "The connection to your server was lost. Check your network and retry.";
+"playback.error.transcode" = "The server couldn't transcode this file. Check your server's transcoding settings.";
+"playback.error.retry" = "Retry";
+"playback.error.close" = "Close";
+
+// MARK: - End of Series
+
+"player.finishedSeries.title" = "You finished %@";
+"player.finishedSeries.subtitle" = "No more episodes to play.";
+"player.finishedSeries.done" = "Done";
+
+// MARK: - Toasts
+
+"toast.surprise.failed" = "Couldn't pick something";
+"toast.surprise.emptyLibrary" = "Your library is empty.";
+"toast.loadFailed" = "Couldn't load content";
 "search.searchLibrary" = "Search your library";
 "search.topMatches" = "Top Matches";
 "search.permissionRequired" = "Permission Required";
 "search.openSettings" = "Open Settings";
+"search.surpriseMePrompt" = "Not sure what to watch?";
+"search.surprise.movie" = "Surprise movie";
+"search.surprise.series" = "Surprise series";
 
 // MARK: - Settings
 
@@ -95,9 +151,25 @@
 "settings.user" = "User";
 "settings.switchAccount" = "Switch Account";
 "settings.switchAccountConfirm" = "You will be logged out and returned to the login screen.";
+"switchAccount.pickUser" = "Pick a user";
+"switchAccount.enterPasswordFor" = "Enter password for %@";
+"switchAccount.signIn" = "Sign In";
+"switchAccount.authFailed" = "Sign-in failed";
+"switchAccount.success" = "Signed in as %@";
 "settings.server" = "Server";
 "settings.connected" = "Connected";
 "settings.refreshConnection" = "Refresh Connection";
+"settings.refreshCatalogue" = "Refresh Catalogue";
+"settings.refreshCatalogue.subtitle" = "Clear cache and reload Home and Library.";
+"toast.catalogueRefreshed" = "Catalogue refreshed";
+
+// MARK: - Debug
+
+"settings.debug" = "Debug";
+"settings.debug.fastSleepTimer" = "Fast sleep timer (15 s)";
+"settings.debug.fastSleepTimer.subtitle" = "Override the sleep duration to 15 seconds for testing the prompt.";
+"settings.debug.skipToEnd" = "Skip-to-end button";
+"settings.debug.skipToEnd.subtitle" = "Show a button in the player that jumps to the last 15 s of the current item.";
 "settings.interface" = "Interface";
 "settings.motionEffects" = "Motion Effects";
 "settings.fontSize" = "Text Size";
@@ -110,10 +182,17 @@
 "settings.deviceName" = "Device Name";
 "settings.network" = "Network";
 "settings.authenticatedDevice" = "Authenticated Device";
+"settings.homePage" = "Home Page";
+"settings.homePage.continueWatching" = "Continue Watching";
+"settings.homePage.recentlyAdded" = "Recently Added";
+"settings.homePage.genreRows" = "Genre Rows";
+"settings.detailPage" = "Detail Page";
+"settings.detailPage.qualityBadges" = "Quality badges";
 
 // MARK: - Media Detail
 
 "detail.play" = "Play";
+"detail.playFromBeginning" = "Play from beginning";
 "detail.castCrew" = "Cast & Crew";
 "detail.moreLikeThis" = "More Like This";
 "detail.episode" = "Episode %d";
@@ -123,6 +202,10 @@
 "detail.seasons" = "%d Seasons";
 "detail.season" = "Season";
 "detail.seeMore" = "See more";
+"detail.studio" = "Studio";
+"detail.network" = "Network";
+"detail.criticRating" = "Critics";
+"detail.audienceRating" = "Audience";
 
 // MARK: - Login
 
@@ -170,6 +253,8 @@
 "player.subtitles" = "Subtitles";
 "player.subtitles.off" = "Off";
 "player.trackPicker.title" = "Playback Tracks";
+"player.skipIntro" = "Skip Intro";
+"player.skipCredits" = "Skip Credits";
 
 // MARK: - Licenses
 

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -22,10 +22,15 @@
 "action.clear" = "Effacer";
 "action.logOut" = "Déconnexion";
 "action.viewAll" = "Tout voir";
+"action.refresh" = "Actualiser";
+"action.surpriseMe" = "Au hasard";
 
 // MARK: - Home Screen
 
 "home.continueWatching" = "Reprendre";
+"home.watchingNow" = "En direct";
+"home.watchingNow.playing" = "%@ regarde";
+"settings.homePage.watchingNow" = "En direct";
 "home.recentlyAdded" = "Ajouts récents";
 "home.remainingTime.hours" = "%dh %dm restantes";
 "home.remainingTime.minutes" = "%dm restantes";
@@ -46,6 +51,10 @@
 "sort.rating" = "Note";
 "sort.runtime" = "Durée";
 "filter.byGenre" = "Genre";
+"filter.watchStatus" = "Statut de visionnage";
+"filter.unwatchedOnly" = "Non vus uniquement";
+"filter.byDecade" = "Décennie";
+"filter.decade" = "Années %d";
 
 // MARK: - TV Series
 
@@ -63,10 +72,57 @@
 "search.placeholder" = "Rechercher des films, séries...";
 "search.listening" = "Écoute en cours...";
 "search.noResults" = "Aucun résultat";
+"empty.library.filtered.title" = "Aucun résultat";
+"empty.library.filtered.subtitle" = "Essayez d'ajuster vos filtres ou de les effacer.";
+"empty.library.filtered.action" = "Effacer les filtres";
+"empty.library.title" = "Aucun titre pour le moment";
+"empty.library.subtitle" = "Ajoutez du contenu à votre serveur Jellyfin pour commencer.";
+"empty.home.title" = "Votre bibliothèque est vide";
+"empty.home.subtitle" = "Ajoutez des films ou séries à votre serveur Jellyfin puis tirez pour actualiser.";
+"empty.series.title" = "Aucun épisode pour le moment";
+
+// MARK: - Sleep Timer
+
+"settings.sleepTimer" = "Minuteur de veille";
+"sleep.disabled" = "Désactivé";
+"sleep.15" = "15 minutes";
+"sleep.30" = "30 minutes";
+"sleep.45" = "45 minutes";
+"sleep.60" = "1 heure";
+"sleep.90" = "1 heure 30 minutes";
+"sleep.indicator" = "Veille dans %@";
+"sleep.prompt.title" = "Toujours là ?";
+"sleep.prompt.subtitle" = "Votre minuteur de veille s'est écoulé.";
+"sleep.prompt.keepWatching" = "Continuer";
+"sleep.prompt.stop" = "Arrêter la lecture";
+
+// MARK: - Playback Errors
+
+"playback.error.title" = "Lecture impossible";
+"playback.error.generic" = "Une erreur est survenue pendant le chargement du flux. Réessayez ou vérifiez votre serveur Jellyfin.";
+"playback.error.network" = "La connexion au serveur a été perdue. Vérifiez votre réseau et réessayez.";
+"playback.error.transcode" = "Le serveur n'a pas pu transcoder ce fichier. Vérifiez les réglages de transcodage.";
+"playback.error.retry" = "Réessayer";
+"playback.error.close" = "Fermer";
+
+// MARK: - End of Series
+
+"player.finishedSeries.title" = "Vous avez terminé %@";
+"player.finishedSeries.subtitle" = "Plus d'épisodes à lire.";
+"player.finishedSeries.done" = "Terminé";
+
+// MARK: - Toasts
+
+"toast.surprise.failed" = "Impossible de choisir un titre";
+"toast.surprise.emptyLibrary" = "Votre bibliothèque est vide.";
+"toast.loadFailed" = "Échec du chargement";
 "search.searchLibrary" = "Rechercher dans votre bibliothèque";
 "search.topMatches" = "Meilleurs résultats";
 "search.permissionRequired" = "Autorisation requise";
 "search.openSettings" = "Ouvrir les réglages";
+"search.surpriseMePrompt" = "Pas d'idée de ce que regarder ?";
+"search.surprise.movie" = "Film surprise";
+"search.surprise.series" = "Série surprise";
 
 // MARK: - Settings
 
@@ -95,9 +151,25 @@
 "settings.user" = "Utilisateur";
 "settings.switchAccount" = "Changer de compte";
 "settings.switchAccountConfirm" = "Vous serez déconnecté et redirigé vers l'écran de connexion.";
+"switchAccount.pickUser" = "Choisir un utilisateur";
+"switchAccount.enterPasswordFor" = "Mot de passe de %@";
+"switchAccount.signIn" = "Connexion";
+"switchAccount.authFailed" = "Échec de la connexion";
+"switchAccount.success" = "Connecté en tant que %@";
 "settings.server" = "Serveur";
 "settings.connected" = "Connecté";
 "settings.refreshConnection" = "Actualiser la connexion";
+"settings.refreshCatalogue" = "Actualiser le catalogue";
+"settings.refreshCatalogue.subtitle" = "Vider le cache et recharger Accueil et Bibliothèque.";
+"toast.catalogueRefreshed" = "Catalogue actualisé";
+
+// MARK: - Debug
+
+"settings.debug" = "Débogage";
+"settings.debug.fastSleepTimer" = "Veille rapide (15 s)";
+"settings.debug.fastSleepTimer.subtitle" = "Forcer la durée de veille à 15 secondes pour tester le prompt.";
+"settings.debug.skipToEnd" = "Bouton aller à la fin";
+"settings.debug.skipToEnd.subtitle" = "Afficher un bouton dans le lecteur qui saute aux 15 dernières secondes.";
 "settings.interface" = "Interface";
 "settings.motionEffects" = "Effets de mouvement";
 "settings.fontSize" = "Taille du texte";
@@ -110,10 +182,17 @@
 "settings.deviceName" = "Nom de l'appareil";
 "settings.network" = "Réseau";
 "settings.authenticatedDevice" = "Appareil authentifié";
+"settings.homePage" = "Page d'accueil";
+"settings.homePage.continueWatching" = "Reprendre";
+"settings.homePage.recentlyAdded" = "Ajouts récents";
+"settings.homePage.genreRows" = "Rangées par genre";
+"settings.detailPage" = "Page de détail";
+"settings.detailPage.qualityBadges" = "Badges de qualité";
 
 // MARK: - Media Detail
 
 "detail.play" = "Lecture";
+"detail.playFromBeginning" = "Lire depuis le début";
 "detail.castCrew" = "Casting";
 "detail.moreLikeThis" = "Titres similaires";
 "detail.episode" = "Épisode %d";
@@ -123,6 +202,10 @@
 "detail.seasons" = "%d saisons";
 "detail.season" = "Saison";
 "detail.seeMore" = "Voir plus";
+"detail.studio" = "Studio";
+"detail.network" = "Chaîne";
+"detail.criticRating" = "Critiques";
+"detail.audienceRating" = "Public";
 
 // MARK: - Login
 
@@ -170,6 +253,8 @@
 "player.subtitles" = "Sous-titres";
 "player.subtitles.off" = "Désactivé";
 "player.trackPicker.title" = "Pistes de lecture";
+"player.skipIntro" = "Passer l'intro";
+"player.skipCredits" = "Passer le générique";
 
 // MARK: - Licenses
 

--- a/Shared/DesignSystem/CinemaGlassTheme.swift
+++ b/Shared/DesignSystem/CinemaGlassTheme.swift
@@ -131,6 +131,45 @@ enum CinemaFont {
         }
     }
 
+    // MARK: - Dynamic Type-aware variants
+    //
+    // The methods above return *fixed-size* `.system(size:)` fonts which do NOT
+    // respond to the user's OS-level text-size preference (Settings > Display &
+    // Brightness > Text Size on iOS, or system accessibility text scaling).
+    //
+    // The variants below layer `UIFontMetrics` on top of the existing
+    // `CinemaScale.factor` so the final size = `baseSize × appScale ×
+    // dynamicTypeMultiplier`. Use for reading-heavy text (setting rows, detail
+    // overviews, episode titles, chat/list cells). Keep the fixed variants for
+    // display/headline where precise layout control matters (hero titles).
+
+    /// Reading-optimized body font. Scales with both app `uiScale` and OS Dynamic Type.
+    static var dynamicBody: Font {
+        .system(size: scaledPoint(17, relativeTo: .body), weight: .regular)
+    }
+
+    /// Larger reading font for overviews / detail screens.
+    static var dynamicBodyLarge: Font {
+        .system(size: scaledPoint(19, relativeTo: .body), weight: .regular)
+    }
+
+    /// Dynamic Type-aware label font. Follows the same `large / medium / small`
+    /// sizing as `label(_:)` but scales with OS text-size preference.
+    static func dynamicLabel(_ size: LabelSize = .medium) -> Font {
+        switch size {
+        case .large:  .system(size: scaledPoint(19, relativeTo: .callout),     weight: .medium)
+        case .medium: .system(size: scaledPoint(16, relativeTo: .subheadline), weight: .medium)
+        case .small:  .system(size: scaledPoint(14, relativeTo: .footnote),    weight: .medium)
+        }
+    }
+
+    /// Helper that combines the app's `uiScale` and the OS's Dynamic Type scaling
+    /// into a final point size. On non-UIKit platforms falls back to `CinemaScale.pt`.
+    private static func scaledPoint(_ baseSize: CGFloat, relativeTo style: UIFont.TextStyle) -> CGFloat {
+        let appScaled = baseSize * CinemaScale.factor
+        return UIFontMetrics(forTextStyle: style).scaledValue(for: appScaled).rounded()
+    }
+
     enum DisplaySize { case large, medium, small }
     enum HeadlineSize { case large, medium, small }
     enum LabelSize { case large, medium, small }

--- a/Shared/DesignSystem/Components/AlphabeticalJumpBar.swift
+++ b/Shared/DesignSystem/Components/AlphabeticalJumpBar.swift
@@ -1,0 +1,66 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+/// Right-edge vertical index strip, Contacts.app-style: tap or drag over a letter
+/// to jump the parent scroll view to the matching item. Only used on iOS — tvOS
+/// focus navigation already handles this naturally via remote.
+struct AlphabeticalJumpBar: View {
+    let accent: Color
+    let onSelect: (String) -> Void
+
+    /// The letters rendered. "#" covers items that begin with a digit or symbol.
+    private static let letters: [String] = {
+        var list = ["#"]
+        list.append(contentsOf: (UnicodeScalar("A").value...UnicodeScalar("Z").value)
+            .compactMap { UnicodeScalar($0).map { String(Character($0)) } })
+        return list
+    }()
+
+    @State private var lastFired: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(Self.letters, id: \.self) { letter in
+                Text(letter)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(accent)
+                    .frame(width: 18, height: 14)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        fire(letter)
+                    }
+            }
+        }
+        .padding(.vertical, 6)
+        .background(
+            Capsule().fill(.ultraThinMaterial)
+        )
+        .gesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { value in
+                    // Use the proportion of the drag y to pick a letter — lets the user
+                    // slide their finger up/down without lifting.
+                    let totalHeight = CGFloat(Self.letters.count) * 14 + 12
+                    let clampedY = max(0, min(value.location.y, totalHeight))
+                    let index = Int(clampedY / 14)
+                    guard index >= 0 && index < Self.letters.count else { return }
+                    let letter = Self.letters[index]
+                    if letter != lastFired {
+                        fire(letter)
+                    }
+                }
+                .onEnded { _ in
+                    lastFired = nil
+                }
+        )
+        .accessibilityHidden(true)
+    }
+
+    private func fire(_ letter: String) {
+        lastFired = letter
+        UISelectionFeedbackGenerator().selectionChanged()
+        onSelect(letter)
+    }
+}
+#endif

--- a/Shared/DesignSystem/Components/EmptyStateView.swift
+++ b/Shared/DesignSystem/Components/EmptyStateView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+/// Standard empty state: SF Symbol + title + optional subtitle + optional action button.
+///
+/// Use when a collection is legitimately empty — no library items, no filtered matches,
+/// no resume entries — as opposed to `ErrorStateView` which signals a request failure.
+struct EmptyStateView: View {
+    let systemImage: String
+    let title: String
+    var subtitle: String? = nil
+    var actionTitle: String? = nil
+    var onAction: (() -> Void)? = nil
+
+    var body: some View {
+        VStack(spacing: CinemaSpacing.spacing3) {
+            Image(systemName: systemImage)
+                .font(.system(size: CinemaScale.pt(56), weight: .regular))
+                .foregroundStyle(CinemaColor.onSurfaceVariant.opacity(0.7))
+                .accessibilityHidden(true)
+
+            Text(title)
+                .font(CinemaFont.headline(.small))
+                .foregroundStyle(CinemaColor.onSurface)
+                .multilineTextAlignment(.center)
+
+            if let subtitle {
+                Text(subtitle)
+                    .font(CinemaFont.body)
+                    .foregroundStyle(CinemaColor.onSurfaceVariant)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, CinemaSpacing.spacing6)
+            }
+
+            if let actionTitle, let onAction {
+                CinemaButton(title: actionTitle, style: .ghost) {
+                    onAction()
+                }
+                .frame(width: 200)
+                .padding(.top, CinemaSpacing.spacing2)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, CinemaSpacing.spacing10)
+    }
+}

--- a/Shared/DesignSystem/Components/ToastOverlay.swift
+++ b/Shared/DesignSystem/Components/ToastOverlay.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+/// Top-anchored toast renderer. Reads `ToastCenter.current` and animates a glass pill
+/// in/out from the top safe area. Only one toast is visible at a time.
+struct ToastOverlay: View {
+    @Environment(ToastCenter.self) private var toasts
+    @Environment(\.motionEffectsEnabled) private var motionEnabled
+
+    var body: some View {
+        VStack {
+            if let toast = toasts.current {
+                ToastView(toast: toast) {
+                    toasts.dismiss()
+                }
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .padding(.horizontal, CinemaSpacing.spacing4)
+                .padding(.top, CinemaSpacing.spacing3)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .allowsHitTesting(toasts.current != nil)
+        .animation(motionEnabled ? .spring(response: 0.4, dampingFraction: 0.82) : nil,
+                   value: toasts.current)
+    }
+}
+
+private struct ToastView: View {
+    let toast: Toast
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: CinemaSpacing.spacing3) {
+            Image(systemName: toast.level.systemImage)
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(toast.level.tint)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(toast.title)
+                    .font(CinemaFont.label(.large))
+                    .foregroundStyle(CinemaColor.onSurface)
+                    .lineLimit(2)
+                if let msg = toast.message {
+                    Text(msg)
+                        .font(CinemaFont.body)
+                        .foregroundStyle(CinemaColor.onSurfaceVariant)
+                        .lineLimit(3)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(CinemaColor.onSurfaceVariant)
+                    .padding(6)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss")
+        }
+        .padding(.horizontal, CinemaSpacing.spacing4)
+        .padding(.vertical, CinemaSpacing.spacing3)
+        .background(.ultraThinMaterial)
+        .background(CinemaColor.surfaceContainerHigh.opacity(0.4))
+        .clipShape(RoundedRectangle(cornerRadius: CinemaRadius.large))
+        .overlay(
+            RoundedRectangle(cornerRadius: CinemaRadius.large)
+                .strokeBorder(toast.level.tint.opacity(0.35), lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.25), radius: 20, x: 0, y: 8)
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/Shared/DesignSystem/SleepTimerOption.swift
+++ b/Shared/DesignSystem/SleepTimerOption.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// User-selectable sleep timer duration. Stored as minutes via `@AppStorage("sleepTimerDefaultMinutes")`.
+///
+/// A value of `0` means disabled. Non-zero values schedule a timer at playback start that
+/// pauses the player and prompts "Still watching?" when it fires.
+enum SleepTimerOption: Int, CaseIterable, Identifiable {
+    case disabled = 0
+    case fifteen  = 15
+    case thirty   = 30
+    case fortyFive = 45
+    case sixty    = 60
+    case ninety   = 90
+
+    var id: Int { rawValue }
+
+    /// Duration in seconds. Zero for `.disabled`.
+    var seconds: TimeInterval { TimeInterval(rawValue * 60) }
+
+    /// Localization key for the picker row label.
+    var localizationKey: String {
+        switch self {
+        case .disabled:  return "sleep.disabled"
+        case .fifteen:   return "sleep.15"
+        case .thirty:    return "sleep.30"
+        case .fortyFive: return "sleep.45"
+        case .sixty:     return "sleep.60"
+        case .ninety:    return "sleep.90"
+        }
+    }
+
+    /// Look up the user's default sleep-timer setting. Writes made via `@AppStorage` are reflected.
+    static var currentDefault: SleepTimerOption {
+        let raw = UserDefaults.standard.integer(forKey: "sleepTimerDefaultMinutes")
+        return SleepTimerOption(rawValue: raw) ?? .disabled
+    }
+
+    /// Effective duration in seconds for the next playback session. Honors a
+    /// developer override (`debug.fastSleepTimer` → 15 s) so the prompt can be
+    /// triggered quickly during testing without rewriting every option.
+    /// Returns `0` when the timer is disabled and no debug override is active.
+    static var currentDefaultSeconds: TimeInterval {
+        let fastDebug = UserDefaults.standard.bool(forKey: "debug.fastSleepTimer")
+        if fastDebug { return 15 }
+        return currentDefault.seconds
+    }
+}

--- a/Shared/DesignSystem/ToastCenter.swift
+++ b/Shared/DesignSystem/ToastCenter.swift
@@ -1,0 +1,76 @@
+import Foundation
+import SwiftUI
+
+/// A single queued toast message.
+struct Toast: Identifiable, Equatable {
+    enum Level: Equatable {
+        case success
+        case error
+        case info
+
+        var systemImage: String {
+            switch self {
+            case .success: return "checkmark.circle.fill"
+            case .error:   return "exclamationmark.triangle.fill"
+            case .info:    return "info.circle.fill"
+            }
+        }
+
+        var tint: Color {
+            switch self {
+            case .success: return .green
+            case .error:   return CinemaColor.error
+            case .info:    return .blue
+            }
+        }
+    }
+
+    let id = UUID()
+    let level: Level
+    let title: String
+    let message: String?
+    let duration: TimeInterval
+}
+
+/// Central queue for user-facing feedback toasts. Injected via `.environment`.
+/// View layer is `ToastOverlay`.
+@MainActor @Observable
+final class ToastCenter {
+    /// The current visible toast (if any). Only one is displayed at a time.
+    private(set) var current: Toast?
+
+    private var dismissTask: Task<Void, Never>?
+
+    /// Enqueue and display a toast. If another toast is currently showing, it is replaced.
+    func show(_ toast: Toast) {
+        dismissTask?.cancel()
+        current = toast
+        dismissTask = Task { [weak self, id = toast.id, duration = toast.duration] in
+            try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                // Only dismiss if we're still showing the same toast.
+                if self?.current?.id == id {
+                    self?.current = nil
+                }
+            }
+        }
+    }
+
+    func success(_ title: String, message: String? = nil, duration: TimeInterval = 2.5) {
+        show(Toast(level: .success, title: title, message: message, duration: duration))
+    }
+
+    func error(_ title: String, message: String? = nil, duration: TimeInterval = 4.0) {
+        show(Toast(level: .error, title: title, message: message, duration: duration))
+    }
+
+    func info(_ title: String, message: String? = nil, duration: TimeInterval = 2.5) {
+        show(Toast(level: .info, title: title, message: message, duration: duration))
+    }
+
+    func dismiss() {
+        dismissTask?.cancel()
+        current = nil
+    }
+}

--- a/Shared/Navigation/AppNavigation.swift
+++ b/Shared/Navigation/AppNavigation.swift
@@ -68,6 +68,7 @@ struct AppNavigation: View {
     @State private var appState = AppState()
     @State private var themeManager = ThemeManager()
     @State private var loc = LocalizationManager()
+    @State private var toasts = ToastCenter()
     @State private var hasCheckedSession = false
     @Environment(\.scenePhase) private var scenePhase
 
@@ -81,21 +82,32 @@ struct AppNavigation: View {
     }
 
     var body: some View {
-        Group {
-            if !hasCheckedSession {
-                launchScreen
-            } else if !appState.hasServer {
-                ServerSetupScreen()
-            } else if !appState.isAuthenticated {
-                LoginScreen()
-            } else {
-                MainTabView()
+        ZStack {
+            Group {
+                if !hasCheckedSession {
+                    launchScreen
+                } else if !appState.hasServer {
+                    ServerSetupScreen()
+                } else if !appState.isAuthenticated {
+                    LoginScreen()
+                } else {
+                    MainTabView()
+                }
             }
+
+            // Toasts overlay the entire app chrome (above tab bar / modals).
+            ToastOverlay()
+                .allowsHitTesting(toasts.current != nil)
         }
         .environment(appState)
         .environment(themeManager)
         .environment(loc)
+        .environment(toasts)
         .environment(\.motionEffectsEnabled, motionEffects)
+        // Respect the user's OS Dynamic Type setting while capping at a size
+        // that won't collapse layouts (hero titles, tab bar). The app also has
+        // its own `uiScale` in Settings > Interface > Font Size for finer control.
+        .dynamicTypeSize(.xSmall ... .accessibility2)
         .preferredColorScheme(themeManager.colorScheme)
         .task {
             await appState.restoreSession()
@@ -112,6 +124,9 @@ struct AppNavigation: View {
 
 extension Notification.Name {
     static let cinemaxDidEnterBackground = Notification.Name("cinemaxDidEnterBackground")
+    /// Posted when the user taps "Refresh Catalogue" in Settings → Server.
+    /// Home and Library observe this and reload their content (cache-busted).
+    static let cinemaxShouldRefreshCatalogue = Notification.Name("cinemaxShouldRefreshCatalogue")
 }
 
 private extension AppNavigation {

--- a/Shared/Screens/HomeScreen.swift
+++ b/Shared/Screens/HomeScreen.swift
@@ -8,12 +8,19 @@ struct HomeScreen: View {
     @Environment(LocalizationManager.self) private var loc
     @State private var viewModel = HomeViewModel()
 
+    @AppStorage("home.showContinueWatching") private var showContinueWatching: Bool = true
+    @AppStorage("home.showRecentlyAdded") private var showRecentlyAdded: Bool = true
+    @AppStorage("home.showGenreRows") private var showGenreRows: Bool = true
+    @AppStorage("home.showWatchingNow") private var showWatchingNow: Bool = true
+
     var body: some View {
         ZStack {
             CinemaColor.surface.ignoresSafeArea()
 
             if viewModel.isLoading {
                 LoadingStateView()
+            } else if isHomeEmpty {
+                homeEmptyState
             } else {
                 content
             }
@@ -25,32 +32,102 @@ struct HomeScreen: View {
         .task {
             await viewModel.load(using: appState)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .cinemaxShouldRefreshCatalogue)) { _ in
+            Task { await viewModel.reload(using: appState) }
+        }
+    }
+
+    /// True when there's no hero, no resume items, no recently added items, and no genre rows.
+    /// Happens on a fresh Jellyfin install or a server with no media.
+    private var isHomeEmpty: Bool {
+        viewModel.heroItem == nil
+            && viewModel.resumeItems.isEmpty
+            && viewModel.latestItems.isEmpty
+            && viewModel.genreRows.isEmpty
+    }
+
+    private var homeEmptyState: some View {
+        ScrollView {
+            EmptyStateView(
+                systemImage: "tv.slash",
+                title: loc.localized("empty.home.title"),
+                subtitle: loc.localized("empty.home.subtitle"),
+                actionTitle: loc.localized("action.refresh")
+            ) {
+                Task { await viewModel.reload(using: appState) }
+            }
+            .padding(.top, CinemaSpacing.spacing20)
+        }
+        .refreshable { await viewModel.reload(using: appState) }
     }
 
     private var content: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: CinemaSpacing.spacing6) {
-                // Hero
-                if let hero = viewModel.heroItem {
-                    heroSection(hero)
-                }
+        // Wrap in `ScrollViewReader` so that on tvOS we can scroll back to the
+        // top sentinel whenever the screen reappears (after a deep-nav pop or
+        // tab switch). Without this the tvOS top tab bar can be hidden behind
+        // scrolled content and the user can't reach it with the remote.
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: CinemaSpacing.spacing6) {
+                    // Sentinel for `proxy.scrollTo(_:anchor:)`
+                    Color.clear.frame(height: 0).id(scrollTopID)
 
-                // Continue Watching
-                if !viewModel.resumeItems.isEmpty {
-                    continueWatchingRow
-                }
+                    // Hero
+                    if let hero = viewModel.heroItem {
+                        heroSection(hero)
+                    }
 
-                // Recently Added
-                if !viewModel.latestItems.isEmpty {
-                    recentlyAddedRow
-                }
+                    // Watching Now (other users on the server)
+                    if showWatchingNow, !viewModel.activeSessions.isEmpty {
+                        watchingNowRow
+                    }
 
-                Spacer(minLength: 80)
+                    // Continue Watching
+                    if showContinueWatching, !viewModel.resumeItems.isEmpty {
+                        continueWatchingRow
+                    }
+
+                    // Recently Added
+                    if showRecentlyAdded, !viewModel.latestItems.isEmpty {
+                        recentlyAddedRow
+                    }
+
+                    // Genre rows
+                    if showGenreRows {
+                        ForEach(viewModel.genreRows, id: \.genre) { row in
+                            genreRow(genre: row.genre, items: row.items)
+                        }
+                    }
+
+                    Spacer(minLength: 80)
+                }
+            }
+            .refreshable {
+                await viewModel.reload(using: appState)
+            }
+            #if os(tvOS)
+            .scrollClipDisabled()
+            .onAppear {
+                // Returning from a deep navigation (e.g., MediaDetail → Menu) —
+                // reveal the top tab bar by scrolling to the sentinel.
+                proxy.scrollTo(scrollTopID, anchor: .top)
+            }
+            #endif
+        }
+    }
+
+    private var scrollTopID: String { "home.top" }
+
+    // MARK: - Genre Rows
+
+    @ViewBuilder
+    private func genreRow(genre: String, items: [BaseItemDto]) -> some View {
+        ContentRow(title: genre) {
+            ForEach(items, id: \.id) { item in
+                recentlyAddedCard(item)
+                    .frame(width: posterCardWidth)
             }
         }
-        #if os(tvOS)
-        .scrollClipDisabled()
-        #endif
     }
 
     // MARK: - Hero
@@ -176,6 +253,68 @@ struct HomeScreen: View {
     }
 
     // MARK: - Continue Watching
+
+    // MARK: - Watching Now (other users)
+
+    /// Small row showing other server users' active playback sessions. Each card shows
+    /// the item artwork + "Name is watching" label, and navigates to the item's detail
+    /// screen on tap. Hidden entirely when the server has no other active sessions.
+    private var watchingNowRow: some View {
+        ContentRow(title: loc.localized("home.watchingNow")) {
+            ForEach(viewModel.activeSessions.indices, id: \.self) { idx in
+                watchingNowCard(viewModel.activeSessions[idx])
+                    .frame(width: wideCardWidth)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func watchingNowCard(_ session: SessionInfoDto) -> some View {
+        if let item = session.nowPlayingItem, let id = item.id {
+            // Episodes → use parent series for backdrop; fall back to the episode itself.
+            let backdropId = item.parentBackdropItemID ?? item.seriesID ?? id
+            let title = (item.seriesName ?? item.name) ?? ""
+            let subtitle = String(format: loc.localized("home.watchingNow.playing"), session.userName ?? "")
+
+            NavigationLink {
+                MediaDetailScreen(itemId: id, itemType: item.type ?? .movie)
+            } label: {
+                WideCard(
+                    title: title,
+                    imageURL: appState.imageBuilder.imageURL(itemId: backdropId, imageType: .backdrop, maxWidth: 600),
+                    progress: sessionProgress(session),
+                    subtitle: subtitle
+                )
+                .overlay(alignment: .topLeading) {
+                    // Small red "LIVE" pill to signal this is a session, not a recommendation.
+                    HStack(spacing: 4) {
+                        Circle().fill(Color.red).frame(width: 6, height: 6)
+                        Text("LIVE")
+                            .font(.system(size: 10, weight: .bold))
+                            .tracking(0.5)
+                            .foregroundStyle(.white)
+                    }
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 3)
+                    .background(.ultraThinMaterial, in: Capsule())
+                    .padding(8)
+                }
+            }
+            #if os(tvOS)
+            .buttonStyle(CinemaTVCardButtonStyle())
+            #else
+            .buttonStyle(.plain)
+            #endif
+            .accessibilityLabel("\(title), \(subtitle)")
+        }
+    }
+
+    private func sessionProgress(_ session: SessionInfoDto) -> Double {
+        guard let position = session.playState?.positionTicks,
+              let total = session.nowPlayingItem?.runTimeTicks,
+              total > 0 else { return 0 }
+        return min(1.0, Double(position) / Double(total))
+    }
 
     private var continueWatchingRow: some View {
         ContentRow(title: loc.localized("home.continueWatching")) {

--- a/Shared/Screens/LibrarySortFilterSheet.swift
+++ b/Shared/Screens/LibrarySortFilterSheet.swift
@@ -28,6 +28,8 @@ struct LibrarySortFilterSheet: View {
                     VStack(alignment: .leading, spacing: CinemaSpacing.spacing6) {
                         sortSection
                         sortOrderSection
+                        unwatchedSection
+                        decadeSection
                         if !availableGenres.isEmpty {
                             genreSection
                         }
@@ -149,6 +151,90 @@ struct LibrarySortFilterSheet: View {
                     : CinemaColor.surfaceContainerHigh
             )
             .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: Watch Status
+
+    private var unwatchedSection: some View {
+        VStack(alignment: .leading, spacing: CinemaSpacing.spacing3) {
+            sectionHeader(loc.localized("filter.watchStatus"))
+
+            Button {
+                sortFilter.showUnwatchedOnly.toggle()
+            } label: {
+                HStack {
+                    Text(loc.localized("filter.unwatchedOnly"))
+                        .font(CinemaFont.body)
+                        .foregroundStyle(CinemaColor.onSurface)
+                    Spacer()
+                    CinemaToggleIndicator(
+                        isOn: sortFilter.showUnwatchedOnly,
+                        accent: themeManager.accent
+                    )
+                }
+                .padding(.horizontal, CinemaSpacing.spacing4)
+                .padding(.vertical, CinemaSpacing.spacing3)
+                .background(CinemaColor.surfaceContainerHigh)
+                .clipShape(RoundedRectangle(cornerRadius: CinemaRadius.large))
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: Decade Filter
+
+    /// Decades offered in the UI. Starting years, most-recent-first.
+    private static let decadeOptions: [Int] = [2020, 2010, 2000, 1990, 1980, 1970, 1960, 1950]
+
+    private var decadeSection: some View {
+        VStack(alignment: .leading, spacing: CinemaSpacing.spacing3) {
+            HStack {
+                sectionHeader(loc.localized("filter.byDecade"))
+                Spacer()
+                if !sortFilter.selectedDecades.isEmpty {
+                    Button {
+                        sortFilter.selectedDecades = []
+                    } label: {
+                        Text(loc.localized("action.clear"))
+                            .font(CinemaFont.label(.large))
+                            .foregroundStyle(themeManager.accent)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            FlowLayout(spacing: CinemaSpacing.spacing2) {
+                ForEach(Self.decadeOptions, id: \.self) { decade in
+                    decadeChip(decade)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func decadeChip(_ decade: Int) -> some View {
+        let isSelected = sortFilter.selectedDecades.contains(decade)
+
+        Button {
+            if isSelected {
+                sortFilter.selectedDecades.remove(decade)
+            } else {
+                sortFilter.selectedDecades.insert(decade)
+            }
+        } label: {
+            Text(loc.localized("filter.decade", decade))
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(isSelected ? .white : CinemaColor.onSurfaceVariant)
+                .padding(.horizontal, CinemaSpacing.spacing3)
+                .padding(.vertical, CinemaSpacing.spacing2)
+                .background(
+                    isSelected
+                        ? themeManager.accentContainer
+                        : CinemaColor.surfaceContainerHigh
+                )
+                .clipShape(Capsule())
         }
         .buttonStyle(.plain)
     }

--- a/Shared/Screens/MediaDetailScreen.swift
+++ b/Shared/Screens/MediaDetailScreen.swift
@@ -11,6 +11,7 @@ struct MediaDetailScreen: View {
     #endif
     @State var viewModel: MediaDetailViewModel
     @State private var episodeOverview: EpisodeOverviewItem?
+    @AppStorage("detail.showQualityBadges") private var showQualityBadges: Bool = true
 
     init(itemId: String, itemType: BaseItemKind = .movie) {
         _viewModel = State(initialValue: MediaDetailViewModel(itemId: itemId, itemType: itemType))
@@ -57,16 +58,26 @@ struct MediaDetailScreen: View {
                     // Action buttons
                     actionButtons(item)
 
-                    // Overview
+                    // Quality badges
+                    if showQualityBadges {
+                        MediaQualityBadges(item: item)
+                            .padding(.horizontal, contentPadding)
+                    }
+
+                    // Overview — Dynamic Type-aware since users read this prose.
                     if let overview = item.overview {
                         Text(overview)
-                            .font(CinemaFont.body)
+                            .font(CinemaFont.dynamicBody)
                             .foregroundStyle(CinemaColor.onSurfaceVariant)
                             .padding(.horizontal, contentPadding)
                             #if os(tvOS)
                             .focusable()
                             #endif
                     }
+
+                    // Studio / Network
+                    studioLine(item)
+                        .padding(.horizontal, contentPadding)
 
                     // Cast
                     if let people = item.people, !people.isEmpty {
@@ -135,17 +146,8 @@ struct MediaDetailScreen: View {
                         .foregroundStyle(themeManager.accent)
                 }
 
-                // Community rating
-                if let rating = item.communityRating {
-                    HStack(spacing: 4) {
-                        Image(systemName: "star.fill")
-                            .foregroundStyle(.yellow)
-                        Text(String(format: "%.1f", rating))
-                            .fontWeight(.bold)
-                    }
-                    .font(.system(size: ratingFontSize))
-                    .foregroundStyle(CinemaColor.onSurface)
-                }
+                // Community + critic ratings (audience on left, critics on right)
+                ratingsRow(item)
             }
             .padding(.horizontal, contentPadding)
             .padding(.top, contentPadding)
@@ -155,6 +157,68 @@ struct MediaDetailScreen: View {
         .frame(maxWidth: .infinity)
         .frame(height: backdropHeight)
         .clipped()
+    }
+
+    // MARK: - Ratings Row (backdrop)
+
+    @ViewBuilder
+    private func ratingsRow(_ item: BaseItemDto) -> some View {
+        let hasCommunity = item.communityRating != nil
+        let hasCritic = item.criticRating != nil
+
+        if hasCommunity || hasCritic {
+            HStack(spacing: CinemaSpacing.spacing4) {
+                if let rating = item.communityRating {
+                    HStack(spacing: 4) {
+                        Image(systemName: "star.fill")
+                            .foregroundStyle(.yellow)
+                        Text(String(format: "%.1f", rating))
+                            .fontWeight(.bold)
+                    }
+                    .font(.system(size: ratingFontSize))
+                    .foregroundStyle(CinemaColor.onSurface)
+                    .accessibilityLabel("\(loc.localized("detail.audienceRating")) \(String(format: "%.1f", rating))")
+                }
+
+                if let critic = item.criticRating {
+                    let isFresh = critic >= 60
+                    HStack(spacing: 4) {
+                        // Rotten Tomatoes-style — green when ≥ 60, red otherwise.
+                        Image(systemName: isFresh ? "applescript.fill" : "takeoutbag.and.cup.and.straw.fill")
+                            .foregroundStyle(isFresh ? .green : .red)
+                        Text("\(Int(critic.rounded()))%")
+                            .fontWeight(.bold)
+                    }
+                    .font(.system(size: ratingFontSize))
+                    .foregroundStyle(CinemaColor.onSurface)
+                    .accessibilityLabel("\(loc.localized("detail.criticRating")) \(Int(critic.rounded())) percent")
+                }
+            }
+        }
+    }
+
+    // MARK: - Studio / Network
+
+    /// Comma-separated list of up to 2 studios (or network label for series).
+    /// Rendered below the overview text. Returns `EmptyView` when no studios are present.
+    @ViewBuilder
+    private func studioLine(_ item: BaseItemDto) -> some View {
+        let names = (item.studios ?? []).compactMap { $0.name }.filter { !$0.isEmpty }
+        if !names.isEmpty {
+            let isSeries = viewModel.resolvedType == .series
+            let labelKey = isSeries ? "detail.network" : "detail.studio"
+            HStack(alignment: .firstTextBaseline, spacing: CinemaSpacing.spacing2) {
+                Text(loc.localized(labelKey))
+                    .font(CinemaFont.label(.large))
+                    .foregroundStyle(CinemaColor.onSurfaceVariant)
+                    .textCase(.uppercase)
+                    .tracking(0.8)
+                Text(names.prefix(2).joined(separator: ", "))
+                    .font(CinemaFont.body)
+                    .foregroundStyle(CinemaColor.onSurface)
+                    .lineLimit(1)
+            }
+        }
     }
 
     // MARK: - Metadata
@@ -275,6 +339,38 @@ struct MediaDetailScreen: View {
                 .buttonStyle(.plain)
                 #endif
                 .frame(width: playButtonWidth)
+
+                // Secondary — Play from beginning (only when resuming)
+                if showResume {
+                    PlayLink(
+                        itemId: playItemId, title: playTitle, startTime: nil,
+                        previousEpisode: epNav?.previous, nextEpisode: epNav?.next,
+                        episodeNavigator: epNav?.navigator
+                    ) {
+                        HStack(spacing: CinemaSpacing.spacing2) {
+                            Image(systemName: "backward.end.fill")
+                                .font(.system(size: buttonFontSize - 2, weight: .bold))
+                            Text(loc.localized("detail.playFromBeginning"))
+                                .font(.system(size: buttonFontSize, weight: .bold))
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.7)
+                        }
+                        .foregroundStyle(CinemaColor.onSurface)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, buttonVerticalPadding)
+                        .padding(.horizontal, CinemaSpacing.spacing4)
+                        #if os(iOS)
+                        .background(.ultraThinMaterial)
+                        .clipShape(RoundedRectangle(cornerRadius: CinemaRadius.large))
+                        #endif
+                    }
+                    #if os(tvOS)
+                    .buttonStyle(CinemaTVButtonStyle(cinemaStyle: .ghost))
+                    #else
+                    .buttonStyle(.plain)
+                    #endif
+                    .frame(width: playButtonWidth)
+                }
             }
         }
         .padding(.horizontal, contentPadding)
@@ -447,9 +543,11 @@ struct MediaDetailScreen: View {
                         .foregroundStyle(CinemaColor.onSurface)
                         .lineLimit(2)
 
+                    episodeMetadataLine(episode)
+
                     if let ov = overview {
                         Text(ov)
-                            .font(CinemaFont.body)
+                            .font(CinemaFont.dynamicBody)
                             .foregroundStyle(CinemaColor.onSurfaceVariant)
                             .lineLimit(3)
                             .padding(.top, 2)
@@ -520,11 +618,7 @@ struct MediaDetailScreen: View {
                                 .font(.system(size: episodeTitleFontSize, weight: .semibold))
                                 .foregroundStyle(CinemaColor.onSurface)
                                 .lineLimit(2)
-                            if let runtime = episode.runTimeTicks {
-                                Text(loc.localized("detail.runtime.min", runtime.jellyfinMinutes))
-                                    .font(CinemaFont.label(.medium))
-                                    .foregroundStyle(CinemaColor.onSurfaceVariant)
-                            }
+                            episodeMetadataLine(episode)
                         }
                         .frame(maxWidth: .infinity, alignment: .topLeading)
                     }
@@ -551,7 +645,7 @@ struct MediaDetailScreen: View {
                     } label: {
                         VStack(alignment: .leading, spacing: 6) {
                             Text(ov)
-                                .font(CinemaFont.body)
+                                .font(CinemaFont.dynamicBody)
                                 .foregroundStyle(CinemaColor.onSurfaceVariant)
                                 .lineLimit(4)
                                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -573,6 +667,43 @@ struct MediaDetailScreen: View {
         }
     }
     #endif
+
+    // MARK: - Shared Episode Metadata Line
+
+    /// Small secondary-text line under an episode title combining "X min remaining" (or runtime)
+    /// with the air date. Returns `EmptyView` when nothing meaningful is available.
+    @ViewBuilder
+    private func episodeMetadataLine(_ episode: BaseItemDto) -> some View {
+        let isPlayed = episode.userData?.isPlayed ?? false
+        let runtimeText: String? = {
+            // Prefer "X remaining" while in-progress, otherwise show total runtime.
+            if !isPlayed,
+               let position = episode.userData?.playbackPositionTicks,
+               let total = episode.runTimeTicks,
+               position > 0, total > position {
+                let remainingMinutes = (total - position).jellyfinMinutes
+                if remainingMinutes <= 0 { return nil }
+                return remainingMinutes > 60
+                    ? loc.localized("home.remainingTime.hours", remainingMinutes / 60, remainingMinutes % 60)
+                    : loc.localized("home.remainingTime.minutes", remainingMinutes)
+            }
+            if let runtime = episode.runTimeTicks, runtime > 0 {
+                return loc.localized("detail.runtime.min", runtime.jellyfinMinutes)
+            }
+            return nil
+        }()
+
+        let dateText: String? = episode.premiereDate.map {
+            $0.formatted(.dateTime.month(.abbreviated).day().year())
+        }
+
+        let parts: [String] = [runtimeText, dateText].compactMap { $0 }
+        if !parts.isEmpty {
+            Text(parts.joined(separator: " • "))
+                .font(CinemaFont.label(.medium))
+                .foregroundStyle(CinemaColor.onSurfaceVariant)
+        }
+    }
 
     // MARK: - Similar Items
 

--- a/Shared/Screens/MediaQualityBadges.swift
+++ b/Shared/Screens/MediaQualityBadges.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+import CinemaxKit
+import JellyfinAPI
+
+/// Horizontal row of small pill badges summarising the technical quality of the
+/// primary media source: resolution, HDR, video codec, audio format, channels.
+struct MediaQualityBadges: View {
+    let item: BaseItemDto
+
+    var body: some View {
+        let labels = Self.badgeLabels(for: item)
+        if labels.isEmpty {
+            EmptyView()
+        } else {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(labels, id: \.self) { label in
+                        Text(label)
+                            .font(CinemaFont.label(.medium))
+                            .foregroundStyle(CinemaColor.onSurface)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(CinemaColor.surfaceContainerHigh)
+                            .clipShape(Capsule())
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Derivation
+
+    static func badgeLabels(for item: BaseItemDto) -> [String] {
+        guard let source = item.mediaSources?.first else { return [] }
+        let streams = source.mediaStreams ?? []
+        let videoStream = streams.first { $0.type == .video }
+
+        let defaultAudioIndex = source.defaultAudioStreamIndex
+        let audioStream: MediaStream? = {
+            if let idx = defaultAudioIndex,
+               let match = streams.first(where: { $0.type == .audio && $0.index == idx }) {
+                return match
+            }
+            return streams.first { $0.type == .audio }
+        }()
+
+        var labels: [String] = []
+
+        if let v = videoStream, let res = resolutionLabel(for: v) {
+            labels.append(res)
+        }
+        if let v = videoStream, let hdr = hdrLabel(for: v) {
+            labels.append(hdr)
+        }
+        if let v = videoStream, let codec = videoCodecLabel(for: v) {
+            labels.append(codec)
+        }
+        if let a = audioStream, let audio = audioFormatLabel(for: a) {
+            labels.append(audio)
+        }
+        if let a = audioStream, let ch = channelsLabel(for: a) {
+            labels.append(ch)
+        }
+
+        return labels
+    }
+
+    // MARK: - Resolution
+
+    private static func resolutionLabel(for stream: MediaStream) -> String? {
+        guard let h = stream.height else { return nil }
+        switch h {
+        case let x where x >= 2160: return "4K"
+        case let x where x >= 1080: return "1080p"
+        case let x where x >= 720:  return "720p"
+        default:                    return "SD"
+        }
+    }
+
+    // MARK: - HDR
+
+    private static func hdrLabel(for stream: MediaStream) -> String? {
+        if let t = stream.videoRangeType {
+            switch t {
+            case .dovi, .doviWithHDR10, .doviWithHLG, .doviWithSDR,
+                 .doviWithEL, .doviWithHDR10Plus, .doviWithELHDR10Plus, .doviInvalid:
+                return "Dolby Vision"
+            case .hdr10Plus:
+                return "HDR10+"
+            case .hdr10:
+                return "HDR10"
+            case .hlg:
+                return "HDR"
+            case .sdr, .unknown:
+                break
+            }
+        }
+        if stream.videoRange == .hdr {
+            return "HDR"
+        }
+        return nil
+    }
+
+    // MARK: - Video codec
+
+    private static func videoCodecLabel(for stream: MediaStream) -> String? {
+        guard let codec = stream.codec?.lowercased(), !codec.isEmpty else { return nil }
+        switch codec {
+        case "hevc", "h265": return "HEVC"
+        case "h264":         return "H.264"
+        case "av1":          return "AV1"
+        case "vp9":          return "VP9"
+        default:             return codec.uppercased()
+        }
+    }
+
+    // MARK: - Audio format
+
+    private static func audioFormatLabel(for stream: MediaStream) -> String? {
+        let profile = stream.profile?.lowercased() ?? ""
+        let displayTitle = stream.displayTitle?.lowercased() ?? ""
+        if profile.contains("atmos") || displayTitle.contains("atmos") {
+            return "Dolby Atmos"
+        }
+        guard let codec = stream.codec?.lowercased(), !codec.isEmpty else { return nil }
+        switch codec {
+        case "truehd": return "TrueHD"
+        case "eac3":   return "Dolby Digital+"
+        case "ac3":    return "Dolby Digital"
+        case "aac":    return "AAC"
+        case "flac":   return "FLAC"
+        case "opus":   return "Opus"
+        case "mp3":    return "MP3"
+        default:
+            if codec == "dts" || codec.contains("dts") {
+                return "DTS"
+            }
+            return codec.uppercased()
+        }
+    }
+
+    // MARK: - Channels
+
+    private static func channelsLabel(for stream: MediaStream) -> String? {
+        if let layout = stream.channelLayout, !layout.isEmpty {
+            let lower = layout.lowercased()
+            switch lower {
+            case "stereo": return "Stereo"
+            case "mono":   return "Mono"
+            default:       return layout.uppercased()
+            }
+        }
+        if let ch = stream.channels {
+            switch ch {
+            case 8: return "7.1"
+            case 6: return "5.1"
+            case 2: return "Stereo"
+            case 1: return "Mono"
+            default: return "\(ch)ch"
+            }
+        }
+        return nil
+    }
+}

--- a/Shared/Screens/MovieLibraryScreen.swift
+++ b/Shared/Screens/MovieLibraryScreen.swift
@@ -49,6 +49,9 @@ struct MediaLibraryScreen: View {
         .task {
             await viewModel.loadInitial(using: appState)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .cinemaxShouldRefreshCatalogue)) { _ in
+            Task { await viewModel.reload(using: appState) }
+        }
     }
 
     // MARK: Main Content Switch
@@ -70,55 +73,69 @@ struct MediaLibraryScreen: View {
 
     #if os(tvOS)
     private var tvMainContent: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 0) {
-                tvFilterBar
-                    .padding(.bottom, CinemaSpacing.spacing6)
+        // ScrollViewReader so we can pop back to the top of the page (and reveal
+        // the tvOS top tab bar) whenever the screen reappears after a deep nav.
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    Color.clear.frame(height: 0).id("library.top")
 
-                if viewModel.sortFilter.isFiltered {
-                    // Filtered grid (genre selected)
-                    if viewModel.filteredLoader.items.isEmpty && viewModel.filteredLoader.isLoadingMore {
-                        ProgressView()
-                            .tint(CinemaColor.onSurfaceVariant)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, CinemaSpacing.spacing10)
-                    } else {
-                        LazyVGrid(columns: filteredColumns, spacing: gridSpacing) {
-                            ForEach(viewModel.filteredLoader.items, id: \.id) { item in
-                                posterCard(item)
-                                    .onAppear {
-                                        if item.id == viewModel.filteredLoader.items.last?.id {
-                                            Task { await viewModel.loadMoreFiltered(using: appState) }
+                    tvFilterBar
+                        .padding(.bottom, CinemaSpacing.spacing6)
+
+                    if viewModel.sortFilter.isFiltered {
+                        // Filtered grid (genre selected)
+                        if viewModel.filteredLoader.items.isEmpty && viewModel.filteredLoader.isLoadingMore {
+                            ProgressView()
+                                .tint(CinemaColor.onSurfaceVariant)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, CinemaSpacing.spacing10)
+                        } else if viewModel.filteredLoader.items.isEmpty {
+                            filteredEmptyState
+                        } else {
+                            LazyVGrid(columns: filteredColumns, spacing: gridSpacing) {
+                                ForEach(viewModel.filteredLoader.items, id: \.id) { item in
+                                    posterCard(item)
+                                        .onAppear {
+                                            if item.id == viewModel.filteredLoader.items.last?.id {
+                                                Task { await viewModel.loadMoreFiltered(using: appState) }
+                                            }
                                         }
-                                    }
+                                }
+                            }
+                            .padding(.horizontal, CinemaSpacing.spacing20)
+                        }
+                    } else {
+                        // Browse genre rows
+                        ForEach(viewModel.genres.prefix(viewModel.genreLoadLimit), id: \.self) { genre in
+                            if let items = viewModel.itemsByGenre[genre], !items.isEmpty {
+                                genreRow(genre: genre, items: items)
+                                    .padding(.bottom, CinemaSpacing.spacing6)
                             }
                         }
-                        .padding(.horizontal, CinemaSpacing.spacing20)
-                    }
-                } else {
-                    // Browse genre rows
-                    ForEach(viewModel.genres.prefix(viewModel.genreLoadLimit), id: \.self) { genre in
-                        if let items = viewModel.itemsByGenre[genre], !items.isEmpty {
-                            genreRow(genre: genre, items: items)
+
+                        if !viewModel.genres.isEmpty {
+                            browseGenresSection
                                 .padding(.bottom, CinemaSpacing.spacing6)
                         }
                     }
 
-                    if !viewModel.genres.isEmpty {
-                        browseGenresSection
-                            .padding(.bottom, CinemaSpacing.spacing6)
-                    }
+                    Spacer(minLength: 80)
                 }
-
-                Spacer(minLength: 80)
             }
-        }
-        .scrollClipDisabled()
-        .task(id: viewModel.sortFilter) {
-            if viewModel.sortFilter.isFiltered {
-                await viewModel.applyFilter(using: appState)
-            } else if !viewModel.genres.isEmpty {
-                await viewModel.reloadGenreItems(using: appState)
+            .scrollClipDisabled()
+            .refreshable {
+                await viewModel.reload(using: appState)
+            }
+            .task(id: viewModel.sortFilter) {
+                if viewModel.sortFilter.isFiltered {
+                    await viewModel.applyFilter(using: appState)
+                } else if !viewModel.genres.isEmpty {
+                    await viewModel.reloadGenreItems(using: appState)
+                }
+            }
+            .onAppear {
+                proxy.scrollTo("library.top", anchor: .top)
             }
         }
     }
@@ -149,6 +166,9 @@ struct MediaLibraryScreen: View {
                 Spacer(minLength: 80)
             }
         }
+        .refreshable {
+            await viewModel.reload(using: appState)
+        }
     }
 
     // MARK: Filtered View (iOS)
@@ -162,38 +182,61 @@ struct MediaLibraryScreen: View {
     }
 
     private var filteredView: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: CinemaSpacing.spacing4) {
-                Text(loc.localized(itemType == .series ? "tvShows.count" : "movies.count", viewModel.filteredLoader.totalCount))
-                    .font(CinemaFont.label(.large))
-                    .foregroundStyle(CinemaColor.onSurfaceVariant)
-                    .padding(.horizontal, gridPadding)
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: CinemaSpacing.spacing4) {
+                    Text(loc.localized(itemType == .series ? "tvShows.count" : "movies.count", viewModel.filteredLoader.totalCount))
+                        .font(CinemaFont.label(.large))
+                        .foregroundStyle(CinemaColor.onSurfaceVariant)
+                        .padding(.horizontal, gridPadding)
 
-                if viewModel.filteredLoader.items.isEmpty && viewModel.filteredLoader.isLoadingMore {
-                    ProgressView()
-                        .tint(CinemaColor.onSurfaceVariant)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, CinemaSpacing.spacing10)
-                } else {
-                    LazyVGrid(columns: filteredColumns, spacing: gridSpacing) {
-                        ForEach(viewModel.filteredLoader.items, id: \.id) { item in
-                            posterCard(item)
-                                .onAppear {
-                                    if item.id == viewModel.filteredLoader.items.last?.id {
-                                        Task { await viewModel.loadMoreFiltered(using: appState) }
+                    if viewModel.filteredLoader.items.isEmpty && viewModel.filteredLoader.isLoadingMore {
+                        ProgressView()
+                            .tint(CinemaColor.onSurfaceVariant)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, CinemaSpacing.spacing10)
+                    } else if viewModel.filteredLoader.items.isEmpty {
+                        filteredEmptyState
+                    } else {
+                        LazyVGrid(columns: filteredColumns, spacing: gridSpacing) {
+                            ForEach(viewModel.filteredLoader.items, id: \.id) { item in
+                                posterCard(item)
+                                    .id(item.id)
+                                    .onAppear {
+                                        if item.id == viewModel.filteredLoader.items.last?.id {
+                                            Task { await viewModel.loadMoreFiltered(using: appState) }
+                                        }
                                     }
-                                }
+                            }
                         }
+                        .padding(.horizontal, gridPadding)
                     }
-                    .padding(.horizontal, gridPadding)
-                }
 
-                Spacer(minLength: 80)
+                    Spacer(minLength: 80)
+                }
+                .padding(.top, CinemaSpacing.spacing3)
             }
-            .padding(.top, CinemaSpacing.spacing3)
-        }
-        .task(id: viewModel.sortFilter) {
-            await viewModel.applyFilter(using: appState)
+            .refreshable {
+                await viewModel.reload(using: appState)
+            }
+            .task(id: viewModel.sortFilter) {
+                await viewModel.applyFilter(using: appState)
+            }
+            #if os(iOS)
+            .overlay(alignment: .trailing) {
+                if shouldShowJumpBar {
+                    AlphabeticalJumpBar(
+                        accent: themeManager.accent,
+                        onSelect: { letter in
+                            if let target = firstItemID(for: letter) {
+                                withAnimation { proxy.scrollTo(target, anchor: .top) }
+                            }
+                        }
+                    )
+                    .padding(.trailing, CinemaSpacing.spacing2)
+                }
+            }
+            #endif
         }
     }
 
@@ -378,6 +421,70 @@ struct MediaLibraryScreen: View {
             }
             .scrollClipDisabled()
 
+            // Watch Status section
+            Text(loc.localized("filter.watchStatus"))
+                .font(CinemaFont.label(.large))
+                .foregroundStyle(CinemaColor.onSurfaceVariant)
+                .textCase(.uppercase)
+                .tracking(0.8)
+
+            HStack(spacing: 10) {
+                let isSelected = viewModel.sortFilter.showUnwatchedOnly
+                Button {
+                    viewModel.sortFilter.showUnwatchedOnly.toggle()
+                } label: {
+                    Text(loc.localized("filter.unwatchedOnly"))
+                        .font(.system(size: CinemaScale.pt(18), weight: isSelected ? .bold : .medium))
+                        .foregroundStyle(isSelected ? themeManager.onAccent : CinemaColor.onSurface)
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 10)
+                        .background(
+                            isSelected
+                                ? themeManager.accentContainer
+                                : CinemaColor.surfaceContainerHigh
+                        )
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(TVFilterChipButtonStyle(accent: themeManager.accent))
+                .focusEffectDisabled()
+                .hoverEffectDisabled()
+            }
+
+            // Decade section
+            Text(loc.localized("filter.byDecade"))
+                .font(CinemaFont.label(.large))
+                .foregroundStyle(CinemaColor.onSurfaceVariant)
+                .textCase(.uppercase)
+                .tracking(0.8)
+
+            FlowLayout(spacing: 10) {
+                ForEach(tvDecadeOptions, id: \.self) { decade in
+                    let isSelected = viewModel.sortFilter.selectedDecades.contains(decade)
+                    Button {
+                        if isSelected {
+                            viewModel.sortFilter.selectedDecades.remove(decade)
+                        } else {
+                            viewModel.sortFilter.selectedDecades.insert(decade)
+                        }
+                    } label: {
+                        Text(loc.localized("filter.decade", decade))
+                            .font(.system(size: CinemaScale.pt(18), weight: isSelected ? .bold : .medium))
+                            .foregroundStyle(isSelected ? themeManager.onAccent : CinemaColor.onSurface)
+                            .padding(.horizontal, 18)
+                            .padding(.vertical, 10)
+                            .background(
+                                isSelected
+                                    ? themeManager.accentContainer
+                                    : CinemaColor.surfaceContainerHigh
+                            )
+                            .clipShape(Capsule())
+                    }
+                    .buttonStyle(TVFilterChipButtonStyle(accent: themeManager.accent))
+                    .focusEffectDisabled()
+                    .hoverEffectDisabled()
+                }
+            }
+
             // Genre section
             if !viewModel.genres.isEmpty {
                 Text(loc.localized("filter.byGenre"))
@@ -436,26 +543,28 @@ struct MediaLibraryScreen: View {
                 }
             }
 
-            // Reset button — separate line, only when filters are active
+            // Reset button (refresh moved to Settings > Server > Refresh Catalogue)
             if viewModel.sortFilter.isNonDefault {
-                Button {
-                    viewModel.sortFilter = LibrarySortFilterState()
-                } label: {
-                    HStack(spacing: 8) {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: CinemaScale.pt(18), weight: .medium))
-                        Text(loc.localized("action.reset"))
-                            .font(.system(size: CinemaScale.pt(18), weight: .semibold))
+                HStack(spacing: 10) {
+                    Button {
+                        viewModel.sortFilter = LibrarySortFilterState()
+                    } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.system(size: CinemaScale.pt(18), weight: .medium))
+                            Text(loc.localized("action.reset"))
+                                .font(.system(size: CinemaScale.pt(18), weight: .semibold))
+                        }
+                        .foregroundStyle(CinemaColor.onSurfaceVariant)
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 10)
+                        .background(CinemaColor.surfaceContainerHigh)
+                        .clipShape(Capsule())
                     }
-                    .foregroundStyle(CinemaColor.onSurfaceVariant)
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 10)
-                    .background(CinemaColor.surfaceContainerHigh)
-                    .clipShape(Capsule())
+                    .buttonStyle(TVFilterChipButtonStyle(accent: themeManager.accent))
+                    .focusEffectDisabled()
+                    .hoverEffectDisabled()
                 }
-                .buttonStyle(TVFilterChipButtonStyle(accent: themeManager.accent))
-                .focusEffectDisabled()
-                .hoverEffectDisabled()
             }
         }
         .padding(.horizontal, CinemaSpacing.spacing20)
@@ -469,6 +578,9 @@ struct MediaLibraryScreen: View {
             (loc.localized("sort.rating"), .communityRating)
         ]
     }
+
+    /// Decades offered as chips on tvOS, most-recent-first.
+    private var tvDecadeOptions: [Int] { [2020, 2010, 2000, 1990, 1980, 1970, 1960, 1950] }
     #endif
 
     // MARK: - Genre Row
@@ -578,10 +690,14 @@ struct MediaLibraryScreen: View {
                 Text(loc.localized("movies.sortFilter"))
                     .font(.system(size: filterLabelSize, weight: .semibold))
                 if viewModel.sortFilter.isFiltered {
+                    let filterCount =
+                        viewModel.sortFilter.selectedGenres.count
+                        + viewModel.sortFilter.selectedDecades.count
+                        + (viewModel.sortFilter.showUnwatchedOnly ? 1 : 0)
                     ZStack {
                         Circle()
                             .fill(CinemaColor.onSurface.opacity(0.25))
-                        Text("\(viewModel.sortFilter.selectedGenres.count)")
+                        Text("\(filterCount)")
                             .font(.system(size: 11, weight: .bold))
                     }
                     .frame(width: 20, height: 20)
@@ -611,6 +727,50 @@ struct MediaLibraryScreen: View {
     private func errorView(_ message: String) -> some View {
         ErrorStateView(message: message, retryTitle: loc.localized("action.retry")) {
             Task { await viewModel.loadInitial(using: appState) }
+        }
+    }
+
+    // MARK: - Empty States
+
+    // MARK: - Alphabetical Jump Bar (iOS)
+
+    #if os(iOS)
+    /// Only shown when the filtered view is actually alphabetically meaningful:
+    /// the user has sorted by name ascending. Other sorts (date added, year, rating)
+    /// wouldn't produce a coherent A→Z scroll.
+    private var shouldShowJumpBar: Bool {
+        viewModel.sortFilter.sortBy == .sortName
+            && viewModel.sortFilter.sortAscending
+            && viewModel.filteredLoader.items.count > 20
+    }
+
+    /// Returns the id of the first loaded item whose name begins with the given letter.
+    /// "#" targets the first item starting with a digit or non-letter character.
+    private func firstItemID(for letter: String) -> String? {
+        let target = letter.uppercased()
+        for item in viewModel.filteredLoader.items {
+            guard let name = item.name else { continue }
+            let first = String(name.prefix(1)).uppercased()
+            if target == "#" {
+                if first.first.map({ !$0.isLetter }) ?? false { return item.id }
+            } else if first == target {
+                return item.id
+            }
+        }
+        return nil
+    }
+    #endif
+
+    /// Shown in the filtered grid (iOS or tvOS) when the current sort/filter combination
+    /// yields no results. Offers a "Clear filters" action that resets sort + filter state.
+    private var filteredEmptyState: some View {
+        EmptyStateView(
+            systemImage: "line.3.horizontal.decrease.circle",
+            title: loc.localized("empty.library.filtered.title"),
+            subtitle: loc.localized("empty.library.filtered.subtitle"),
+            actionTitle: loc.localized("empty.library.filtered.action")
+        ) {
+            viewModel.sortFilter = LibrarySortFilterState()
         }
     }
 

--- a/Shared/Screens/NativeVideoPresenter.swift
+++ b/Shared/Screens/NativeVideoPresenter.swift
@@ -4,6 +4,7 @@ import AVFoundation
 import MediaPlayer
 import OSLog
 import CinemaxKit
+import JellyfinAPI
 
 private let logger = Logger(subsystem: "com.cinemax", category: "Playback")
 
@@ -18,7 +19,6 @@ final class NativeVideoPresenter {
     private var playerVC: AVPlayerViewController?
     private var playerObservation: NSKeyValueObservation?
     private var itemEndObserver: NSObjectProtocol?
-    private var progressReportTask: Task<Void, Never>?
     private var hasRetriedDirectURL = false
     private var playbackInfo: PlaybackInfo?
 
@@ -33,6 +33,7 @@ final class NativeVideoPresenter {
     private let maxBitrate: Int
     private let loc: LocalizationManager
     private let autoPlayNextEpisode: Bool
+    private let imageBuilder: ImageURLBuilder
     private let onDismiss: () -> Void
 
     // Retained for the lifetime of the asset — AVAssetResourceLoader holds only a weak ref.
@@ -44,7 +45,42 @@ final class NativeVideoPresenter {
     private var subtitleTracks: [MediaTrackInfo] = []
     private var currentAudioIndex: Int? = nil
     private var currentSubtitleIndex: Int? = nil
-    private var currentPlayMethod: PlayMethod = .transcode
+    private var currentPlayMethod: CinemaxKit.PlayMethod = .transcode
+
+    // Skip segments
+    //
+    // Pure time-based UX: the skip button is visible iff `currentTime ∈ segment`.
+    // No "already skipped" memory — if the user rewinds back into a segment, the
+    // button reappears.
+    //
+    // Platform split (see `showSkipButton` / `hideSkipButton` for the rendering):
+    // - iOS: a floating `UIButton` added directly to `AVPlayerViewController.view`
+    //   (stored in `skipButton`). Touch reaches it natively.
+    // - tvOS: the native `AVPlayerViewController.contextualActions` API. It's the
+    //   only mechanism that produces a focusable action button that coexists with
+    //   the transport-bar focus context. Custom subviews / overlay modals cannot
+    //   be focused by the Siri Remote while AVPlayerViewController is on screen —
+    //   the player's focus environment is private and locked.
+    private var segments: [MediaSegmentDto] = []
+    private var timeObserver: Any?
+    private var activeSegmentType: MediaSegmentType?
+    #if os(iOS)
+    private var skipButton: UIButton?
+    #endif
+
+    // Sleep timer
+    private var sleepTickTask: Task<Void, Never>?
+    private var sleepEndDate: Date?
+    private var sleepIndicatorContainer: UIView?
+    private var sleepIndicatorLabel: UILabel?
+    private var sleepOverlayContainer: UIView?
+
+    // End-of-series
+    private var currentSeriesName: String?
+    private var finishedSeriesOverlay: UIView?
+
+    // Debug: jump to last 15 seconds button
+    private var skipToEndButton: UIButton?
 
     #if os(tvOS)
     /// Retained delegate — AVPlayerViewControllerDelegate is used on tvOS to detect
@@ -59,6 +95,7 @@ final class NativeVideoPresenter {
         apiClient: any APIClientProtocol, userId: String,
         maxBitrate: Int, loc: LocalizationManager,
         autoPlayNextEpisode: Bool,
+        imageBuilder: ImageURLBuilder,
         onDismiss: @escaping () -> Void
     ) {
         self.itemId = itemId
@@ -72,6 +109,7 @@ final class NativeVideoPresenter {
         self.maxBitrate = maxBitrate
         self.loc = loc
         self.autoPlayNextEpisode = autoPlayNextEpisode
+        self.imageBuilder = imageBuilder
         self.onDismiss = onDismiss
     }
 
@@ -161,6 +199,8 @@ final class NativeVideoPresenter {
                         if let self, let avPlayer {
                             self.retryWithDirectURL(player: avPlayer, startTime: st)
                         }
+                        #else
+                        self?.showPlaybackErrorAlert(error: item.error)
                         #endif
                     default: break
                     }
@@ -172,6 +212,10 @@ final class NativeVideoPresenter {
             reportPlaybackStart()
             startProgressReporting()
             observeItemEnd(playerItem, player: avPlayer)
+            fetchSegments(for: self.itemId)
+            fetchAndApplyChapters(for: self.itemId, playerItem: playerItem)
+            startSleepTimerIfNeeded()
+            showSkipToEndButtonIfDebugEnabled()
         }
     }
 
@@ -199,7 +243,7 @@ final class NativeVideoPresenter {
         applyTitleMetadata(to: playerItem, title: title)
 
         playerObservation?.invalidate()
-        playerObservation = playerItem.observe(\.status) { item, _ in
+        playerObservation = playerItem.observe(\.status) { [weak self] item, _ in
             Task { @MainActor in
                 switch item.status {
                 case .readyToPlay:
@@ -209,6 +253,8 @@ final class NativeVideoPresenter {
                     }
                 case .failed:
                     logger.error("AVPlayer failed on direct URL fallback: \(item.error?.localizedDescription ?? "unknown")")
+                    // Both HLS with manifest loader and direct URL failed — nothing else to try.
+                    self?.showPlaybackErrorAlert(error: item.error)
                 default: break
                 }
             }
@@ -318,6 +364,20 @@ final class NativeVideoPresenter {
             ))
         }
 
+        // Debug: jump to the last 15 seconds. Lives in the transport bar custom menu
+        // (rather than as a free-floating UIView overlay) so the tvOS focus engine
+        // can actually reach it via the Siri Remote.
+        if UserDefaults.standard.bool(forKey: "debug.showSkipToEnd") {
+            items.append(UIAction(
+                title: "⏭ Skip to End (Debug)",
+                image: UIImage(systemName: "forward.end.alt.fill")
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.seekToLast15Seconds()
+                }
+            })
+        }
+
         // Subtitles are handled natively by AVKit via WebVTT HLS renditions in the manifest.
         // No custom subtitle menu injection needed — AVKit shows ONE unified Subtitles entry.
         // On iOS, HLSManifestLoader strips ASS/SSA tags from the WebVTT subtitle segments.
@@ -420,6 +480,11 @@ final class NativeVideoPresenter {
             reportPlaybackStart()
             startProgressReporting()
             observeItemEnd(playerItem, player: avPlayer)
+            fetchSegments(for: ep.id)
+            fetchAndApplyChapters(for: ep.id, playerItem: playerItem)
+            // Episode navigation restarts the sleep timer (keeps playback "session" alive).
+            startSleepTimerIfNeeded()
+            showSkipToEndButtonIfDebugEnabled()
         }
     }
 
@@ -464,25 +529,47 @@ final class NativeVideoPresenter {
         }
     }
 
+    /// Single periodic time observer (0.5 s) that handles both segment skip detection
+    /// and playback progress reporting (every ~10 s).
+    private var progressTickCounter = 0
+
     private func startProgressReporting() {
-        progressReportTask?.cancel()
-        guard let info = playbackInfo else { return }
+        removeTimeObserver()
+        progressTickCounter = 0
+        guard let player = playerVC?.player else { return }
+
+        timeObserver = player.addPeriodicTimeObserver(
+            forInterval: CMTime(seconds: 1, preferredTimescale: 600),
+            queue: .main
+        ) { [weak self] time in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                // Segment skip check every 1 s
+                self.checkSegments(currentTime: time.seconds)
+
+                // Progress report every ~10 s (10 ticks × 1 s)
+                self.progressTickCounter += 1
+                if self.progressTickCounter >= 10 {
+                    self.progressTickCounter = 0
+                    self.reportPeriodicProgress()
+                }
+            }
+        }
+    }
+
+    private func reportPeriodicProgress() {
+        guard let info = playbackInfo, let player = playerVC?.player else { return }
+        let ticks = Int(player.currentTime().seconds * 10_000_000)
+        let isPaused = player.rate == 0
         let id = itemId
         let client = apiClient
         let uid = userId
-        let player = playerVC?.player
-        progressReportTask = Task {
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(10))
-                guard !Task.isCancelled else { return }
-                let ticks = Int((player?.currentTime().seconds ?? 0) * 10_000_000)
-                let isPaused = player?.rate == 0
-                await client.reportPlaybackProgress(
-                    itemId: id, userId: uid,
-                    mediaSourceId: info.mediaSourceId, playSessionId: info.playSessionId,
-                    positionTicks: ticks, isPaused: isPaused, playMethod: info.playMethod
-                )
-            }
+        Task.detached {
+            await client.reportPlaybackProgress(
+                itemId: id, userId: uid,
+                mediaSourceId: info.mediaSourceId, playSessionId: info.playSessionId,
+                positionTicks: ticks, isPaused: isPaused, playMethod: info.playMethod
+            )
         }
     }
 
@@ -498,9 +585,953 @@ final class NativeVideoPresenter {
                 let autoPlay = UserDefaults.standard.object(forKey: "autoPlayNextEpisode") as? Bool ?? true
                 if autoPlay, let next = self.nextEpisode, self.episodeNavigator != nil {
                     self.navigateToEpisode(next)
+                } else if autoPlay, self.episodeNavigator != nil, self.nextEpisode == nil,
+                          let seriesName = self.currentSeriesName {
+                    // We just finished the last episode of a series while auto-play is on.
+                    self.showFinishedSeriesOverlay(seriesName: seriesName)
                 }
             }
         }
+    }
+
+    // MARK: - Skip Segments
+
+    private func fetchSegments(for itemId: String) {
+        segments = []
+        hideSkipButton()
+        activeSegmentType = nil
+
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let fetched = try await self.apiClient.getMediaSegments(
+                    itemId: itemId,
+                    includeSegmentTypes: [.intro, .outro]
+                )
+                self.segments = fetched
+            } catch {
+                logger.info("Media segments unavailable for \(itemId): \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Drives skip-button visibility purely from `currentTime`:
+    /// - If we're inside an intro/outro segment that we're not already showing a
+    ///   button for, show it.
+    /// - If we're outside all segments but a button is shown, hide it.
+    ///
+    /// Re-entry is allowed: if the user rewinds back into a segment after leaving
+    /// it, `activeSegmentType` will have been cleared, so the next tick shows the
+    /// button again.
+    private func checkSegments(currentTime: Double) {
+        for segment in segments {
+            let start = Double(segment.startTicks ?? 0) / 10_000_000
+            let end = Double(segment.endTicks ?? 0) / 10_000_000
+            guard end > start else { continue }
+
+            if currentTime >= start && currentTime < end - 1 {
+                if activeSegmentType != segment.type {
+                    activeSegmentType = segment.type
+                    showSkipButton(for: segment)
+                }
+                return
+            }
+        }
+
+        // Outside all segments — clear the button if one is up.
+        if activeSegmentType != nil {
+            activeSegmentType = nil
+            hideSkipButton()
+        }
+    }
+
+    /// Renders the skip button. Platform-split:
+    /// - **iOS**: a floating `UIButton` added to `AVPlayerViewController.view`.
+    ///   Touch reaches it directly.
+    /// - **tvOS**: a `UIAction` installed on `AVPlayerViewController.contextualActions`.
+    ///   This is the native tvOS API for skip-intro-style affordances: the button
+    ///   appears in the player's own focus container, is focusable by the Siri
+    ///   Remote, and coexists with the transport bar (users can navigate from the
+    ///   scrubber/play button up to the skip action without losing HUD access).
+    ///   Custom subviews / overlay modals cannot achieve this — AVPlayerViewController
+    ///   locks its focus environment.
+    private func showSkipButton(for segment: MediaSegmentDto) {
+        guard let vc = playerVC else { return }
+
+        let title: String
+        switch segment.type {
+        case .intro:
+            title = loc.localized("player.skipIntro")
+        case .outro:
+            title = loc.localized("player.skipCredits")
+        default:
+            return
+        }
+
+        let endSeconds = Double(segment.endTicks ?? 0) / 10_000_000
+
+        #if os(tvOS)
+        // Native tvOS path. Setting `contextualActions` to a non-empty array makes
+        // the action visible in the playback chrome; clearing it removes the button.
+        // The time observer (via `checkSegments`) drives both sides, so the button's
+        // lifetime is exactly `[segment.start, segment.end)`.
+        let action = UIAction(
+            title: title,
+            image: UIImage(systemName: "forward.fill")
+        ) { [weak self] _ in
+            guard let player = self?.playerVC?.player else { return }
+            player.seek(
+                to: CMTime(seconds: endSeconds, preferredTimescale: 600),
+                toleranceBefore: .zero, toleranceAfter: .zero
+            )
+            // No manual hide call: the seek moves currentTime past segment.end,
+            // `checkSegments` sees we're outside all segments, and hideSkipButton
+            // clears the contextual action. Pure time-based state.
+        }
+        vc.contextualActions = [action]
+        #else
+        hideSkipButton() // idempotent
+
+        // Modern UIButton.Configuration replaces the deprecated `contentEdgeInsets`,
+        // `setTitle`, `setTitleColor`, etc. Visuals (frosted glass + 20% white tint)
+        // are reproduced via `background.customView` (UIVisualEffectView) plus
+        // `background.backgroundColor`.
+        var config = UIButton.Configuration.plain()
+        var attrTitle = AttributedString("  \(title)  ▶▶")
+        attrTitle.font = .systemFont(ofSize: buttonFontSize, weight: .semibold)
+        attrTitle.foregroundColor = UIColor.white
+        config.attributedTitle = attrTitle
+        config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: buttonPaddingH, bottom: 0, trailing: buttonPaddingH)
+
+        let blur = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
+        blur.isUserInteractionEnabled = false
+        blur.layer.cornerRadius = buttonCornerRadius
+        blur.clipsToBounds = true
+        config.background.customView = blur
+        config.background.backgroundColor = UIColor.white.withAlphaComponent(0.2)
+        config.background.cornerRadius = buttonCornerRadius
+
+        let action = UIAction { [weak self] _ in
+            guard let player = self?.playerVC?.player else { return }
+            player.seek(
+                to: CMTime(seconds: endSeconds, preferredTimescale: 600),
+                toleranceBefore: .zero, toleranceAfter: .zero
+            )
+            // Same time-based cleanup as tvOS — the next checkSegments tick will
+            // hide the button when currentTime crosses segment.end.
+        }
+        let button = UIButton(configuration: config, primaryAction: action)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.alpha = 0
+        self.skipButton = button
+
+        let targetView = vc.view!
+        targetView.addSubview(button)
+        NSLayoutConstraint.activate([
+            button.trailingAnchor.constraint(equalTo: targetView.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            button.bottomAnchor.constraint(equalTo: targetView.safeAreaLayoutGuide.bottomAnchor, constant: -80),
+            button.heightAnchor.constraint(equalToConstant: 44),
+        ])
+        UIView.animate(withDuration: 0.3) { button.alpha = 1 }
+        #endif
+    }
+
+    private func hideSkipButton() {
+        #if os(tvOS)
+        // Clearing `contextualActions` removes the button from the HUD.
+        playerVC?.contextualActions = []
+        #else
+        guard let button = skipButton else { return }
+        UIView.animate(withDuration: 0.25, animations: { button.alpha = 0 }) { _ in
+            button.removeFromSuperview()
+        }
+        skipButton = nil
+        #endif
+    }
+
+    private func removeTimeObserver() {
+        if let observer = timeObserver, let player = playerVC?.player {
+            player.removeTimeObserver(observer)
+        }
+        timeObserver = nil
+    }
+
+    private var buttonFontSize: CGFloat {
+        #if os(tvOS)
+        28
+        #else
+        16
+        #endif
+    }
+
+    private var buttonCornerRadius: CGFloat {
+        #if os(tvOS)
+        14
+        #else
+        10
+        #endif
+    }
+
+    private var buttonPaddingH: CGFloat {
+        #if os(tvOS)
+        32
+        #else
+        20
+        #endif
+    }
+
+    // MARK: - Chapters
+
+    /// Fetches the full item (which carries the chapter list) and builds an
+    /// `AVNavigationMarkersGroup` exposed to AVPlayerViewController's scrubber.
+    /// Chapter images are downloaded in parallel and embedded as artwork metadata.
+    private func fetchAndApplyChapters(for id: String, playerItem: AVPlayerItem) {
+        let client = apiClient
+        let uid = userId
+        let builder = imageBuilder
+        let token = playbackInfo?.authToken
+        Task { [weak self, weak playerItem] in
+            guard let fullItem = try? await client.getItem(userId: uid, itemId: id) else { return }
+
+            // Capture the series name while we have the full item — used by the
+            // end-of-series completion overlay when this was the last episode.
+            await MainActor.run { [weak self] in
+                self?.currentSeriesName = fullItem.seriesName
+            }
+
+            guard let chapters = fullItem.chapters, chapters.count > 1 else { return }
+
+            // Chapter markers are tvOS-only (AVNavigationMarkersGroup lives in AVKit
+            // on tvOS only). Skip image download and marker build on iOS.
+            #if os(tvOS)
+            // Fetch chapter thumbnails in parallel. Missing images are fine — chapter
+            // markers still render with just a title.
+            let images: [Int: Data] = await withTaskGroup(of: (Int, Data?).self) { group in
+                for (index, _) in chapters.enumerated() {
+                    let url = builder.chapterImageURL(itemId: id, imageIndex: index, maxWidth: 480)
+                    group.addTask {
+                        await Self.loadChapterImage(url: url, token: token).map { (index, $0) } ?? (index, nil)
+                    }
+                }
+                var results: [Int: Data] = [:]
+                for await (idx, data) in group {
+                    if let data { results[idx] = data }
+                }
+                return results
+            }
+
+            await MainActor.run {
+                guard let self, let playerItem else { return }
+                self.applyChapterMarkers(chapters: chapters, images: images, to: playerItem)
+            }
+            #else
+            _ = builder
+            _ = token
+            _ = playerItem
+            _ = self
+            #endif
+        }
+    }
+
+    /// Downloads one chapter thumbnail, attaching the Jellyfin access token so the server
+    /// authorises the request. Returns `nil` on HTTP error or non-image content.
+    nonisolated private static func loadChapterImage(url: URL, token: String?) async -> Data? {
+        var request = URLRequest(url: url)
+        if let token {
+            request.addValue("MediaBrowser Token=\(token)", forHTTPHeaderField: "Authorization")
+        }
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            return nil
+        }
+        return data
+    }
+
+    /// Builds `AVTimedMetadataGroup` markers for the scrubber and assigns them via
+    /// `AVPlayerItem.navigationMarkerGroups`. Group title becomes the section label
+    /// in AVKit's Chapters menu.
+    ///
+    /// **tvOS-only**: `AVNavigationMarkersGroup` lives in `AVKit` and only ships on tvOS.
+    /// On iOS, `AVPlayerViewController` has no built-in chapters scrubber, so we skip.
+    private func applyChapterMarkers(chapters: [ChapterInfo], images: [Int: Data], to playerItem: AVPlayerItem) {
+        #if os(tvOS)
+        var markers: [AVTimedMetadataGroup] = []
+        markers.reserveCapacity(chapters.count)
+
+        for (index, chapter) in chapters.enumerated() {
+            let startSeconds = Double(chapter.startPositionTicks ?? 0) / 10_000_000
+            let startTime = CMTime(seconds: startSeconds, preferredTimescale: 600)
+            let range = CMTimeRange(start: startTime, duration: .zero)
+
+            var items: [AVMetadataItem] = []
+
+            let titleItem = AVMutableMetadataItem()
+            titleItem.identifier = .commonIdentifierTitle
+            titleItem.value = (chapter.name ?? "Chapter \(index + 1)") as NSString
+            titleItem.extendedLanguageTag = "und"
+            items.append(titleItem)
+
+            if let data = images[index] {
+                let artwork = AVMutableMetadataItem()
+                artwork.identifier = .commonIdentifierArtwork
+                artwork.value = data as NSData
+                artwork.dataType = kCMMetadataBaseDataType_JPEG as String
+                artwork.extendedLanguageTag = "und"
+                items.append(artwork)
+            }
+
+            markers.append(AVTimedMetadataGroup(items: items, timeRange: range))
+        }
+
+        let group = AVNavigationMarkersGroup(title: "Chapters", timedNavigationMarkers: markers)
+        playerItem.navigationMarkerGroups = [group]
+        #endif
+    }
+
+    // MARK: - Error Recovery
+
+    /// Presents a native UIAlertController with a specific, actionable message when all
+    /// playback attempts have failed. Translates common AVFoundation error codes
+    /// (-12881 transcode, -12938 network) into human-readable guidance.
+    private var isShowingErrorAlert = false
+
+    private func showPlaybackErrorAlert(error: Error?) {
+        guard !isShowingErrorAlert, let vc = playerVC else { return }
+        isShowingErrorAlert = true
+
+        let message = errorMessage(for: error)
+
+        let alert = UIAlertController(
+            title: loc.localized("playback.error.title"),
+            message: message,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(
+            title: loc.localized("playback.error.close"),
+            style: .default,
+            handler: { [weak self] _ in
+                self?.isShowingErrorAlert = false
+                self?.playerVC?.dismiss(animated: true)
+            }
+        ))
+        vc.present(alert, animated: true)
+    }
+
+    private func errorMessage(for error: Error?) -> String {
+        guard let nsError = error as NSError? else {
+            return loc.localized("playback.error.generic")
+        }
+        switch nsError.code {
+        case -12881, -12886, -16170:
+            return loc.localized("playback.error.transcode")
+        case -12938, -1009, -1001, -1004, -1005:
+            return loc.localized("playback.error.network")
+        default:
+            return loc.localized("playback.error.generic")
+        }
+    }
+
+    // MARK: - Debug: Skip to End
+
+    /// iOS draws a small floating overlay button (top-right) that the user taps directly.
+    /// On tvOS the same overlay isn't focusable through the AVPlayerViewController focus
+    /// engine — so the action is injected into `transportBarCustomMenuItems` instead
+    /// (see `setupTrackMenus`).
+    private func showSkipToEndButtonIfDebugEnabled() {
+        #if os(tvOS)
+        // tvOS path is handled by the transport-bar custom menu; nothing to draw here.
+        return
+        #else
+        let enabled = UserDefaults.standard.bool(forKey: "debug.showSkipToEnd")
+        guard enabled else {
+            hideSkipToEndButton()
+            return
+        }
+        guard skipToEndButton == nil, let vc = playerVC else { return }
+
+        var config = UIButton.Configuration.plain()
+        var attrTitle = AttributedString("  ⏭ End  ")
+        attrTitle.font = .systemFont(ofSize: buttonFontSize, weight: .semibold)
+        attrTitle.foregroundColor = UIColor.white
+        config.attributedTitle = attrTitle
+        config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: buttonPaddingH, bottom: 0, trailing: buttonPaddingH)
+        config.background.backgroundColor = UIColor.systemPurple.withAlphaComponent(0.55)
+        config.background.cornerRadius = buttonCornerRadius
+
+        let button = UIButton(
+            configuration: config,
+            primaryAction: UIAction { [weak self] _ in self?.seekToLast15Seconds() }
+        )
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.alpha = 0.85
+
+        let targetView = vc.view!
+        targetView.addSubview(button)
+
+        NSLayoutConstraint.activate([
+            button.trailingAnchor.constraint(equalTo: targetView.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            button.topAnchor.constraint(equalTo: targetView.safeAreaLayoutGuide.topAnchor, constant: 12),
+            button.heightAnchor.constraint(equalToConstant: 36),
+        ])
+
+        skipToEndButton = button
+        #endif
+    }
+
+    private func hideSkipToEndButton() {
+        skipToEndButton?.removeFromSuperview()
+        skipToEndButton = nil
+    }
+
+    private func seekToLast15Seconds() {
+        guard let player = playerVC?.player,
+              let item = player.currentItem else { return }
+        let duration = item.duration.seconds
+        guard duration.isFinite, duration > 15 else { return }
+        let target = CMTime(seconds: duration - 15, preferredTimescale: 600)
+        player.seek(to: target, toleranceBefore: .zero, toleranceAfter: .zero)
+    }
+
+    // MARK: - End-of-Series Overlay
+
+    /// Shown when the last episode of a series finishes with autoplay on. Gives the user
+    /// a concrete "you're done" moment rather than the player just sitting at the end.
+    private func showFinishedSeriesOverlay(seriesName: String) {
+        #if os(tvOS)
+        // Same focus-engine reasoning as `showSleepOverlay` — UIAlertController
+        // owns its own focus context so the Done button is reachable with the remote.
+        guard finishedSeriesOverlay == nil, let vc = playerVC else { return }
+
+        let alert = UIAlertController(
+            title: String(format: loc.localized("player.finishedSeries.title"), seriesName),
+            message: loc.localized("player.finishedSeries.subtitle"),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(
+            title: loc.localized("player.finishedSeries.done"),
+            style: .default,
+            handler: { [weak self] _ in
+                self?.finishedSeriesOverlay = nil
+                self?.playerVC?.dismiss(animated: true)
+            }
+        ))
+
+        finishedSeriesOverlay = alert.view
+        vc.present(alert, animated: true)
+        return
+        #else
+        guard finishedSeriesOverlay == nil, let vc = playerVC else { return }
+
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.backgroundColor = UIColor.black.withAlphaComponent(0.75)
+        container.alpha = 0
+
+        let card = UIView()
+        card.translatesAutoresizingMaskIntoConstraints = false
+        card.layer.cornerRadius = 20
+        card.clipsToBounds = true
+
+        let blur = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
+        blur.translatesAutoresizingMaskIntoConstraints = false
+        blur.isUserInteractionEnabled = false
+        card.addSubview(blur)
+
+        let icon = UIImageView(image: UIImage(systemName: "checkmark.circle.fill"))
+        icon.tintColor = .systemGreen
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        icon.contentMode = .scaleAspectFit
+
+        let titleLabel = UILabel()
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.font = .systemFont(ofSize: overlayTitleSize, weight: .bold)
+        titleLabel.textColor = .white
+        titleLabel.textAlignment = .center
+        titleLabel.numberOfLines = 0
+        titleLabel.text = String(format: loc.localized("player.finishedSeries.title"), seriesName)
+
+        let subtitleLabel = UILabel()
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        subtitleLabel.font = .systemFont(ofSize: overlaySubtitleSize, weight: .medium)
+        subtitleLabel.textColor = .white.withAlphaComponent(0.8)
+        subtitleLabel.textAlignment = .center
+        subtitleLabel.numberOfLines = 0
+        subtitleLabel.text = loc.localized("player.finishedSeries.subtitle")
+
+        var doneConfig = UIButton.Configuration.plain()
+        var doneTitle = AttributedString(loc.localized("player.finishedSeries.done"))
+        doneTitle.font = .systemFont(ofSize: overlayButtonSize, weight: .semibold)
+        doneTitle.foregroundColor = UIColor.black
+        doneConfig.attributedTitle = doneTitle
+        doneConfig.contentInsets = NSDirectionalEdgeInsets(top: 14, leading: 24, bottom: 14, trailing: 24)
+        doneConfig.background.backgroundColor = UIColor.white.withAlphaComponent(0.95)
+        doneConfig.background.cornerRadius = 12
+
+        let doneButton = UIButton(
+            configuration: doneConfig,
+            primaryAction: UIAction { [weak self] _ in
+                self?.hideFinishedSeriesOverlay()
+                self?.playerVC?.dismiss(animated: true)
+            }
+        )
+        doneButton.translatesAutoresizingMaskIntoConstraints = false
+
+        card.addSubview(icon)
+        card.addSubview(titleLabel)
+        card.addSubview(subtitleLabel)
+        card.addSubview(doneButton)
+        container.addSubview(card)
+
+        let targetView = vc.view!
+        targetView.addSubview(container)
+
+        NSLayoutConstraint.activate([
+            container.topAnchor.constraint(equalTo: targetView.topAnchor),
+            container.bottomAnchor.constraint(equalTo: targetView.bottomAnchor),
+            container.leadingAnchor.constraint(equalTo: targetView.leadingAnchor),
+            container.trailingAnchor.constraint(equalTo: targetView.trailingAnchor),
+
+            card.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            card.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            card.widthAnchor.constraint(equalToConstant: overlayCardWidth),
+
+            blur.topAnchor.constraint(equalTo: card.topAnchor),
+            blur.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+            blur.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            blur.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+
+            icon.topAnchor.constraint(equalTo: card.topAnchor, constant: 36),
+            icon.centerXAnchor.constraint(equalTo: card.centerXAnchor),
+            icon.widthAnchor.constraint(equalToConstant: overlayIconSize),
+            icon.heightAnchor.constraint(equalToConstant: overlayIconSize),
+
+            titleLabel.topAnchor.constraint(equalTo: icon.bottomAnchor, constant: 20),
+            titleLabel.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 24),
+            titleLabel.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -24),
+
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
+            subtitleLabel.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 24),
+            subtitleLabel.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -24),
+
+            doneButton.topAnchor.constraint(equalTo: subtitleLabel.bottomAnchor, constant: 28),
+            doneButton.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 24),
+            doneButton.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -24),
+            doneButton.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -24),
+        ])
+
+        self.finishedSeriesOverlay = container
+
+        UIView.animate(withDuration: 0.3) { container.alpha = 1 }
+        #endif
+    }
+
+    private func hideFinishedSeriesOverlay() {
+        guard let container = finishedSeriesOverlay else { return }
+        #if os(tvOS)
+        if let presented = playerVC?.presentedViewController {
+            presented.dismiss(animated: true)
+        }
+        finishedSeriesOverlay = nil
+        return
+        #else
+        UIView.animate(withDuration: 0.25, animations: { container.alpha = 0 }) { _ in
+            container.removeFromSuperview()
+        }
+        finishedSeriesOverlay = nil
+        #endif
+    }
+
+    // MARK: - Sleep Timer
+
+    /// Reads the effective sleep-timer duration (user setting or debug override) and starts
+    /// a timer if non-zero. Called on playback start, episode navigation, and "Keep watching".
+    private func startSleepTimerIfNeeded() {
+        let seconds = SleepTimerOption.currentDefaultSeconds
+        guard seconds > 0 else { return }
+        startSleepTimer(seconds: seconds)
+    }
+
+    private func startSleepTimer(seconds: TimeInterval) {
+        stopSleepTimer()
+        sleepEndDate = Date().addingTimeInterval(seconds)
+        showSleepIndicator()
+        updateSleepIndicator(remaining: seconds)
+
+        sleepTickTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                guard let self, let end = self.sleepEndDate else { return }
+                let remaining = end.timeIntervalSinceNow
+                if remaining <= 0 {
+                    self.stopSleepTimer()
+                    self.hideSleepIndicator()
+                    self.triggerSleep()
+                    return
+                }
+                self.updateSleepIndicator(remaining: remaining)
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+        }
+    }
+
+    private func stopSleepTimer() {
+        sleepTickTask?.cancel()
+        sleepTickTask = nil
+        sleepEndDate = nil
+    }
+
+    private func triggerSleep() {
+        playerVC?.player?.pause()
+        showSleepOverlay()
+    }
+
+    private func showSleepIndicator() {
+        guard sleepIndicatorContainer == nil, let vc = playerVC else { return }
+
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.layer.cornerRadius = buttonCornerRadius
+        container.clipsToBounds = true
+        container.alpha = 0
+
+        let blur = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
+        blur.translatesAutoresizingMaskIntoConstraints = false
+        blur.isUserInteractionEnabled = false
+        container.addSubview(blur)
+
+        let icon = UIImageView(image: UIImage(systemName: "moon.zzz.fill"))
+        icon.tintColor = .white
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        icon.contentMode = .scaleAspectFit
+
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: indicatorFontSize, weight: .semibold)
+        label.textColor = .white
+        label.text = ""
+
+        container.addSubview(icon)
+        container.addSubview(label)
+
+        let targetView = vc.view!
+        targetView.addSubview(container)
+
+        NSLayoutConstraint.activate([
+            blur.topAnchor.constraint(equalTo: container.topAnchor),
+            blur.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            blur.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            blur.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            icon.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: indicatorPaddingH),
+            icon.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            icon.widthAnchor.constraint(equalToConstant: indicatorIconSize),
+            icon.heightAnchor.constraint(equalToConstant: indicatorIconSize),
+
+            label.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 8),
+            label.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -indicatorPaddingH),
+            label.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+
+            container.heightAnchor.constraint(equalToConstant: indicatorHeight),
+        ])
+
+        #if os(tvOS)
+        NSLayoutConstraint.activate([
+            container.leadingAnchor.constraint(equalTo: targetView.safeAreaLayoutGuide.leadingAnchor, constant: 80),
+            container.bottomAnchor.constraint(equalTo: targetView.safeAreaLayoutGuide.bottomAnchor, constant: -80),
+        ])
+        #else
+        NSLayoutConstraint.activate([
+            container.leadingAnchor.constraint(equalTo: targetView.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            container.bottomAnchor.constraint(equalTo: targetView.safeAreaLayoutGuide.bottomAnchor, constant: -80),
+        ])
+        #endif
+
+        self.sleepIndicatorContainer = container
+        self.sleepIndicatorLabel = label
+
+        UIView.animate(withDuration: 0.3) { container.alpha = 1 }
+    }
+
+    private func updateSleepIndicator(remaining: TimeInterval) {
+        guard let label = sleepIndicatorLabel else { return }
+        let seconds = max(0, Int(remaining.rounded(.up)))
+        let hh = seconds / 3600
+        let mm = (seconds % 3600) / 60
+        let ss = seconds % 60
+        let formatted: String
+        if hh > 0 {
+            formatted = String(format: "%d:%02d:%02d", hh, mm, ss)
+        } else {
+            formatted = String(format: "%d:%02d", mm, ss)
+        }
+        label.text = String(format: loc.localized("sleep.indicator"), formatted)
+    }
+
+    private func hideSleepIndicator() {
+        guard let container = sleepIndicatorContainer else { return }
+        UIView.animate(withDuration: 0.25, animations: { container.alpha = 0 }) { _ in
+            container.removeFromSuperview()
+        }
+        sleepIndicatorContainer = nil
+        sleepIndicatorLabel = nil
+    }
+
+    private func showSleepOverlay() {
+        #if os(tvOS)
+        // On tvOS the focus engine doesn't claim arbitrary UIView subviews added to
+        // AVPlayerViewController.view, so the custom blur card's UIButtons are
+        // unreachable with the remote. UIAlertController owns its own focus context
+        // and gives us free Siri-Remote navigation.
+        guard sleepOverlayContainer == nil, let vc = playerVC else { return }
+
+        let alert = UIAlertController(
+            title: loc.localized("sleep.prompt.title"),
+            message: loc.localized("sleep.prompt.subtitle"),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(
+            title: loc.localized("sleep.prompt.keepWatching"),
+            style: .default,
+            handler: { [weak self] _ in
+                self?.sleepOverlayContainer = nil
+                self?.handleSleepKeepWatching()
+            }
+        ))
+        alert.addAction(UIAlertAction(
+            title: loc.localized("sleep.prompt.stop"),
+            style: .destructive,
+            handler: { [weak self] _ in
+                self?.sleepOverlayContainer = nil
+                self?.handleSleepStop()
+            }
+        ))
+
+        // Use the alert controller's view as a sentinel so `hideSleepOverlay` and
+        // cleanup paths know "an overlay is active" without us tracking another field.
+        sleepOverlayContainer = alert.view
+        vc.present(alert, animated: true)
+        return
+        #else
+        guard sleepOverlayContainer == nil, let vc = playerVC else { return }
+
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        container.alpha = 0
+
+        let card = UIView()
+        card.translatesAutoresizingMaskIntoConstraints = false
+        card.layer.cornerRadius = 20
+        card.clipsToBounds = true
+
+        let blur = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
+        blur.translatesAutoresizingMaskIntoConstraints = false
+        blur.isUserInteractionEnabled = false
+        card.addSubview(blur)
+
+        let icon = UIImageView(image: UIImage(systemName: "moon.zzz.fill"))
+        icon.tintColor = .white
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        icon.contentMode = .scaleAspectFit
+
+        let titleLabel = UILabel()
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.font = .systemFont(ofSize: overlayTitleSize, weight: .bold)
+        titleLabel.textColor = .white
+        titleLabel.textAlignment = .center
+        titleLabel.numberOfLines = 0
+        titleLabel.text = loc.localized("sleep.prompt.title")
+
+        let subtitleLabel = UILabel()
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        subtitleLabel.font = .systemFont(ofSize: overlaySubtitleSize, weight: .medium)
+        subtitleLabel.textColor = .white.withAlphaComponent(0.8)
+        subtitleLabel.textAlignment = .center
+        subtitleLabel.numberOfLines = 0
+        subtitleLabel.text = loc.localized("sleep.prompt.subtitle")
+
+        var keepConfig = UIButton.Configuration.plain()
+        var keepTitle = AttributedString(loc.localized("sleep.prompt.keepWatching"))
+        keepTitle.font = .systemFont(ofSize: overlayButtonSize, weight: .semibold)
+        keepTitle.foregroundColor = UIColor.black
+        keepConfig.attributedTitle = keepTitle
+        keepConfig.contentInsets = NSDirectionalEdgeInsets(top: 14, leading: 24, bottom: 14, trailing: 24)
+        keepConfig.background.backgroundColor = UIColor.white.withAlphaComponent(0.95)
+        keepConfig.background.cornerRadius = 12
+
+        let keepWatchingButton = UIButton(
+            configuration: keepConfig,
+            primaryAction: UIAction { [weak self] _ in self?.handleSleepKeepWatching() }
+        )
+        keepWatchingButton.translatesAutoresizingMaskIntoConstraints = false
+
+        var stopConfig = UIButton.Configuration.plain()
+        var stopTitle = AttributedString(loc.localized("sleep.prompt.stop"))
+        stopTitle.font = .systemFont(ofSize: overlayButtonSize, weight: .semibold)
+        stopTitle.foregroundColor = UIColor.white
+        stopConfig.attributedTitle = stopTitle
+        stopConfig.contentInsets = NSDirectionalEdgeInsets(top: 14, leading: 24, bottom: 14, trailing: 24)
+        stopConfig.background.backgroundColor = UIColor.white.withAlphaComponent(0.15)
+        stopConfig.background.cornerRadius = 12
+
+        let stopButton = UIButton(
+            configuration: stopConfig,
+            primaryAction: UIAction { [weak self] _ in self?.handleSleepStop() }
+        )
+        stopButton.translatesAutoresizingMaskIntoConstraints = false
+
+        card.addSubview(icon)
+        card.addSubview(titleLabel)
+        card.addSubview(subtitleLabel)
+        card.addSubview(keepWatchingButton)
+        card.addSubview(stopButton)
+        container.addSubview(card)
+
+        let targetView = vc.view!
+        targetView.addSubview(container)
+
+        NSLayoutConstraint.activate([
+            container.topAnchor.constraint(equalTo: targetView.topAnchor),
+            container.bottomAnchor.constraint(equalTo: targetView.bottomAnchor),
+            container.leadingAnchor.constraint(equalTo: targetView.leadingAnchor),
+            container.trailingAnchor.constraint(equalTo: targetView.trailingAnchor),
+
+            card.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            card.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            card.widthAnchor.constraint(equalToConstant: overlayCardWidth),
+
+            blur.topAnchor.constraint(equalTo: card.topAnchor),
+            blur.bottomAnchor.constraint(equalTo: card.bottomAnchor),
+            blur.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            blur.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+
+            icon.topAnchor.constraint(equalTo: card.topAnchor, constant: 36),
+            icon.centerXAnchor.constraint(equalTo: card.centerXAnchor),
+            icon.widthAnchor.constraint(equalToConstant: overlayIconSize),
+            icon.heightAnchor.constraint(equalToConstant: overlayIconSize),
+
+            titleLabel.topAnchor.constraint(equalTo: icon.bottomAnchor, constant: 20),
+            titleLabel.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 24),
+            titleLabel.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -24),
+
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
+            subtitleLabel.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 24),
+            subtitleLabel.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -24),
+
+            keepWatchingButton.topAnchor.constraint(equalTo: subtitleLabel.bottomAnchor, constant: 28),
+            keepWatchingButton.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 24),
+            keepWatchingButton.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -24),
+
+            stopButton.topAnchor.constraint(equalTo: keepWatchingButton.bottomAnchor, constant: 12),
+            stopButton.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 24),
+            stopButton.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -24),
+            stopButton.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -24),
+        ])
+
+        self.sleepOverlayContainer = container
+
+        UIView.animate(withDuration: 0.3) { container.alpha = 1 }
+        #endif
+    }
+
+    private func hideSleepOverlay() {
+        guard let container = sleepOverlayContainer else { return }
+        #if os(tvOS)
+        // tvOS path uses a presented UIAlertController — dismiss it via the controller.
+        if let presented = playerVC?.presentedViewController {
+            presented.dismiss(animated: true)
+        }
+        sleepOverlayContainer = nil
+        return
+        #else
+        UIView.animate(withDuration: 0.25, animations: { container.alpha = 0 }) { _ in
+            container.removeFromSuperview()
+        }
+        sleepOverlayContainer = nil
+        #endif
+    }
+
+    private func handleSleepKeepWatching() {
+        hideSleepOverlay()
+        playerVC?.player?.play()
+        // Restart timer with the user's configured default.
+        startSleepTimerIfNeeded()
+    }
+
+    private func handleSleepStop() {
+        hideSleepOverlay()
+        playerVC?.dismiss(animated: true)
+    }
+
+    private var indicatorFontSize: CGFloat {
+        #if os(tvOS)
+        26
+        #else
+        14
+        #endif
+    }
+
+    private var indicatorIconSize: CGFloat {
+        #if os(tvOS)
+        26
+        #else
+        16
+        #endif
+    }
+
+    private var indicatorHeight: CGFloat {
+        #if os(tvOS)
+        56
+        #else
+        36
+        #endif
+    }
+
+    private var indicatorPaddingH: CGFloat {
+        #if os(tvOS)
+        24
+        #else
+        14
+        #endif
+    }
+
+    private var overlayCardWidth: CGFloat {
+        #if os(tvOS)
+        640
+        #else
+        340
+        #endif
+    }
+
+    private var overlayIconSize: CGFloat {
+        #if os(tvOS)
+        72
+        #else
+        48
+        #endif
+    }
+
+    private var overlayTitleSize: CGFloat {
+        #if os(tvOS)
+        36
+        #else
+        22
+        #endif
+    }
+
+    private var overlaySubtitleSize: CGFloat {
+        #if os(tvOS)
+        22
+        #else
+        15
+        #endif
+    }
+
+    private var overlayButtonSize: CGFloat {
+        #if os(tvOS)
+        24
+        #else
+        16
+        #endif
     }
 
     // MARK: - Helpers
@@ -566,8 +1597,15 @@ final class NativeVideoPresenter {
     }
 
     private func cleanupPlayer() {
-        progressReportTask?.cancel()
-        progressReportTask = nil
+        removeTimeObserver()
+        hideSkipButton()
+        hideSkipToEndButton()
+        stopSleepTimer()
+        hideSleepIndicator()
+        hideSleepOverlay()
+        hideFinishedSeriesOverlay()
+        segments = []
+        activeSegmentType = nil
         playerObservation?.invalidate()
         playerObservation = nil
         if let obs = itemEndObserver {
@@ -605,6 +1643,7 @@ final class NativeVideoPresenter {
             Task { @MainActor in cb?() }
         }
     }
+
     #else
     /// Wraps AVPlayerViewController on iOS so we can detect modal dismissal
     /// via viewWillDisappear(isBeingDismissed:), which fires when the user taps Done/X.

--- a/Shared/Screens/SearchScreen.swift
+++ b/Shared/Screens/SearchScreen.swift
@@ -8,10 +8,21 @@ struct SearchScreen: View {
     @Environment(AppState.self) private var appState
     @Environment(ThemeManager.self) private var themeManager
     @Environment(LocalizationManager.self) private var loc
+    @Environment(ToastCenter.self) private var toasts
     @State private var viewModel = SearchViewModel()
 
     // Pulsing animation state for the listening indicator
     @State private var isPulsing = false
+
+    // Surprise Me state — two buttons (movie + series) in the empty state.
+    @State private var surpriseDestination: SurpriseDestination?
+    @State private var isPickingSurpriseMovie = false
+    @State private var isPickingSurpriseSeries = false
+
+    private struct SurpriseDestination: Identifiable, Hashable {
+        let id: String
+        let itemType: BaseItemKind
+    }
 
     private let columns: [GridItem] = {
         #if os(tvOS)
@@ -25,13 +36,35 @@ struct SearchScreen: View {
         ZStack {
             CinemaColor.surface.ignoresSafeArea()
 
+            #if os(tvOS)
+            // tvOS path is wrapped in a ScrollView + ScrollViewReader so we can
+            // force the page back to the top whenever it reappears (e.g., user
+            // pops back from a result detail). This is what surfaces the tvOS
+            // top tab bar — it stays hidden when content overlaps its area.
+            ScrollViewReader { proxy in
+                ScrollView {
+                    Color.clear.frame(height: 0).id("search.top")
+                    VStack(spacing: 0) {
+                        searchField
+                        resultContent
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 720, maxHeight: .infinity)
+                }
+                .scrollClipDisabled()
+                .onAppear {
+                    proxy.scrollTo("search.top", anchor: .top)
+                }
+            }
+            #else
             VStack(spacing: 0) {
                 searchField
-                #if os(iOS)
                 listeningLabel
-                #endif
                 resultContent
             }
+            #endif
+        }
+        .navigationDestination(item: $surpriseDestination) { dest in
+            MediaDetailScreen(itemId: dest.id, itemType: dest.itemType)
         }
         #if os(iOS)
         .navigationTitle(loc.localized("search.title"))
@@ -177,7 +210,7 @@ struct SearchScreen: View {
             Spacer()
         } else if viewModel.results.isEmpty {
             Spacer()
-            VStack(spacing: CinemaSpacing.spacing3) {
+            VStack(spacing: CinemaSpacing.spacing4) {
                 Image(systemName: "sparkle.magnifyingglass")
                     .font(.system(size: 48))
                     .foregroundStyle(CinemaColor.outlineVariant)
@@ -185,11 +218,114 @@ struct SearchScreen: View {
                 Text(loc.localized("search.searchLibrary"))
                     .font(CinemaFont.headline(.small))
                     .foregroundStyle(CinemaColor.onSurfaceVariant)
+
+                // "Not sure what to watch?" → two pills for a random movie or series.
+                surpriseMePills
             }
             Spacer()
         } else {
             resultsGrid
         }
+    }
+
+    // MARK: - Surprise Me
+
+    private var surpriseMePills: some View {
+        VStack(spacing: CinemaSpacing.spacing2) {
+            Text(loc.localized("search.surpriseMePrompt"))
+                .font(CinemaFont.label(.medium))
+                .foregroundStyle(CinemaColor.onSurfaceVariant)
+
+            HStack(spacing: CinemaSpacing.spacing3) {
+                surprisePill(
+                    label: loc.localized("search.surprise.movie"),
+                    icon: "film.fill",
+                    isLoading: isPickingSurpriseMovie
+                ) {
+                    await performSurprise(type: .movie)
+                }
+                surprisePill(
+                    label: loc.localized("search.surprise.series"),
+                    icon: "tv.fill",
+                    isLoading: isPickingSurpriseSeries
+                ) {
+                    await performSurprise(type: .series)
+                }
+            }
+        }
+        .padding(.top, CinemaSpacing.spacing4)
+    }
+
+    @ViewBuilder
+    private func surprisePill(label: String, icon: String, isLoading: Bool, action: @escaping () async -> Void) -> some View {
+        Button {
+            Task { await action() }
+        } label: {
+            HStack(spacing: CinemaSpacing.spacing2) {
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Image(systemName: icon)
+                        .font(.system(size: surpriseIconSize, weight: .semibold))
+                }
+                Text(label)
+                    .font(.system(size: surpriseLabelSize, weight: .semibold))
+            }
+            .foregroundStyle(themeManager.onAccent)
+            .padding(.horizontal, CinemaSpacing.spacing4)
+            .padding(.vertical, CinemaSpacing.spacing3)
+            .background(themeManager.accentContainer)
+            .clipShape(Capsule())
+        }
+        #if os(tvOS)
+        .buttonStyle(CinemaTVButtonStyle(cinemaStyle: .accent))
+        #else
+        .buttonStyle(.plain)
+        #endif
+        .disabled(isLoading)
+        .accessibilityLabel(label)
+    }
+
+    private func performSurprise(type: BaseItemKind) async {
+        if type == .movie { isPickingSurpriseMovie = true }
+        else { isPickingSurpriseSeries = true }
+        defer {
+            if type == .movie { isPickingSurpriseMovie = false }
+            else { isPickingSurpriseSeries = false }
+        }
+
+        let item: BaseItemDto?
+        switch type {
+        case .movie:  item = await viewModel.fetchRandomMovie(using: appState)
+        case .series: item = await viewModel.fetchRandomSeries(using: appState)
+        default:      item = nil
+        }
+
+        guard let item, let id = item.id else {
+            toasts.error(
+                loc.localized("toast.surprise.failed"),
+                message: loc.localized("toast.surprise.emptyLibrary")
+            )
+            return
+        }
+        surpriseDestination = SurpriseDestination(id: id, itemType: item.type ?? type)
+    }
+
+    private var surpriseIconSize: CGFloat {
+        #if os(tvOS)
+        24
+        #else
+        16
+        #endif
+    }
+
+    private var surpriseLabelSize: CGFloat {
+        #if os(tvOS)
+        22
+        #else
+        15
+        #endif
     }
 
     private var resultsGrid: some View {

--- a/Shared/Screens/SettingsAppearanceView+iOS.swift
+++ b/Shared/Screens/SettingsAppearanceView+iOS.swift
@@ -1,0 +1,141 @@
+#if os(iOS)
+import SwiftUI
+import CinemaxKit
+
+// MARK: - Appearance Detail View (iOS)
+
+/// Standalone View struct so NavigationStack destination has its own `@Observable`
+/// observation tracking for `ThemeManager` and `LocalizationManager`.
+///
+/// Extracted from `SettingsScreen+iOS.swift` to keep that file focused on layout
+/// scaffolding. All rows here are Appearance-only (dark mode, accent, language).
+struct IOSAppearanceDetailView: View {
+    @Environment(ThemeManager.self) var themeManager
+    @Environment(LocalizationManager.self) var loc
+    @Environment(\.motionEffectsEnabled) private var motionEffects
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: CinemaSpacing.spacing2) {
+            iOSSettingsSectionHeader(loc.localized("settings.personalization"))
+
+            VStack(spacing: 0) {
+                iOSSettingsRow {
+                    HStack {
+                        iOSRowIcon(systemName: themeManager.darkModeEnabled ? "moon.fill" : "sun.max.fill", color: themeManager.accent)
+
+                        Text(themeManager.darkModeEnabled ? loc.localized("settings.darkMode") : loc.localized("settings.lightMode"))
+                            .font(CinemaFont.label(.large))
+                            .foregroundStyle(CinemaColor.onSurface)
+
+                        Spacer()
+
+                        Button { themeManager.darkModeEnabled.toggle() } label: {
+                            CinemaToggleIndicator(isOn: themeManager.darkModeEnabled, accent: themeManager.accent, animated: motionEffects)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+
+                iOSSettingsDivider
+
+                iOSSettingsRow {
+                    VStack(alignment: .leading, spacing: CinemaSpacing.spacing2) {
+                        HStack {
+                            iOSRowIcon(systemName: "paintpalette.fill", color: selectedAccent.color)
+
+                            Text(loc.localized("settings.accentColor"))
+                                .font(CinemaFont.label(.large))
+                                .foregroundStyle(CinemaColor.onSurface)
+
+                            Spacer()
+                        }
+
+                        HStack(spacing: CinemaSpacing.spacing2) {
+                            ForEach(AccentOption.allCases) { option in
+                                accentDot(option)
+                            }
+                        }
+                    }
+                    .hoverEffectDisabled()
+                }
+
+                iOSSettingsDivider
+
+                iOSSettingsRow {
+                    HStack {
+                        iOSRowIcon(systemName: "globe", color: themeManager.accent)
+
+                        Text(loc.localized("settings.language"))
+                            .font(CinemaFont.label(.large))
+                            .foregroundStyle(CinemaColor.onSurface)
+
+                        Spacer()
+
+                        languagePicker
+                    }
+                }
+            }
+            .glassPanel(cornerRadius: CinemaRadius.extraLarge)
+        }
+    }
+
+    // MARK: - Appearance-specific helpers
+
+    var selectedAccent: AccentOption {
+        AccentOption(rawValue: themeManager.accentColorKey) ?? .blue
+    }
+
+    var languagePicker: some View {
+        HStack(spacing: CinemaSpacing.spacing2) {
+            languageButton("fr", label: "FR")
+            languageButton("en", label: "EN")
+        }
+    }
+
+    func languageButton(_ code: String, label: String) -> some View {
+        let isSelected = loc.languageCode == code
+        return Button {
+            loc.languageCode = code
+        } label: {
+            Text(label)
+                .font(.system(size: CinemaScale.pt(17), weight: .bold))
+                .foregroundStyle(isSelected ? themeManager.onAccent : CinemaColor.onSurfaceVariant)
+                .frame(width: 40, height: 30)
+                .background(
+                    RoundedRectangle(cornerRadius: CinemaRadius.medium)
+                        .fill(isSelected ? themeManager.accent : CinemaColor.surfaceContainerHigh)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    func accentDot(_ option: AccentOption) -> some View {
+        let isSelected = option.rawValue == themeManager.accentColorKey
+
+        Button {
+            themeManager.accentColorKey = option.rawValue
+        } label: {
+            ZStack {
+                Circle()
+                    .fill(option.color)
+                    .frame(width: 28, height: 28)
+
+                if isSelected {
+                    Circle()
+                        .strokeBorder(.white.opacity(0.9), lineWidth: 2)
+                        .frame(width: 28, height: 28)
+
+                    Image(systemName: "checkmark")
+                        .font(.system(size: CinemaScale.pt(13), weight: .bold))
+                        .foregroundStyle(.white)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .hoverEffectDisabled()
+        .scaleEffect(isSelected ? 1.1 : 1.0)
+        .animation(.spring(response: 0.25, dampingFraction: 0.7), value: isSelected)
+    }
+}
+#endif

--- a/Shared/Screens/SettingsRowHelpers.swift
+++ b/Shared/Screens/SettingsRowHelpers.swift
@@ -49,6 +49,12 @@ func iOSSettingsSectionHeader(_ title: String) -> some View {
 
 /// Toggle row matching the iOS settings pattern: icon + label + CinemaToggleIndicator.
 /// Equivalent to tvOS's `tvGlassToggle` — one call per boolean setting.
+///
+/// `@MainActor` is required because the helper touches `PrimitiveButtonStyle.plain`,
+/// which is main-actor isolated under Swift 6 strict concurrency. Without it the
+/// compiler raises "Main actor-isolated static property 'plain' can not be referenced
+/// from a nonisolated context".
+@MainActor
 @ViewBuilder
 func iOSToggleRow(
     icon: String,
@@ -61,7 +67,7 @@ func iOSToggleRow(
         HStack {
             iOSRowIcon(systemName: icon, color: accent)
             Text(label)
-                .font(CinemaFont.label(.large))
+                .font(CinemaFont.dynamicLabel(.large))
                 .foregroundStyle(CinemaColor.onSurface)
             Spacer()
             Button { value.wrappedValue.toggle() } label: {

--- a/Shared/Screens/SettingsScreen+iOS.swift
+++ b/Shared/Screens/SettingsScreen+iOS.swift
@@ -192,6 +192,12 @@ extension SettingsScreen {
 
                     iOSSettingsDivider
 
+                    navigationRow(icon: "person.2.circle", label: loc.localized("settings.switchAccount")) {
+                        showUserSwitch = true
+                    }
+
+                    iOSSettingsDivider
+
                     iOSSettingsRow {
                         Button {
                             showLogOutAlert = true
@@ -258,6 +264,29 @@ extension SettingsScreen {
                 .glassPanel(cornerRadius: CinemaRadius.extraLarge)
             }
 
+            // Refresh Catalogue
+            VStack(spacing: 0) {
+                iOSSettingsRow {
+                    Button { refreshCatalogue() } label: {
+                        HStack(alignment: .center, spacing: CinemaSpacing.spacing3) {
+                            iOSRowIcon(systemName: "arrow.triangle.2.circlepath", color: themeManager.accent)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(loc.localized("settings.refreshCatalogue"))
+                                    .font(CinemaFont.label(.large))
+                                    .foregroundStyle(CinemaColor.onSurface)
+                                Text(loc.localized("settings.refreshCatalogue.subtitle"))
+                                    .font(CinemaFont.label(.medium))
+                                    .foregroundStyle(CinemaColor.onSurfaceVariant)
+                                    .multilineTextAlignment(.leading)
+                            }
+                            Spacer()
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .glassPanel(cornerRadius: CinemaRadius.extraLarge)
+
             // Licenses
             VStack(spacing: 0) {
                 iOSSettingsRow {
@@ -283,51 +312,101 @@ extension SettingsScreen {
     // MARK: Interface Detail (iOS)
 
     var iOSInterfaceDetail: some View {
-        VStack(alignment: .leading, spacing: CinemaSpacing.spacing2) {
-            iOSSettingsSectionHeader(loc.localized("settings.interface"))
+        VStack(alignment: .leading, spacing: CinemaSpacing.spacing5) {
+            VStack(alignment: .leading, spacing: CinemaSpacing.spacing2) {
+                iOSSettingsSectionHeader(loc.localized("settings.interface"))
 
-            VStack(spacing: 0) {
-                iOSToggleRow(icon: "sparkles", label: loc.localized("settings.motionEffects"),
-                             value: $motionEffects, accent: themeManager.accent, animated: motionEffects)
-                iOSSettingsDivider
-                iOSToggleRow(icon: "captions.bubble", label: loc.localized("settings.forceSubtitles"),
-                             value: $forceSubtitles, accent: themeManager.accent, animated: motionEffects)
-                iOSSettingsDivider
-                iOSToggleRow(icon: "4k.tv", label: loc.localized("settings.4kRendering"),
-                             value: $render4K, accent: themeManager.accent, animated: motionEffects)
-                iOSSettingsDivider
-                iOSToggleRow(icon: "play.square.stack", label: loc.localized("settings.autoPlayNextEpisode"),
-                             value: $autoPlayNextEpisode, accent: themeManager.accent, animated: motionEffects)
-                iOSSettingsDivider
+                VStack(spacing: 0) {
+                    iOSToggleRow(icon: "sparkles", label: loc.localized("settings.motionEffects"),
+                                 value: $motionEffects, accent: themeManager.accent, animated: motionEffects)
+                    iOSSettingsDivider
+                    iOSToggleRow(icon: "captions.bubble", label: loc.localized("settings.forceSubtitles"),
+                                 value: $forceSubtitles, accent: themeManager.accent, animated: motionEffects)
+                    iOSSettingsDivider
+                    iOSToggleRow(icon: "4k.tv", label: loc.localized("settings.4kRendering"),
+                                 value: $render4K, accent: themeManager.accent, animated: motionEffects)
+                    iOSSettingsDivider
+                    iOSToggleRow(icon: "play.square.stack", label: loc.localized("settings.autoPlayNextEpisode"),
+                                 value: $autoPlayNextEpisode, accent: themeManager.accent, animated: motionEffects)
+                    iOSSettingsDivider
 
-                iOSSettingsRow {
-                    HStack {
-                        iOSRowIcon(systemName: "textformat.size", color: themeManager.accent)
-                        Text(loc.localized("settings.fontSize"))
-                            .font(CinemaFont.label(.large))
-                            .foregroundStyle(CinemaColor.onSurface)
-                        Spacer()
-                        Stepper(
-                            "\(Int(fontScale * 100))%",
-                            onIncrement: {
-                                if let idx = fontScaleOptions.firstIndex(of: fontScale), idx < fontScaleOptions.count - 1 {
-                                    fontScale = fontScaleOptions[idx + 1]
-                                    themeManager.uiScale = fontScale
+                    iOSSleepTimerRow
+                    iOSSettingsDivider
+
+                    iOSSettingsRow {
+                        HStack {
+                            iOSRowIcon(systemName: "textformat.size", color: themeManager.accent)
+                            Text(loc.localized("settings.fontSize"))
+                                .font(CinemaFont.label(.large))
+                                .foregroundStyle(CinemaColor.onSurface)
+                            Spacer()
+                            Stepper(
+                                "\(Int(fontScale * 100))%",
+                                onIncrement: {
+                                    if let idx = fontScaleOptions.firstIndex(of: fontScale), idx < fontScaleOptions.count - 1 {
+                                        fontScale = fontScaleOptions[idx + 1]
+                                        themeManager.uiScale = fontScale
+                                    }
+                                },
+                                onDecrement: {
+                                    if let idx = fontScaleOptions.firstIndex(of: fontScale), idx > 0 {
+                                        fontScale = fontScaleOptions[idx - 1]
+                                        themeManager.uiScale = fontScale
+                                    }
                                 }
-                            },
-                            onDecrement: {
-                                if let idx = fontScaleOptions.firstIndex(of: fontScale), idx > 0 {
-                                    fontScale = fontScaleOptions[idx - 1]
-                                    themeManager.uiScale = fontScale
-                                }
-                            }
-                        )
-                        .fixedSize()
-                        .tint(themeManager.accent)
+                            )
+                            .fixedSize()
+                            .tint(themeManager.accent)
+                        }
                     }
                 }
+                .glassPanel(cornerRadius: CinemaRadius.extraLarge)
             }
-            .glassPanel(cornerRadius: CinemaRadius.extraLarge)
+
+            // Home Page section
+            VStack(alignment: .leading, spacing: CinemaSpacing.spacing2) {
+                iOSSettingsSectionHeader(loc.localized("settings.homePage"))
+
+                VStack(spacing: 0) {
+                    iOSToggleRow(icon: "play.circle", label: loc.localized("settings.homePage.continueWatching"),
+                                 value: $showContinueWatching, accent: themeManager.accent, animated: motionEffects)
+                    iOSSettingsDivider
+                    iOSToggleRow(icon: "sparkles.rectangle.stack", label: loc.localized("settings.homePage.recentlyAdded"),
+                                 value: $showRecentlyAdded, accent: themeManager.accent, animated: motionEffects)
+                    iOSSettingsDivider
+                    iOSToggleRow(icon: "square.grid.2x2", label: loc.localized("settings.homePage.genreRows"),
+                                 value: $showGenreRows, accent: themeManager.accent, animated: motionEffects)
+                    iOSSettingsDivider
+                    iOSToggleRow(icon: "person.2.wave.2", label: loc.localized("settings.homePage.watchingNow"),
+                                 value: $showWatchingNow, accent: themeManager.accent, animated: motionEffects)
+                }
+                .glassPanel(cornerRadius: CinemaRadius.extraLarge)
+            }
+
+            // Detail Page section
+            VStack(alignment: .leading, spacing: CinemaSpacing.spacing2) {
+                iOSSettingsSectionHeader(loc.localized("settings.detailPage"))
+
+                VStack(spacing: 0) {
+                    iOSToggleRow(icon: "info.square", label: loc.localized("settings.detailPage.qualityBadges"),
+                                 value: $showQualityBadges, accent: themeManager.accent, animated: motionEffects)
+                }
+                .glassPanel(cornerRadius: CinemaRadius.extraLarge)
+            }
+
+            // Debug section
+            VStack(alignment: .leading, spacing: CinemaSpacing.spacing2) {
+                iOSSettingsSectionHeader(loc.localized("settings.debug"))
+
+                VStack(spacing: 0) {
+                    iOSToggleRow(icon: "moon.zzz.fill", label: loc.localized("settings.debug.fastSleepTimer"),
+                                 value: $debugFastSleepTimer, accent: .orange, animated: motionEffects)
+                    iOSSettingsDivider
+                    iOSToggleRow(icon: "forward.end.fill", label: loc.localized("settings.debug.skipToEnd"),
+                                 value: $debugShowSkipToEnd, accent: .orange, animated: motionEffects)
+                }
+                .glassPanel(cornerRadius: CinemaRadius.extraLarge)
+            }
         }
     }
 
@@ -404,140 +483,46 @@ extension SettingsScreen {
             .buttonStyle(.plain)
         }
     }
-}
+    // MARK: - Sleep Timer Row (iOS)
 
-// MARK: - Appearance Detail View (iOS)
-// Standalone View struct so NavigationStack destination has its own
-// @Observable observation tracking for ThemeManager and LocalizationManager.
-
-private struct IOSAppearanceDetailView: View {
-    @Environment(ThemeManager.self) var themeManager
-    @Environment(LocalizationManager.self) var loc
-    @Environment(\.motionEffectsEnabled) private var motionEffects
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: CinemaSpacing.spacing2) {
-            iOSSettingsSectionHeader(loc.localized("settings.personalization"))
-
-            VStack(spacing: 0) {
-                iOSSettingsRow {
-                    HStack {
-                        iOSRowIcon(systemName: themeManager.darkModeEnabled ? "moon.fill" : "sun.max.fill", color: themeManager.accent)
-
-                        Text(themeManager.darkModeEnabled ? loc.localized("settings.darkMode") : loc.localized("settings.lightMode"))
-                            .font(CinemaFont.label(.large))
-                            .foregroundStyle(CinemaColor.onSurface)
-
-                        Spacer()
-
-                        Button { themeManager.darkModeEnabled.toggle() } label: {
-                            CinemaToggleIndicator(isOn: themeManager.darkModeEnabled, accent: themeManager.accent, animated: motionEffects)
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-
-                iOSSettingsDivider
-
-                iOSSettingsRow {
-                    VStack(alignment: .leading, spacing: CinemaSpacing.spacing2) {
-                        HStack {
-                            iOSRowIcon(systemName: "paintpalette.fill", color: selectedAccent.color)
-
-                            Text(loc.localized("settings.accentColor"))
-                                .font(CinemaFont.label(.large))
-                                .foregroundStyle(CinemaColor.onSurface)
-
-                            Spacer()
-                        }
-
-                        HStack(spacing: CinemaSpacing.spacing2) {
-                            ForEach(AccentOption.allCases) { option in
-                                accentDot(option)
+    /// Menu-based picker for the default sleep timer duration. Label matches the selected
+    /// option's localized name ("Off", "30 minutes", etc.).
+    @ViewBuilder
+    var iOSSleepTimerRow: some View {
+        iOSSettingsRow {
+            HStack {
+                iOSRowIcon(systemName: "moon.zzz", color: themeManager.accent)
+                Text(loc.localized("settings.sleepTimer"))
+                    .font(CinemaFont.label(.large))
+                    .foregroundStyle(CinemaColor.onSurface)
+                Spacer()
+                Menu {
+                    ForEach(SleepTimerOption.allCases) { option in
+                        Button {
+                            sleepTimerMinutes = option.rawValue
+                        } label: {
+                            if sleepTimerMinutes == option.rawValue {
+                                Label(loc.localized(option.localizationKey), systemImage: "checkmark")
+                            } else {
+                                Text(loc.localized(option.localizationKey))
                             }
                         }
                     }
-                    .hoverEffectDisabled()
-                }
-
-                iOSSettingsDivider
-
-                iOSSettingsRow {
-                    HStack {
-                        iOSRowIcon(systemName: "globe", color: themeManager.accent)
-
-                        Text(loc.localized("settings.language"))
+                } label: {
+                    let selected = SleepTimerOption(rawValue: sleepTimerMinutes) ?? .disabled
+                    HStack(spacing: 4) {
+                        Text(loc.localized(selected.localizationKey))
                             .font(CinemaFont.label(.large))
-                            .foregroundStyle(CinemaColor.onSurface)
-
-                        Spacer()
-
-                        languagePicker
+                            .foregroundStyle(CinemaColor.onSurfaceVariant)
+                        Image(systemName: "chevron.up.chevron.down")
+                            .font(.system(size: CinemaScale.pt(11), weight: .semibold))
+                            .foregroundStyle(CinemaColor.outlineVariant)
                     }
                 }
-            }
-            .glassPanel(cornerRadius: CinemaRadius.extraLarge)
-        }
-    }
-
-    // MARK: - Appearance-specific helpers
-
-    var selectedAccent: AccentOption {
-        AccentOption(rawValue: themeManager.accentColorKey) ?? .blue
-    }
-
-    var languagePicker: some View {
-        HStack(spacing: CinemaSpacing.spacing2) {
-            languageButton("fr", label: "FR")
-            languageButton("en", label: "EN")
-        }
-    }
-
-    func languageButton(_ code: String, label: String) -> some View {
-        let isSelected = loc.languageCode == code
-        return Button {
-            loc.languageCode = code
-        } label: {
-            Text(label)
-                .font(.system(size: CinemaScale.pt(17), weight: .bold))
-                .foregroundStyle(isSelected ? themeManager.onAccent : CinemaColor.onSurfaceVariant)
-                .frame(width: 40, height: 30)
-                .background(
-                    RoundedRectangle(cornerRadius: CinemaRadius.medium)
-                        .fill(isSelected ? themeManager.accent : CinemaColor.surfaceContainerHigh)
-                )
-        }
-        .buttonStyle(.plain)
-    }
-
-    @ViewBuilder
-    func accentDot(_ option: AccentOption) -> some View {
-        let isSelected = option.rawValue == themeManager.accentColorKey
-
-        Button {
-            themeManager.accentColorKey = option.rawValue
-        } label: {
-            ZStack {
-                Circle()
-                    .fill(option.color)
-                    .frame(width: 28, height: 28)
-
-                if isSelected {
-                    Circle()
-                        .strokeBorder(.white.opacity(0.9), lineWidth: 2)
-                        .frame(width: 28, height: 28)
-
-                    Image(systemName: "checkmark")
-                        .font(.system(size: CinemaScale.pt(13), weight: .bold))
-                        .foregroundStyle(.white)
-                }
+                .tint(themeManager.accent)
             }
         }
-        .buttonStyle(.plain)
-        .hoverEffectDisabled()
-        .scaleEffect(isSelected ? 1.1 : 1.0)
-        .animation(.spring(response: 0.25, dampingFraction: 0.7), value: isSelected)
     }
-
 }
+
 #endif

--- a/Shared/Screens/SettingsScreen+tvOS.swift
+++ b/Shared/Screens/SettingsScreen+tvOS.swift
@@ -8,15 +8,38 @@ import CinemaxKit
 extension SettingsScreen {
 
     var tvOSLayout: some View {
-        Group {
-            if let category = selectedCategory {
-                tvDetailView(for: category)
-                    .onExitCommand { selectedCategory = nil }
-            } else {
-                tvLandingPage
+        // Wrap in a ScrollView + ScrollViewReader so we can force the page to
+        // scroll back to its top whenever the user pops back from a category
+        // detail. Without this, tvOS keeps the page scrolled (or focus stranded)
+        // and the system top tab bar can stay hidden behind page content.
+        ScrollViewReader { proxy in
+            ScrollView {
+                Color.clear.frame(height: 0).id("settings.top")
+
+                Group {
+                    if let category = selectedCategory {
+                        tvDetailView(for: category)
+                            .onExitCommand { selectedCategory = nil }
+                    } else {
+                        tvLandingPage
+                    }
+                }
+                // Hold full height so the visual layout is unchanged from the
+                // pre-ScrollView version (brand panel + categories centered).
+                .frame(maxWidth: .infinity, minHeight: tvLandingMinHeight, maxHeight: .infinity)
+            }
+            .scrollClipDisabled()
+            .onChange(of: selectedCategory) { _, newValue in
+                // When a category is closed (newValue == nil), bring the page
+                // back to the top so the tab bar resurfaces naturally.
+                if newValue == nil {
+                    proxy.scrollTo("settings.top", anchor: .top)
+                }
+            }
+            .onAppear {
+                proxy.scrollTo("settings.top", anchor: .top)
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background {
             // Centered accent bloom — persists across all settings pages
             Circle()
@@ -26,8 +49,8 @@ extension SettingsScreen {
         }
         .task { await loadServerUsers() }
         .alert(loc.localized("settings.switchAccount"), isPresented: $showSwitchAccountAlert) {
-            Button(loc.localized("settings.switchAccount"), role: .destructive) {
-                appState.logout()
+            Button(loc.localized("settings.switchAccount")) {
+                showUserSwitch = true
             }
             Button(loc.localized("action.cancel"), role: .cancel) {}
         } message: {
@@ -293,6 +316,7 @@ extension SettingsScreen {
                 }
 
                 tvRefreshConnectionButton
+                tvRefreshCatalogueButton
             }
             .padding(CinemaSpacing.spacing4)
             .background(
@@ -306,6 +330,40 @@ extension SettingsScreen {
 
             tvLicensesButton
         }
+    }
+
+    // MARK: - Refresh Catalogue (tvOS)
+
+    var tvRefreshCatalogueButton: some View {
+        let isFocused = focusedItem == .toggle("refreshCatalogue")
+        return Button {
+            refreshCatalogue()
+        } label: {
+            HStack(spacing: CinemaSpacing.spacing3) {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .font(.system(size: CinemaScale.pt(20), weight: .medium))
+                    .foregroundStyle(themeManager.accent)
+                    .frame(width: 24)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(loc.localized("settings.refreshCatalogue"))
+                        .font(.system(size: CinemaScale.pt(20), weight: .medium))
+                        .foregroundStyle(CinemaColor.onSurface)
+                    Text(loc.localized("settings.refreshCatalogue.subtitle"))
+                        .font(.system(size: CinemaScale.pt(16), weight: .regular))
+                        .foregroundStyle(CinemaColor.onSurfaceVariant)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, CinemaSpacing.spacing4)
+            .frame(maxWidth: .infinity, minHeight: 80)
+            .tvSettingsFocusable(isFocused: isFocused, accent: themeManager.accent, colorScheme: themeManager.darkModeEnabled ? .dark : .light)
+        }
+        .buttonStyle(.plain)
+        .focusEffectDisabled()
+        .hoverEffectDisabled()
+        .focused($focusedItem, equals: .toggle("refreshCatalogue"))
     }
 
     var tvLicensesButton: some View {
@@ -343,13 +401,41 @@ extension SettingsScreen {
     // MARK: Interface Detail (tvOS)
 
     var tvInterfaceDetail: some View {
-        VStack(alignment: .leading, spacing: CinemaSpacing.spacing3) {
-            tvGlassToggle(icon: "sparkles", label: loc.localized("settings.motionEffects"), key: "motion", value: $motionEffects)
-            tvGlassToggle(icon: "captions.bubble", label: loc.localized("settings.forceSubtitles"), key: "subtitles", value: $forceSubtitles)
-            tvGlassToggle(icon: "4k.tv", label: loc.localized("settings.4kRendering"), key: "4k", value: $render4K)
-            tvGlassToggle(icon: "play.square.stack", label: loc.localized("settings.autoPlayNextEpisode"), key: "autoPlayNext", value: $autoPlayNextEpisode)
+        VStack(alignment: .leading, spacing: CinemaSpacing.spacing5) {
+            VStack(alignment: .leading, spacing: CinemaSpacing.spacing3) {
+                tvGlassToggle(icon: "sparkles", label: loc.localized("settings.motionEffects"), key: "motion", value: $motionEffects)
+                tvGlassToggle(icon: "captions.bubble", label: loc.localized("settings.forceSubtitles"), key: "subtitles", value: $forceSubtitles)
+                tvGlassToggle(icon: "4k.tv", label: loc.localized("settings.4kRendering"), key: "4k", value: $render4K)
+                tvGlassToggle(icon: "play.square.stack", label: loc.localized("settings.autoPlayNextEpisode"), key: "autoPlayNext", value: $autoPlayNextEpisode)
 
-            tvFontSizeRow
+                tvSleepTimerRow
+                tvFontSizeRow
+            }
+
+            // Home Page section
+            VStack(alignment: .leading, spacing: CinemaSpacing.spacing3) {
+                tvSectionLabel(loc.localized("settings.homePage"))
+
+                tvGlassToggle(icon: "play.circle", label: loc.localized("settings.homePage.continueWatching"), key: "homeContinueWatching", value: $showContinueWatching)
+                tvGlassToggle(icon: "sparkles.rectangle.stack", label: loc.localized("settings.homePage.recentlyAdded"), key: "homeRecentlyAdded", value: $showRecentlyAdded)
+                tvGlassToggle(icon: "square.grid.2x2", label: loc.localized("settings.homePage.genreRows"), key: "homeGenreRows", value: $showGenreRows)
+                tvGlassToggle(icon: "person.2.wave.2", label: loc.localized("settings.homePage.watchingNow"), key: "homeWatchingNow", value: $showWatchingNow)
+            }
+
+            // Detail Page section
+            VStack(alignment: .leading, spacing: CinemaSpacing.spacing3) {
+                tvSectionLabel(loc.localized("settings.detailPage"))
+
+                tvGlassToggle(icon: "info.square", label: loc.localized("settings.detailPage.qualityBadges"), key: "detailQualityBadges", value: $showQualityBadges)
+            }
+
+            // Debug section
+            VStack(alignment: .leading, spacing: CinemaSpacing.spacing3) {
+                tvSectionLabel(loc.localized("settings.debug"))
+
+                tvGlassToggle(icon: "moon.zzz.fill", label: loc.localized("settings.debug.fastSleepTimer"), key: "debugFastSleep", value: $debugFastSleepTimer)
+                tvGlassToggle(icon: "forward.end.fill", label: loc.localized("settings.debug.skipToEnd"), key: "debugSkipToEnd", value: $debugShowSkipToEnd)
+            }
         }
     }
 
@@ -704,6 +790,52 @@ extension SettingsScreen {
                 Button("\(Int(option * 100))%") {
                     fontScale = option
                     themeManager.uiScale = option
+                }
+            }
+        }
+    }
+
+    /// Minimum height for the Settings landing page so the brand+categories layout
+    /// keeps its visual proportions inside the new ScrollView wrapper. tvOS screens
+    /// are ≥ 720pt tall, so this safely fills the viewport without forcing scroll.
+    var tvLandingMinHeight: CGFloat { 720 }
+
+    // MARK: - Sleep Timer Row (tvOS)
+
+    var tvSleepTimerRow: some View {
+        let isFocused = focusedItem == .toggle("sleepTimer")
+        let selected = SleepTimerOption(rawValue: sleepTimerMinutes) ?? .disabled
+        return Button {
+            showSleepTimerPicker = true
+        } label: {
+            HStack(spacing: CinemaSpacing.spacing3) {
+                Image(systemName: "moon.zzz")
+                    .font(.system(size: CinemaScale.pt(20), weight: .medium))
+                    .foregroundStyle(themeManager.accent)
+                    .frame(width: 24)
+                Text(loc.localized("settings.sleepTimer"))
+                    .font(.system(size: CinemaScale.pt(20), weight: .medium))
+                    .foregroundStyle(CinemaColor.onSurface)
+                Spacer()
+                Text(loc.localized(selected.localizationKey))
+                    .font(.system(size: CinemaScale.pt(17), weight: .semibold))
+                    .foregroundStyle(CinemaColor.onSurfaceVariant)
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: CinemaScale.pt(14), weight: .medium))
+                    .foregroundStyle(CinemaColor.onSurfaceVariant)
+            }
+            .padding(.horizontal, CinemaSpacing.spacing4)
+            .frame(maxWidth: .infinity, minHeight: 80)
+            .tvSettingsFocusable(isFocused: isFocused, accent: themeManager.accent, animated: motionEffects, colorScheme: themeManager.darkModeEnabled ? .dark : .light)
+        }
+        .buttonStyle(.plain)
+        .focusEffectDisabled()
+        .hoverEffectDisabled()
+        .focused($focusedItem, equals: .toggle("sleepTimer"))
+        .confirmationDialog(loc.localized("settings.sleepTimer"), isPresented: $showSleepTimerPicker) {
+            ForEach(SleepTimerOption.allCases) { option in
+                Button(loc.localized(option.localizationKey)) {
+                    sleepTimerMinutes = option.rawValue
                 }
             }
         }

--- a/Shared/Screens/SettingsScreen.swift
+++ b/Shared/Screens/SettingsScreen.swift
@@ -113,8 +113,10 @@ struct SettingsScreen: View {
     @Environment(AppState.self) var appState
     @Environment(ThemeManager.self) var themeManager
     @Environment(LocalizationManager.self) var loc
+    @Environment(ToastCenter.self) var toasts
     @State var showLogOutAlert = false
     @State var showLicenses = false
+    @State var showUserSwitch = false
     @State var selectedCategory: SettingsCategory? = nil
 
     // Shared stored properties
@@ -123,6 +125,14 @@ struct SettingsScreen: View {
     @AppStorage("render4K") var render4K: Bool = true
     @AppStorage("autoPlayNextEpisode") var autoPlayNextEpisode: Bool = true
     @AppStorage("darkMode") var darkModeStorage: Bool = true
+    @AppStorage("home.showContinueWatching") var showContinueWatching: Bool = true
+    @AppStorage("home.showRecentlyAdded") var showRecentlyAdded: Bool = true
+    @AppStorage("home.showGenreRows") var showGenreRows: Bool = true
+    @AppStorage("home.showWatchingNow") var showWatchingNow: Bool = true
+    @AppStorage("detail.showQualityBadges") var showQualityBadges: Bool = true
+    @AppStorage("sleepTimerDefaultMinutes") var sleepTimerMinutes: Int = 0
+    @AppStorage("debug.fastSleepTimer") var debugFastSleepTimer: Bool = false
+    @AppStorage("debug.showSkipToEnd") var debugShowSkipToEnd: Bool = false
     @State var fontScale: Double = UserDefaults.standard.object(forKey: "uiScale") as? Double ?? 1.0
     @State var showFontSizePicker = false
     let fontScaleOptions: [Double] = [0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30]
@@ -132,6 +142,7 @@ struct SettingsScreen: View {
     @FocusState var focusedItem: SettingsFocus?
     @State var serverUsers: [UserDto] = []
     @State var showSwitchAccountAlert = false
+    @State var showSleepTimerPicker = false
     #endif
 
     // MARK: Shared Computed Properties
@@ -173,6 +184,14 @@ struct SettingsScreen: View {
 
     // MARK: Body
 
+    /// Clears the API client cache and broadcasts `cinemaxShouldRefreshCatalogue` so Home
+    /// and Library reload from the server on their next render. Shown as a toast for feedback.
+    func refreshCatalogue() {
+        appState.apiClient.clearCache()
+        NotificationCenter.default.post(name: .cinemaxShouldRefreshCatalogue, object: nil)
+        toasts.success(loc.localized("toast.catalogueRefreshed"))
+    }
+
     var body: some View {
         ZStack {
             CinemaColor.surface.ignoresSafeArea()
@@ -189,6 +208,12 @@ struct SettingsScreen: View {
         #endif
         .sheet(isPresented: $showLicenses) {
             LicensesView()
+        }
+        .sheet(isPresented: $showUserSwitch) {
+            UserSwitchSheet()
+                .environment(appState)
+                .environment(themeManager)
+                .environment(loc)
         }
         .alert(loc.localized("action.logOut"), isPresented: $showLogOutAlert) {
             Button(loc.localized("action.logOut"), role: .destructive) {

--- a/Shared/Screens/UserSwitchSheet.swift
+++ b/Shared/Screens/UserSwitchSheet.swift
@@ -1,0 +1,249 @@
+import SwiftUI
+import CinemaxKit
+@preconcurrency import JellyfinAPI
+
+/// Two-step user switcher presented from Settings → Account. Avoids the full
+/// server-setup + login flow when families share a single device (common on tvOS).
+///
+/// Step 1 — grid of server users with their primary images
+/// Step 2 — password prompt for the picked user
+///
+/// On success, updates `AppState` (access token + userId) without clearing the server URL,
+/// and emits a success toast before dismissing. Errors show inline; the sheet stays open
+/// so users can retry without losing their place.
+struct UserSwitchSheet: View {
+    @Environment(AppState.self) private var appState
+    @Environment(ThemeManager.self) private var themeManager
+    @Environment(LocalizationManager.self) private var loc
+    @Environment(ToastCenter.self) private var toasts
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var users: [UserDto] = []
+    @State private var isLoading = true
+    @State private var selectedUser: UserDto?
+    @State private var password: String = ""
+    @State private var isAuthenticating = false
+    @State private var authError: String?
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                CinemaColor.surface.ignoresSafeArea()
+
+                if let user = selectedUser {
+                    passwordStep(for: user)
+                } else if isLoading {
+                    LoadingStateView()
+                } else if users.isEmpty {
+                    EmptyStateView(
+                        systemImage: "person.slash",
+                        title: loc.localized("switchAccount.pickUser")
+                    )
+                } else {
+                    userGrid
+                }
+            }
+            .navigationTitle(loc.localized("settings.switchAccount"))
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(loc.localized("action.cancel")) { dismiss() }
+                        .foregroundStyle(CinemaColor.onSurfaceVariant)
+                }
+            }
+        }
+        .task {
+            await loadUsers()
+        }
+    }
+
+    // MARK: - Step 1: Pick a user
+
+    private var userGrid: some View {
+        ScrollView {
+            LazyVGrid(columns: gridColumns, spacing: CinemaSpacing.spacing4) {
+                ForEach(users, id: \.id) { user in
+                    userTile(user)
+                }
+            }
+            .padding(CinemaSpacing.spacing4)
+        }
+    }
+
+    @ViewBuilder
+    private func userTile(_ user: UserDto) -> some View {
+        Button {
+            selectedUser = user
+            authError = nil
+            password = ""
+        } label: {
+            VStack(spacing: CinemaSpacing.spacing2) {
+                avatar(for: user)
+                Text(user.name ?? "")
+                    .font(CinemaFont.label(.large))
+                    .foregroundStyle(CinemaColor.onSurface)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, CinemaSpacing.spacing3)
+            .background(CinemaColor.surfaceContainerHigh)
+            .clipShape(RoundedRectangle(cornerRadius: CinemaRadius.large))
+        }
+        #if os(tvOS)
+        .buttonStyle(CinemaTVCardButtonStyle())
+        #else
+        .buttonStyle(.plain)
+        #endif
+        .accessibilityLabel(user.name ?? "")
+    }
+
+    @ViewBuilder
+    private func avatar(for user: UserDto) -> some View {
+        let size: CGFloat = avatarSize
+        let initial = String((user.name ?? "?").prefix(1)).uppercased()
+
+        if let id = user.id,
+           let tag = user.primaryImageTag {
+            CinemaLazyImage(
+                url: appState.imageBuilder.userImageURL(userId: id, tag: tag, maxWidth: 200),
+                fallbackIcon: nil
+            )
+            .frame(width: size, height: size)
+            .clipShape(Circle())
+        } else {
+            ZStack {
+                Circle()
+                    .fill(
+                        LinearGradient(
+                            colors: [themeManager.accentContainer, themeManager.accent.opacity(0.6)],
+                            startPoint: .topLeading, endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(width: size, height: size)
+                Text(initial)
+                    .font(.system(size: size * 0.4, weight: .bold))
+                    .foregroundStyle(.white)
+            }
+        }
+    }
+
+    // MARK: - Step 2: Password prompt
+
+    @ViewBuilder
+    private func passwordStep(for user: UserDto) -> some View {
+        VStack(spacing: CinemaSpacing.spacing5) {
+            Spacer()
+
+            avatar(for: user)
+
+            Text(String(format: loc.localized("switchAccount.enterPasswordFor"), user.name ?? ""))
+                .font(CinemaFont.headline(.small))
+                .foregroundStyle(CinemaColor.onSurface)
+                .multilineTextAlignment(.center)
+
+            SecureField(loc.localized("login.password"), text: $password)
+                .textContentType(.password)
+                #if os(iOS)
+                .submitLabel(.go)
+                #endif
+                .onSubmit { Task { await performAuth(user: user) } }
+                .padding(.horizontal, CinemaSpacing.spacing4)
+                .padding(.vertical, CinemaSpacing.spacing3)
+                .background(CinemaColor.surfaceContainerHigh)
+                .clipShape(RoundedRectangle(cornerRadius: CinemaRadius.large))
+                .padding(.horizontal, CinemaSpacing.spacing4)
+
+            if let authError {
+                Text(authError)
+                    .font(CinemaFont.label(.medium))
+                    .foregroundStyle(CinemaColor.error)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, CinemaSpacing.spacing4)
+            }
+
+            CinemaButton(
+                title: isAuthenticating ? "…" : loc.localized("switchAccount.signIn"),
+                style: .primary
+            ) {
+                Task { await performAuth(user: user) }
+            }
+            .disabled(isAuthenticating)
+            .padding(.horizontal, CinemaSpacing.spacing4)
+
+            Button {
+                selectedUser = nil
+                password = ""
+                authError = nil
+            } label: {
+                Text(loc.localized("action.cancel"))
+                    .font(CinemaFont.label(.large))
+                    .foregroundStyle(CinemaColor.onSurfaceVariant)
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+        }
+        .frame(maxWidth: 480)
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Actions
+
+    private func loadUsers() async {
+        isLoading = true
+        defer { isLoading = false }
+        // Prefer authenticated list when available (richer); fall back to public users.
+        if let fetched = try? await appState.apiClient.getUsers(), !fetched.isEmpty {
+            users = fetched
+            return
+        }
+        users = (try? await appState.apiClient.getPublicUsers()) ?? []
+    }
+
+    private func performAuth(user: UserDto) async {
+        guard let username = user.name else { return }
+        isAuthenticating = true
+        authError = nil
+        defer { isAuthenticating = false }
+        do {
+            let session = try await appState.apiClient.authenticate(
+                username: username, password: password
+            )
+            try appState.keychain.saveAccessToken(session.accessToken)
+            try appState.keychain.saveUserSession(session)
+            appState.accessToken = session.accessToken
+            appState.currentUserId = session.userID
+            appState.apiClient.reconnect(
+                url: appState.serverURL ?? URL(string: "http://localhost")!,
+                accessToken: session.accessToken
+            )
+            appState.isAuthenticated = true
+
+            toasts.success(String(format: loc.localized("switchAccount.success"), username))
+            password = ""
+            dismiss()
+        } catch {
+            authError = loc.localized("switchAccount.authFailed")
+        }
+    }
+
+    // MARK: - Sizing
+
+    private var gridColumns: [GridItem] {
+        #if os(tvOS)
+        Array(repeating: GridItem(.flexible(), spacing: CinemaSpacing.spacing4), count: 4)
+        #else
+        Array(repeating: GridItem(.flexible(), spacing: CinemaSpacing.spacing3), count: 3)
+        #endif
+    }
+
+    private var avatarSize: CGFloat {
+        #if os(tvOS)
+        140
+        #else
+        80
+        #endif
+    }
+}

--- a/Shared/Screens/VideoPlayerView.swift
+++ b/Shared/Screens/VideoPlayerView.swift
@@ -86,6 +86,7 @@ struct VideoPlayerView: View {
                 apiClient: appState.apiClient, userId: userId,
                 maxBitrate: bitrate, loc: loc,
                 autoPlayNextEpisode: autoPlayNextEpisode,
+                imageBuilder: appState.imageBuilder,
                 onDismiss: { dismiss() }
             )
             presenter = p

--- a/Shared/ViewModels/HomeViewModel.swift
+++ b/Shared/ViewModels/HomeViewModel.swift
@@ -8,10 +8,20 @@ final class HomeViewModel {
     var heroItem: BaseItemDto?
     var resumeItems: [BaseItemDto] = []
     var latestItems: [BaseItemDto] = []
+    /// Ordered list of genre rows (mixed movies + series). Empty genres are skipped.
+    var genreRows: [(genre: String, items: [BaseItemDto])] = []
     /// Episode navigation keyed by episode item ID. Populated after resumeItems loads.
     var resumeNavigation: [String: (previous: EpisodeRef?, next: EpisodeRef?, navigator: EpisodeNavigator?)] = [:]
+    /// Other users currently watching something on this server. Excludes the logged-in user.
+    var activeSessions: [SessionInfoDto] = []
     var isLoading = true
     var errorMessage: String?
+
+    /// Re-runs the full home load (equivalent to calling `load` again). Exposed for pull-to-refresh.
+    func reload(using appState: AppState) async {
+        activeSessions = []
+        await load(using: appState)
+    }
 
     func load(using appState: AppState) async {
         guard let userId = appState.currentUserId else { return }
@@ -64,6 +74,7 @@ final class HomeViewModel {
                 }
             }
 
+            resumeNavigation.removeAll()
             for item in episodeItems {
                 guard let id = item.id, let seasonId = item.seasonID else { continue }
                 guard let eps = seasonEpisodes[seasonId] else { continue }
@@ -73,8 +84,87 @@ final class HomeViewModel {
                 )
                 resumeNavigation[id] = nav
             }
+        } else {
+            resumeNavigation.removeAll()
         }
 
+        // Genre rows: pick up to 4 random genres from the server and fetch 10 random
+        // items per genre in parallel. Genres with no items are skipped.
+        await loadGenreRows(userId: userId, appState: appState)
+
+        // Active sessions ("Watching Now" row). Non-blocking — quietly drops on error.
+        await loadActiveSessions(userId: userId, appState: appState)
+
         isLoading = false
+    }
+
+    /// Fetches active sessions and filters down to ones with a currently-playing item,
+    /// excluding the logged-in user (their own "resume" already covers that).
+    private func loadActiveSessions(userId: String, appState: AppState) async {
+        do {
+            let all = try await appState.apiClient.getActiveSessions(activeWithinSeconds: 60)
+            activeSessions = all.filter { session in
+                session.nowPlayingItem != nil
+                    && (session.userID ?? "") != userId
+            }
+        } catch {
+            activeSessions = []
+        }
+    }
+
+    private func loadGenreRows(userId: String, appState: AppState) async {
+        let allGenres: [String]
+        do {
+            allGenres = try await appState.apiClient.getGenres(
+                userId: userId, includeItemTypes: [.movie, .series]
+            )
+        } catch {
+            genreRows = []
+            return
+        }
+
+        guard !allGenres.isEmpty else {
+            genreRows = []
+            return
+        }
+
+        let picked = Array(allGenres.shuffled().prefix(4))
+
+        // Fetch items for each picked genre in parallel. Preserve the order of `picked`.
+        var results: [String: [BaseItemDto]] = [:]
+        await withTaskGroup(of: (String, [BaseItemDto])?.self) { group in
+            for genre in picked {
+                group.addTask {
+                    do {
+                        let response = try await appState.apiClient.getItems(
+                            userId: userId,
+                            parentId: nil,
+                            includeItemTypes: [.movie, .series],
+                            sortBy: [.random],
+                            sortOrder: nil,
+                            genres: [genre],
+                            years: nil,
+                            isFavorite: nil,
+                            filters: nil,
+                            limit: 10,
+                            startIndex: nil
+                        )
+                        return (genre, response.items)
+                    } catch {
+                        return nil
+                    }
+                }
+            }
+            for await result in group {
+                if let (genre, items) = result {
+                    results[genre] = items
+                }
+            }
+        }
+
+        genreRows = picked.compactMap { genre in
+            guard let items = results[genre], !items.isEmpty else { return nil }
+            return (genre: genre, items: items)
+        }
     }
 }

--- a/Shared/ViewModels/MediaLibraryViewModel.swift
+++ b/Shared/ViewModels/MediaLibraryViewModel.swift
@@ -9,9 +9,18 @@ struct LibrarySortFilterState: Equatable {
     var sortBy: ItemSortBy = .dateCreated
     var sortAscending: Bool = false
     var selectedGenres: Set<String> = []
+    var showUnwatchedOnly: Bool = false
+    /// Selected decades, stored as the starting year (e.g. 1980 → "1980s"). Empty == no decade filter.
+    var selectedDecades: Set<Int> = []
 
-    var isFiltered: Bool { !selectedGenres.isEmpty }
+    var isFiltered: Bool { !selectedGenres.isEmpty || showUnwatchedOnly || !selectedDecades.isEmpty }
     var isNonDefault: Bool { sortBy != .dateCreated || sortAscending || isFiltered }
+
+    /// Expands `selectedDecades` into every year covered. `nil` when no decade filter is active.
+    var expandedYears: [Int]? {
+        guard !selectedDecades.isEmpty else { return nil }
+        return selectedDecades.sorted().flatMap { start in Array(start..<(start + 10)) }
+    }
 }
 
 // MARK: - View Model
@@ -48,8 +57,20 @@ final class MediaLibraryViewModel {
     }
 
     func loadInitial(using appState: AppState) async {
-        guard !hasLoaded, let userId = appState.currentUserId else { return }
+        guard !hasLoaded else { return }
         hasLoaded = true
+        await performLoad(using: appState)
+    }
+
+    func reload(using appState: AppState) async {
+        await performLoad(using: appState)
+        if sortFilter.isFiltered {
+            await applyFilter(using: appState)
+        }
+    }
+
+    private func performLoad(using appState: AppState) async {
+        guard let userId = appState.currentUserId else { return }
         isLoading = true
         errorMessage = nil
 
@@ -136,12 +157,16 @@ final class MediaLibraryViewModel {
         let currentItemType = itemType
         await filteredLoader.loadMore { startIndex in
             let genres = currentSortFilter.selectedGenres.isEmpty ? nil : Array(currentSortFilter.selectedGenres)
+            let filters: [ItemFilter]? = currentSortFilter.showUnwatchedOnly ? [.isUnplayed] : nil
+            let years = currentSortFilter.expandedYears
             let result = try await appState.apiClient.getItems(
                 userId: userId,
                 includeItemTypes: [currentItemType],
                 sortBy: [currentSortFilter.sortBy],
                 sortOrder: currentSortFilter.sortAscending ? [.ascending] : [.descending],
                 genres: genres,
+                years: years,
+                filters: filters,
                 limit: 40,
                 startIndex: startIndex
             )

--- a/Shared/ViewModels/SearchViewModel.swift
+++ b/Shared/ViewModels/SearchViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Observation
 import CinemaxKit
-import JellyfinAPI
+@preconcurrency import JellyfinAPI
 #if os(iOS)
 import Speech
 import AVFoundation
@@ -149,6 +149,42 @@ final class SearchViewModel {
         }
     }
     #endif
+
+    // MARK: - Surprise Me
+
+    /// Two specialized entry points (vs. one parameterized) so the `[BaseItemKind]`
+    /// literal is captured locally — Swift 6 strict concurrency raises a "sending
+    /// non-Sendable value" diagnostic when the array is built from a function
+    /// parameter and sent across the actor boundary into the API call.
+    func fetchRandomMovie(using appState: AppState) async -> BaseItemDto? {
+        guard let userId = appState.currentUserId else { return nil }
+        do {
+            let response = try await appState.apiClient.getItems(
+                userId: userId,
+                includeItemTypes: [.movie],
+                sortBy: [.random],
+                limit: 1
+            )
+            return response.items.first
+        } catch {
+            return nil
+        }
+    }
+
+    func fetchRandomSeries(using appState: AppState) async -> BaseItemDto? {
+        guard let userId = appState.currentUserId else { return nil }
+        do {
+            let response = try await appState.apiClient.getItems(
+                userId: userId,
+                includeItemTypes: [.series],
+                sortBy: [.random],
+                limit: 1
+            )
+            return response.items.first
+        } catch {
+            return nil
+        }
+    }
 
     // MARK: Text search
 

--- a/Shared/ViewModels/VideoPlayerCoordinator.swift
+++ b/Shared/ViewModels/VideoPlayerCoordinator.swift
@@ -60,6 +60,7 @@ final class VideoPlayerCoordinator {
                     apiClient: apiClient, userId: userId,
                     maxBitrate: bitrate, loc: loc,
                     autoPlayNextEpisode: autoPlayNextEpisode,
+                    imageBuilder: appState.imageBuilder,
                     onDismiss: { [weak self] in
                         self?.presenter = nil
                         self?.lastDismissedAt = Date()

--- a/Tests/CinemaxKitTests/MockAPIClient.swift
+++ b/Tests/CinemaxKitTests/MockAPIClient.swift
@@ -53,6 +53,11 @@ final class MockAPIClient: APIClientProtocol, @unchecked Sendable {
 
     func getPublicUsers() async throws -> [UserDto] { [] }
     func getUsers() async throws -> [UserDto] { [] }
+    func getActiveSessions(activeWithinSeconds: Int) async throws -> [SessionInfoDto] { [] }
+
+    // MARK: - Cache
+
+    func clearCache() {}
 
     func getResumeItems(userId: String, limit: Int) async throws -> [BaseItemDto] {
         if shouldThrow { throw stubbedError }
@@ -68,7 +73,7 @@ final class MockAPIClient: APIClientProtocol, @unchecked Sendable {
         userId: String, parentId: String?, includeItemTypes: [BaseItemKind]?,
         sortBy: [ItemSortBy]?, sortOrder: [JellyfinAPI.SortOrder]?,
         genres: [String]?, years: [Int]?, isFavorite: Bool?,
-        limit: Int?, startIndex: Int?
+        filters: [ItemFilter]?, limit: Int?, startIndex: Int?
     ) async throws -> (items: [BaseItemDto], totalCount: Int) {
         if shouldThrow { throw stubbedError }
         return (stubbedItems, stubbedTotalCount)
@@ -97,8 +102,15 @@ final class MockAPIClient: APIClientProtocol, @unchecked Sendable {
     func getEpisodes(seriesId: String, seasonId: String, userId: String) async throws -> [BaseItemDto] { [] }
     func getNextUp(seriesId: String, userId: String) async throws -> BaseItemDto? { nil }
 
-    func reportPlaybackStart(itemId: String, userId: String, mediaSourceId: String?, playSessionId: String?, positionTicks: Int?, playMethod: PlayMethod) async {}
-    func reportPlaybackProgress(itemId: String, userId: String, mediaSourceId: String?, playSessionId: String?, positionTicks: Int?, isPaused: Bool, playMethod: PlayMethod) async {}
+    // MARK: - Media Segments
+
+    func getMediaSegments(itemId: String, includeSegmentTypes: [MediaSegmentType]?) async throws -> [MediaSegmentDto] { [] }
+
+    // `PlayMethod` is disambiguated with `CinemaxKit.` prefix because JellyfinAPI
+    // exports a type of the same name; Swift can't tell which one the protocol
+    // signature refers to without the explicit module qualifier.
+    func reportPlaybackStart(itemId: String, userId: String, mediaSourceId: String?, playSessionId: String?, positionTicks: Int?, playMethod: CinemaxKit.PlayMethod) async {}
+    func reportPlaybackProgress(itemId: String, userId: String, mediaSourceId: String?, playSessionId: String?, positionTicks: Int?, isPaused: Bool, playMethod: CinemaxKit.PlayMethod) async {}
     func reportPlaybackStopped(itemId: String, userId: String, mediaSourceId: String?, playSessionId: String?, positionTicks: Int?) async {}
 
     func getPlaybackInfo(

--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -38,6 +38,8 @@
 	<true/>
 	<key>UILaunchScreen</key>
 	<dict/>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations~iPad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/project.yml
+++ b/project.yml
@@ -41,6 +41,11 @@ targets:
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UIApplicationSupportsIndirectInputEvents: true
+        # Full-screen-only — Cinemax is a video player, iPad split view would
+        # interrupt playback and shrink hero/backdrop layouts. Setting this
+        # also silences Xcode's "all interface orientations must be supported
+        # unless the app requires full screen" iPad multitasking warning.
+        UIRequiresFullScreen: true
         UILaunchScreen: {}
         NSSpeechRecognitionUsageDescription: "Cinemax uses speech recognition for voice search to find movies and shows."
         NSMicrophoneUsageDescription: "Cinemax uses the microphone for voice search."


### PR DESCRIPTION
…s infra

Ships the remaining Section 7 items and cleans up the audit. Adds new infra (toasts, empty states, Dynamic Type, Refresh Catalogue, debug tooling) that several features depend on.

## Discovery & Information
- Studio/Network label + Community/Critic ratings on MediaDetailScreen
- Year/Decade filter in library (chips 1950s–2020s, iOS sheet + tvOS bar)
- Episode air dates + "Xm remaining" on episode rows (shared metadata line)
- Genre-aware Surprise Me — moved from Home to SearchScreen empty state (two pills: random movie / random series)
- iOS alphabetical jump bar in filtered library (sort-by-name only)

## Playback
- Sleep timer (Off/15/30/45/60/90 min) — Settings picker, countdown pill, "Still watching?" prompt with Keep watching / Stop playback
- Chapter support (tvOS only) via AVNavigationMarkersGroup with thumbnails
- End-of-series completion overlay (autoplay on + last episode)
- Error recovery alerts with code-specific messages (transcode / network)
- Skip Intro / Credits — iOS: floating pill. tvOS: native AVPlayerViewController.contextualActions (the only focusable path that coexists with the transport-bar focus context). Pure time-based visibility, click seeks to segment end, rewind re-shows the button

## Multi-user & Social
- "Watching Now" row on Home via new getActiveSessions Sessions API call
- Quick user switch: UserSwitchSheet (avatar grid → password prompt → re-auth preserving server URL), wired into Settings → Account

## UX Infrastructure
- ToastCenter + ToastOverlay — top-anchored glass pill, single-at-a-time queue
- EmptyStateView — used on Home/Library/UserSwitchSheet when collections empty
- iOS Dynamic Type — UIFontMetrics-aware CinemaFont.dynamicBody/dynamicLabel, .dynamicTypeSize cap applied at AppNavigation root
- Settings → Server → Refresh Catalogue — single action, posts .cinemaxShouldRefreshCatalogue notification consumed by Home + Library
- Debug section (Settings → Interface → Debug) with fastSleepTimer override and skip-to-end-of-video button

## tvOS focus fixes
- Sleep prompt + end-of-series → UIAlertController (UIView overlays can't be focused inside AVPlayerViewController)
- Settings/Search scroll-to-top on reappearance (ScrollViewReader + sentinel) so the system tab bar resurfaces after deep-nav pops
- Removed in-page Refresh buttons (Home pill, Library filter bar)

## Deprecation + warning cleanup
- Migrated 5 UIButton.contentEdgeInsets sites to UIButton.Configuration
- Added @MainActor to iOSToggleRow for Swift 6 strict concurrency
- Set UIRequiresFullScreen=true on iOS (video player, silences iPad multitasking lint)
- CLAUDE.md section "Modern API requirements (iOS 18 / tvOS 26)" documents the UIButton.Configuration pattern and iPhone orientation caveat

## Refactoring (conservative first pass)
- JellyfinError → own file
- MediaTrackInfo → Models/ own file
- IOSAppearanceDetailView → SettingsAppearanceView+iOS.swift

## Localization
All new UI strings in both fr.lproj and en.lproj — sleep/prompt, error recovery, end-of-series, decade filter, debug, Watching Now, user switch, refresh catalogue, Surprise Me.

## Audit.md + CLAUDE.md
- Audit.md: Section 7 items 6–20 flipped to DONE with per-feature notes; Section 5 #10 marked PARTIAL (deferred the risky NativeVideoPresenter / MovieLibraryScreen splits); Section 6 #1 DONE; new Section 8 "UX Refinements & Debug Tooling"
- CLAUDE.md: documented all new subsystems (Toasts, Empty states, Dynamic Type, SearchScreen, Watching Now, Quick user switch, Refresh Catalogue, Debug section, chapters, sleep timer, end-of-series, error recovery); expanded Skip Intro/Credits section with the tvOS focus-engine lesson ("custom subviews / overlay modals / subclass preferredFocusEnvironments overrides cannot be focused on tvOS while AVPlayerViewController is on screen — use contextualActions or other native player APIs")

All 21 CinemaxKit tests pass. iOS + tvOS simulators build clean.