### PR TITLE
feat(ipad): adaptive layout + hero landscape fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,348 +1,303 @@
 # Cinemax - Jellyfin Client for Apple Platforms
 
-Native Jellyfin media streaming client for iOS 18+ and tvOS 26+. Uses a "Cinema Glass" design system (dark glassmorphism, editorial layouts, no borders).
+Native Jellyfin media streaming client for iOS 18+ and tvOS 26+. "Cinema Glass" design system (dark glassmorphism, editorial layouts, no borders).
 
 ## Architecture
 
 - **SwiftUI** multi-platform (single Xcode project, iOS + tvOS targets)
 - **CinemaxKit** local Swift Package at `Packages/CinemaxKit` — shared networking, models, persistence
-- **@Observable** + `@MainActor` for all state management. **iOS `NavigationStack` caveat**: destination views pushed via `navigationDestination(item:)` render in a separate context — `@Observable` changes to environment objects won't re-render the destination unless it is a standalone `View` struct with its own `@Environment` properties. Always use a proper struct (not an extension method returning `some View`) for interactive pushed destinations.
-- **Swift 6** strict concurrency
+- **Swift 6** strict concurrency; **@Observable** + `@MainActor` for all state
 - **JellyfinClient** wrapped with `NSLock` + `nonisolated(unsafe)` for Sendable conformance
+- **iOS `NavigationStack` caveat**: destinations pushed via `navigationDestination(item:)` render in a separate context — `@Observable` changes to environment objects won't re-render the destination unless it is a standalone `View` struct with its own `@Environment` properties. Use a proper struct, not an extension method returning `some View`.
 
 ### Modern API requirements (iOS 18 / tvOS 26)
 
-The project's deployment targets are iOS 18 and tvOS 26. Avoid pre-iOS-15 APIs that the compiler has now deprecated.
-
-- **`UIButton`**: never use `UIButton(type:)` + `setTitle` / `setTitleColor` / `titleLabel?.font` / `backgroundColor` / `contentEdgeInsets`. Build buttons with `UIButton.Configuration`:
-  ```swift
-  var config = UIButton.Configuration.plain()
-  var attrTitle = AttributedString("Hello")
-  attrTitle.font = .systemFont(ofSize: 17, weight: .semibold)
-  attrTitle.foregroundColor = UIColor.white
-  config.attributedTitle = attrTitle
-  config.contentInsets = NSDirectionalEdgeInsets(top: 14, leading: 24, bottom: 14, trailing: 24)
-  config.background.backgroundColor = .systemBlue
-  config.background.cornerRadius = 12
-  // Frosted background is supported via `config.background.customView = UIVisualEffectView(...)`
-  let button = UIButton(configuration: config, primaryAction: UIAction { _ in ... })
-  ```
-- **Free SwiftUI helpers**: free functions returning `some View` that touch SwiftUI types (`PrimitiveButtonStyle.plain`, `Font`, etc.) must be `@MainActor`. Under Swift 6 strict concurrency, those types are main-actor-isolated and the compiler raises "Main actor-isolated static property X can not be referenced from a nonisolated context" otherwise. The shared `iOSToggleRow` / `iOSToggleRowsJoined` / `iOSSettingsRow` helpers in `SettingsRowHelpers.swift` follow this pattern.
-- **iPad multitasking**: `UIRequiresFullScreen: true` is set in `project.yml` for the iOS target. Cinemax is a video player — split view would interrupt playback and break hero/backdrop layouts, and the flag also satisfies Xcode's "all interface orientations must be supported unless the app requires full screen" warning. Don't change this without a strong reason; if the app ever needs split view, the iPhone orientation list must be expanded to include `UIInterfaceOrientationPortraitUpsideDown` (currently omitted on iPhone).
+- **`UIButton`**: never use `UIButton(type:)` + `setTitle/setTitleColor/titleLabel?.font/backgroundColor/contentEdgeInsets`. Build with `UIButton.Configuration` (see the skip-intro button and debug "End" pill in `NativeVideoPresenter` for the pattern). Frosted background via `config.background.customView = UIVisualEffectView(...)`.
+- **Free SwiftUI helpers**: free functions returning `some View` that touch SwiftUI types (`PrimitiveButtonStyle.plain`, `Font`, etc.) must be `@MainActor` under Swift 6 — those types are main-actor-isolated. The `iOSToggleRow` / `iOSToggleRowsJoined` / `iOSSettingsRow` helpers in `SettingsRowHelpers.swift` follow this.
+- **iPad multitasking**: `UIRequiresFullScreen: true` in `project.yml`. Split view would interrupt playback and break hero/backdrop layouts; also satisfies the "all orientations unless full screen" warning. If ever changed, the iPhone orientation list must add `UIInterfaceOrientationPortraitUpsideDown`.
 
 **Dependencies**: `jellyfin-sdk-swift` v0.6.0, `Nuke`/`NukeUI` v12.9.0, `AVKit`/`AVPlayer`
 
-**API protocol split** (`Packages/CinemaxKit/.../APIClientProtocol.swift`): the umbrella `APIClientProtocol` is a typealias for `ServerAPI & AuthAPI & LibraryAPI & PlaybackAPI`. View models that touch multiple domains depend on `APIClientProtocol`; leaf controllers narrow to the slice they need (`PlaybackReporter` / `SkipSegmentController` → `any PlaybackAPI`). `JellyfinAPIClient` conforms to all four sub-protocols; `MockAPIClient` declares conformance to `APIClientProtocol` and inherits all methods transparently.
+**API protocol split** (`Packages/CinemaxKit/.../APIClientProtocol.swift`): umbrella `APIClientProtocol` is a typealias for `ServerAPI & AuthAPI & LibraryAPI & PlaybackAPI`. View models needing multiple domains depend on `APIClientProtocol`; leaf controllers narrow to the slice they use (`PlaybackReporter` / `SkipSegmentController` → `any PlaybackAPI`). `JellyfinAPIClient` conforms to all four; `MockAPIClient` declares `APIClientProtocol` and inherits transparently.
 
-**Swift 6 `nonisolated` escape hatches**: two patterns recur when the compiler flags non-Sendable data crossing a `@MainActor` boundary. (1) A `View, Equatable` sub-type defined inside an `@MainActor` screen needs `nonisolated static func ==` because `Equatable` is not main-actor-isolated — see `PlayActionButtonsSection` in `MediaDetailScreen.swift`. (2) A `@MainActor` class's `static func` that returns non-Sendable types (e.g. `[BaseItemDto]`) into a `TaskGroup.addTask @Sendable` closure needs `nonisolated private static func …` — see `HomeViewModel.fetchGenreItems`. Both are safe when the body only reads its parameters.
+**Swift 6 `nonisolated` escape hatches**:
+1. `View, Equatable` sub-type inside an `@MainActor` screen needs `nonisolated static func ==` — `Equatable` isn't main-actor-isolated. See `PlayActionButtonsSection` in `MediaDetailScreen.swift`.
+2. A `@MainActor` class's `static func` returning non-Sendable types (e.g. `[BaseItemDto]`) into a `TaskGroup.addTask @Sendable` closure needs `nonisolated private static func`. See `HomeViewModel.fetchGenreItems`.
+
+Both safe when the body only reads its parameters.
 
 ## Project Structure
 
 ```
 Shared/
-  DesignSystem/     CinemaGlassTheme, ThemeManager, GlassModifiers, FocusScaleModifier, LocalizationManager, TVButtonStyles
-    Components/     CinemaLazyImage, ProgressBarView, RatingBadge, LoadingStateView, ErrorStateView, PosterCard, WideCard, ContentRow, CinemaButton, FlowLayout
-  Navigation/       AppNavigation (auth routing), MainTabView (tab bar/sidebar)
-  Screens/          HomeScreen, LoginScreen, ServerSetupScreen, SearchScreen, MediaDetailScreen,
-                    MovieLibraryScreen, LibrarySortFilterSheet, TVSeriesScreen, MediaQualityBadges,
-                    VideoPlayerView, NativeVideoPresenter, HLSManifestLoader, PlayLink, TrackPickerSheet,
-                    SettingsScreen (+iOS, +tvOS platform variants), SettingsRowHelpers
-    VideoPlayer/    PlaybackReporter, SkipSegmentController, SleepTimerController (sub-controllers consumed by NativeVideoPresenter)
-  ViewModels/       HomeViewModel, LoginViewModel, SearchViewModel, ServerSetupViewModel,
-                    MediaDetailViewModel, MediaLibraryViewModel, VideoPlayerCoordinator
-iOS/                app entry point
-tvOS/               app entry point
-Resources/
-  fr.lproj/         French localization (default)
-  en.lproj/         English localization
-Packages/CinemaxKit/  Models, Networking (JellyfinAPIClient, ImageURLBuilder), Persistence (KeychainService)
+  DesignSystem/Components/  CinemaLazyImage, ProgressBarView, RatingBadge, LoadingStateView, ErrorStateView, PosterCard, WideCard, ContentRow, CinemaButton, FlowLayout
+  Navigation/               AppNavigation (auth routing), MainTabView (tab bar/sidebar)
+  Screens/                  Home/Login/ServerSetup/Search/MediaDetail/MovieLibrary/TVSeries/Settings/VideoPlayer (+ NativeVideoPresenter, HLSManifestLoader, PlayLink, TrackPickerSheet, MediaQualityBadges, SettingsRowHelpers)
+    VideoPlayer/            PlaybackReporter, SkipSegmentController, SleepTimerController
+  ViewModels/               Home/Login/Search/ServerSetup/MediaDetail/MediaLibrary ViewModels, VideoPlayerCoordinator
+iOS/ tvOS/                  app entry points
+Resources/{fr,en}.lproj/    Localization (fr default)
+Packages/CinemaxKit/        Models, Networking (JellyfinAPIClient, ImageURLBuilder), Persistence (KeychainService)
 ```
 
 ## Design System
 
-- Dynamic color tokens in `CinemaGlassTheme.swift` (`CinemaColor`, `CinemaFont`, `CinemaSpacing`, `CinemaRadius`). All `CinemaColor` tokens use `Color.dynamic(light:dark:)` backed by `UIColor(dynamicProvider:)` — they resolve against the active `UITraitCollection` automatically. **Never use `Color(hex:)` for new tokens** — always use `Color.dynamic(light:dark:)` so they work in both modes.
-- **Reusable components** in `Shared/DesignSystem/Components/`: `CinemaLazyImage`, `ProgressBarView`, `RatingBadge`, `LoadingStateView`, `ErrorStateView`, `PosterCard`, `WideCard`, `ContentRow`, `CinemaButton`
-- **Shared toggle**: `CinemaToggleIndicator` (Capsule+Circle pill, in `SettingsScreen.swift`) — used on both iOS and tvOS for all boolean settings. Interaction is parent-driven (wrap in `Button { value.toggle() }`). Never use system `Toggle` in settings.
-- **No 1px borders** — use color shifts for boundaries. Glass panels: `.glassPanel()` modifier
-- **Dynamic accent**: use `themeManager.accent` / `.accentContainer` / `.accentDim` / `.onAccent` — never `CinemaColor.tertiary*`. All four sub-tokens are dual-mode via `Color.dynamic`.
-- **Dark/Light mode**: `ThemeManager.darkModeEnabled` → `.preferredColorScheme()` at root (set in `AppNavigation`, nowhere else). Colors flip automatically via `UITraitCollection`. **Always route dark mode changes through `themeManager.darkModeEnabled =` setter** — direct `@AppStorage("darkMode")` writes bypass `_accentRevision` and break reactivity.
-- **Hardcoded `.white` / `.black` rule**: `.white` and `.black` are only acceptable inside the video player (always dark) and on elements that sit directly on a saturated `accentContainer` background. Everywhere else use `CinemaColor.onSurface` / `CinemaColor.onSurfaceVariant`.
-- **Font scaling**: `CinemaScale.factor` applies a 1.4× base multiplier on tvOS, then user `uiScale` (80–130%) on top. All `CinemaFont` and `CinemaScale.pt()` calls multiply by this. **Exception**: Play/Lecture button labels use hardcoded `28pt` on tvOS
-- **Focus — tvOS**: `@FocusState` + `.focusEffectDisabled()` + `.hoverEffectDisabled()`. Indicator is a 2px accent `strokeBorder` — no scale, no white background. Cards: `CinemaTVCardButtonStyle`. Settings rows: `.tvSettingsFocusable()`. Season tabs: `SeasonTabButtonStyle`. **tvOS focus trait-collection caveat**: when a `Button` receives focus, tvOS overrides the `UITraitCollection` inside the button label, flipping all `Color.dynamic` tokens to their light-mode values. `tvSettingsFocusable` takes a `colorScheme` parameter and injects `.environment(\.colorScheme, colorScheme)` on both the content and the background shape to prevent this. Always pass `colorScheme: themeManager.darkModeEnabled ? .dark : .light` at call sites.
-- **Focus — iOS**: `.cinemaFocus()` modifier (accent border + shadow)
-- **Motion Effects**: `motionEffectsEnabled` environment key (from `AppNavigation` via `@AppStorage("motionEffects")`). When off, all `.animation()` calls use `nil`. Consumed by `CinemaFocusModifier`, `CinemaTVButtonStyle`, `CinemaTVCardButtonStyle`, toggle indicators. Injected on both iOS and tvOS.
-- Platform-adaptive layouts: `#if os(tvOS)` or `horizontalSizeClass`
+- Color/font/spacing tokens in `CinemaGlassTheme.swift`. All `CinemaColor` tokens use `Color.dynamic(light:dark:)` backed by `UIColor(dynamicProvider:)` — they resolve against the active `UITraitCollection`. **Never use `Color(hex:)` for new tokens.**
+- **Shared toggle**: `CinemaToggleIndicator` (Capsule+Circle pill, in `SettingsScreen.swift`) — used on both platforms. Parent-driven (wrap in `Button { value.toggle() }`). Never use system `Toggle` in settings.
+- **No 1px borders** — use color shifts. Glass panels: `.glassPanel()`.
+- **Dynamic accent**: `themeManager.accent` / `.accentContainer` / `.accentDim` / `.onAccent` — never `CinemaColor.tertiary*`. All four are dual-mode via `Color.dynamic`.
+- **Dark/Light mode**: `ThemeManager.darkModeEnabled` → `.preferredColorScheme()` at root (set in `AppNavigation`, nowhere else). Colors flip via `UITraitCollection`. **Always route through `themeManager.darkModeEnabled =`** — direct `@AppStorage("darkMode")` writes bypass `_accentRevision` and break reactivity. Same for `themeManager.accentColorKey`.
+- **Hardcoded `.white`/`.black`**: only acceptable inside the video player (always dark) and on elements sitting directly on a saturated `accentContainer`. Elsewhere use `CinemaColor.onSurface` / `.onSurfaceVariant`.
+- **Font scaling**: `CinemaScale.factor` = 1.4× base on tvOS × user `uiScale` (80–130%). All `CinemaFont` and `CinemaScale.pt()` multiply by this. **Exception**: Play/Lecture button labels hardcode `28pt` on tvOS.
+- **tvOS focus**: `@FocusState` + `.focusEffectDisabled()` + `.hoverEffectDisabled()`. Indicator is a 2px accent `strokeBorder` — no scale, no white bg. Cards: `CinemaTVCardButtonStyle`. Settings rows: `.tvSettingsFocusable()`. **Trait-collection caveat**: a focused `Button` overrides the `UITraitCollection` inside its label, flipping all `Color.dynamic` tokens to light-mode values. `tvSettingsFocusable` takes a `colorScheme` parameter and injects `.environment(\.colorScheme, colorScheme)` on both content and background shape. Always pass `colorScheme: themeManager.darkModeEnabled ? .dark : .light`.
+- **iOS focus**: `.cinemaFocus()` (accent border + shadow).
+- **Motion Effects**: `motionEffectsEnabled` env key (from `AppNavigation` via `@AppStorage("motionEffects")`). When off, all `.animation()` calls use `nil`. Consumed by `CinemaFocusModifier`, `CinemaTVButtonStyle`, `CinemaTVCardButtonStyle`, toggle indicators.
+- Platform-adaptive layouts: `#if os(tvOS)` or `horizontalSizeClass`.
 
 ## Navigation
 
-- `AppNavigation` → Keychain session check → `apiClient.reconnect()` + `fetchServerInfo()`
-- `AppNavigation` injects `ThemeManager` and `LocalizationManager`, applies `.preferredColorScheme()` at root
-- No server → `ServerSetupScreen` → `LoginScreen` → `MainTabView`
-- `MainTabView`: top tab bar on tvOS, sidebar on iPad, bottom tab bar on iPhone
-- All play buttons use `PlayLink<Label>` (Button+coordinator on tvOS, NavigationLink on iOS) — never direct `NavigationLink` to `VideoPlayerView`
+- `AppNavigation` → Keychain session check → `apiClient.reconnect()` + `fetchServerInfo()`. Injects `ThemeManager`, `LocalizationManager`, `ToastCenter`; applies `.preferredColorScheme()` at root.
+- No server → `ServerSetupScreen` → `LoginScreen` → `MainTabView` (top tabs on tvOS, sidebar on iPad, bottom tabs on iPhone).
+- All play buttons use `PlayLink<Label>` (Button+coordinator on tvOS, NavigationLink on iOS) — never direct `NavigationLink` to `VideoPlayerView`.
 
 ## Media Library (`MediaLibraryScreen`)
 
 Unified screen parameterized by `BaseItemKind` (movies or series).
 
 **Sort & Filter state** (`LibrarySortFilterState`):
-- Default: `dateCreated` descending. `isNonDefault` is true when sort or filter differs from default
-- `isFiltered` is true when genre chips are selected OR `showUnwatchedOnly == true` OR `selectedDecades` non-empty
-- **Browse vs filtered**: show browse view (genre rows) whenever `isFiltered == false`, regardless of sort. Genre chip / unwatched toggle / decade chip switches to the flat filtered grid
-- **Title count**: uses `isFiltered` (not `isNonDefault`) — sort-only changes don't affect total count. Shows `filteredTotalCount` when filtered, `totalCount` otherwise
-- Sort change triggers `reloadGenreItems` (genre rows respect current sort); filter change triggers `applyFilter` (flat paginated list)
-- `loadInitial` guarded by `hasLoaded` — prevents re-randomization on tab switch. `reload(using:)` bypasses the guard and re-runs the full load. Triggered by pull-to-refresh on iOS and by `.cinemaxShouldRefreshCatalogue` notification from Settings → Server → Refresh Catalogue on both platforms
+- Default: `dateCreated` descending. `isNonDefault` = sort or filter differs from default.
+- `isFiltered` = genre chips selected OR `showUnwatchedOnly` OR `selectedDecades` non-empty.
+- **Browse vs filtered**: browse view (genre rows) whenever `isFiltered == false`, regardless of sort. Any filter switches to the flat filtered grid.
+- **Title count** uses `isFiltered` (not `isNonDefault`) — sort-only changes don't affect count. Shows `filteredTotalCount` when filtered, `totalCount` otherwise.
+- Sort change → `reloadGenreItems`; filter change → `applyFilter`.
+- `loadInitial` guarded by `hasLoaded` (prevents re-randomization on tab switch). `reload(using:)` bypasses the guard — triggered by pull-to-refresh (iOS) and `.cinemaxShouldRefreshCatalogue`.
 
 **Filters**:
-- Unwatched: iOS sort sheet `unwatchedSection` + tvOS inline Watch Status chip → `LibrarySortFilterState.showUnwatchedOnly` → `filters: [.isUnplayed]` on `getItems`
-- Decade: `LibrarySortFilterState.selectedDecades: Set<Int>` (stored as the starting year, e.g. `1980`). `expandedYears` explodes the set into every concrete year and passes to `getItems(years:)`. UI: chips for 1950s–2020s in both iOS sort sheet and tvOS inline bar
+- Unwatched → `filters: [.isUnplayed]`.
+- Decade: `selectedDecades: Set<Int>` (starting year, e.g. `1980`). `expandedYears` explodes into every concrete year for `getItems(years:)`. UI: 1950s–2020s chips.
 
-**Refresh**: `.refreshable { reload() }` on iOS. On both platforms, observes `.cinemaxShouldRefreshCatalogue` (posted by Settings → Server → Refresh Catalogue, which also calls `apiClient.clearCache()`). No in-page refresh button — the global Settings action is the single source of truth.
+**tvOS filter bar**: inline (not modal) — sort pills + watch-status + decade + genre chips (`FlowLayout`, multi-line) + Reset. `TVFilterChipButtonStyle` for chip focus.
 
-**tvOS filter bar**: inline (not modal) — sort pills (horizontal scroll) + watch-status chip + decade chips + genre chips (`FlowLayout`, multi-line) + Reset button only. `TVFilterChipButtonStyle` for chip focus.
-
-**iOS alphabetical jump bar**: `AlphabeticalJumpBar` (Contacts-style capsule, ultraThinMaterial background, right edge of filtered view). Tap or drag to scroll the grid. Uses `ScrollViewReader` + `proxy.scrollTo(firstItemID(for: letter))` and `UISelectionFeedbackGenerator` for per-letter haptics. Only rendered when `sortBy == .sortName && sortAscending && items.count > 20` — other sorts aren't alphabetically meaningful.
+**iOS alphabetical jump bar**: `AlphabeticalJumpBar` (Contacts-style capsule, ultraThinMaterial, right edge). Uses `ScrollViewReader` + `proxy.scrollTo(firstItemID(for: letter))` + `UISelectionFeedbackGenerator` per-letter haptics. Only rendered when `sortBy == .sortName && sortAscending && items.count > 20`.
 
 ## Video Playback
 
 ### Playback Flow
-1. `getItem()` — fetch full metadata
-2. Resolve non-playable items: Series → `getNextUp()` or first episode; Season → first episode (**Series/Season have no media sources — must resolve to Episode first**)
-3. POST PlaybackInfo with `DeviceProfile` (`isAutoOpenLiveStream=true`, `mediaSourceID`, `userID`)
-4. Build stream URL: use `transcodingURL` if present (HLS), otherwise direct stream `/Videos/{id}/stream?static=true&...`
-5. Fallback: direct stream without PlaybackInfo session
+1. `getItem()` — fetch full metadata.
+2. Resolve non-playable items: Series → `getNextUp()` or first episode; Season → first episode. **Series/Season have no media sources — must resolve to Episode first.**
+3. POST PlaybackInfo with `DeviceProfile` (`isAutoOpenLiveStream=true`, `mediaSourceID`, `userID`).
+4. Build stream URL: `transcodingURL` if present (HLS), else direct stream `/Videos/{id}/stream?static=true&...`.
+5. Fallback: direct stream without PlaybackInfo session.
 
-**DeviceProfile**: DirectPlay for mp4/m4v/mov + h264/hevc; transcode to HLS mp4 with `hevc,h264` only. **Never include `mpeg4`** in video codec lists — MPEG-4 ASP is not a valid HLS transcode target on Apple platforms and causes Jellyfin to inject `mpeg4-*` URL parameters that AVFoundation doesn't recognise. `maxBitrate`: 120 Mbps (4K) or 20 Mbps (1080p) via `@AppStorage("render4K")`.
+**DeviceProfile**: DirectPlay for mp4/m4v/mov + h264/hevc; transcode to HLS mp4 with `hevc,h264` only. **Never include `mpeg4`** — not a valid HLS transcode target on Apple platforms; causes Jellyfin to inject `mpeg4-*` URL params AVFoundation doesn't recognise. `maxBitrate`: 120 Mbps (4K) or 20 Mbps (1080p) via `@AppStorage("render4K")`.
 
-### Native Player — Both Platforms (`NativeVideoPresenter.swift`)
-Both iOS and tvOS use native `AVPlayerViewController` presented via UIKit modal (`UIViewController.present()`). The shared `NativeVideoPresenter` class handles playback, track menus, episode navigation, chapters, end-of-series overlay, and error alerts. Three `@MainActor` sub-controllers in `Shared/Screens/VideoPlayer/` own cohesive slices:
-- `PlaybackReporter` — reportStart/Stop/Background + periodic progress (10-tick throttle driven by the presenter's shared time observer via `onTick()`).
-- `SkipSegmentController` — intro/outro skip affordance (iOS floating UIButton / tvOS `contextualActions`). Loads segments per item, cancels in-flight fetches on teardown, shows/hides purely from `onTick(currentTime:)`.
-- `SleepTimerController` — countdown indicator + "Still watching?" prompt. Presenter owns the `playerVC` lifecycle, passes a `playerVCProvider` closure + an `onStopPlayback` callback (Stop → presenter dismisses player).
+### Native Player (`NativeVideoPresenter.swift`)
 
-Presenter keeps the single `addPeriodicTimeObserver` (1 s) and fans out ticks to `skipSegments.onTick` + `playbackReporter.onTick`. Sub-controllers never add their own time observers — this preserves the CLAUDE.md invariant that one observer drives both segment detection and progress reporting.
+Both platforms use native `AVPlayerViewController` presented via UIKit modal (`UIViewController.present()`). Three `@MainActor` sub-controllers in `Shared/Screens/VideoPlayer/` own cohesive slices:
+- `PlaybackReporter` — reportStart/Stop/Background + periodic progress (10-tick throttle).
+- `SkipSegmentController` — intro/outro affordance (iOS floating UIButton / tvOS `contextualActions`). Loads segments per item, cancels in-flight fetches on teardown, shows/hides purely from `onTick(currentTime:)`.
+- `SleepTimerController` — countdown + "Still watching?" prompt. Presenter owns `playerVC` lifecycle, passes a `playerVCProvider` closure + `onStopPlayback` callback.
 
-- **MUST present via UIKit modal**, NOT SwiftUI — SwiftUI presentation corrupts `TabView`/`NavigationSplitView` focus on dismiss
-- **iOS dismiss detection**: `PlayerHostingVC` wrapper (child VC) with `viewWillDisappear(isBeingDismissed:)`
-- **tvOS dismiss detection**: `TVDismissDelegate` using `AVPlayerViewControllerDelegate.playerViewControllerDidEndDismissalTransition` (tvOS-only API). Do NOT embed `AVPlayerViewController` as a child VC on tvOS — causes internal constraint conflicts and `-12881` playback errors
+Presenter keeps **one** `addPeriodicTimeObserver` (1 s) and fans ticks to both `skipSegments.onTick` + `playbackReporter.onTick`. Sub-controllers never add their own observers — preserves the single-observer invariant.
 
-**Audio track menus**: injected via `transportBarCustomMenuItems` — first-class public API on tvOS, accessed via ObjC runtime KVC on iOS (marked `API_UNAVAILABLE(ios)` in Swift SDK but exists at runtime on iOS 16+). Custom audio menu shows Jellyfin track names instead of AVKit's default "Unknown" labels
+- **MUST present via UIKit modal**, not SwiftUI — SwiftUI presentation corrupts `TabView`/`NavigationSplitView` focus on dismiss.
+- **iOS dismiss detection**: `PlayerHostingVC` wrapper with `viewWillDisappear(isBeingDismissed:)`.
+- **tvOS dismiss detection**: `TVDismissDelegate` using `playerViewControllerDidEndDismissalTransition`. Do NOT embed `AVPlayerViewController` as a child VC on tvOS — causes internal constraint conflicts and `-12881`.
 
-**Subtitle handling** (platform-split):
-- **iOS**: `enableSubtitlesInManifest: true` + subtitle profiles `.hls` → Jellyfin includes WebVTT renditions in the HLS manifest. `HLSManifestLoader` (`AVAssetResourceLoaderDelegate` with `cinemax-https://` custom scheme) strips `#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS` from playlists and ASS/SSA override tags (`{\i1}`, `{\b}`, `{comments}`) from VTT segments. AVKit shows ONE unified native Subtitles menu. **iOS fallback**: `HLSManifestLoader` can also fail with `-12881` on iOS (not just tvOS) — `retryWithDirectURL` in `NativeVideoPresenter` automatically retries with the direct HLS URL (no custom scheme) when the player item fails. ASS tags won't be stripped on fallback (same as tvOS). Flag `hasRetriedDirectURL` resets on episode navigation so each episode gets its own retry
-- **tvOS**: Same `enableSubtitlesInManifest: true` + `.hls` profiles. `HLSManifestLoader` does NOT work on tvOS (`AVAssetResourceLoaderDelegate` causes `-12881` with `AVPlayerViewController`), so the HLS URL is used directly. AVKit shows native Subtitles menu, but ASS tags may appear in subtitle text (known Jellyfin server-side limitation)
-- **`HLSManifestLoader` key constraint**: `contentInformationRequest.contentType` must be a **UTI**, not a MIME type. Use `"public.m3u-playlist"` for M3U8, `"org.w3.webvtt"` for VTT. For segment types, skip `contentType` to let AVFoundation infer it
+**Audio track menus**: injected via `transportBarCustomMenuItems` — first-class on tvOS, accessed via ObjC runtime KVC on iOS (marked `API_UNAVAILABLE(ios)` in SDK but exists on iOS 16+). Shows Jellyfin track names instead of AVKit's "Unknown".
 
-**Episode navigation**: `MPRemoteCommandCenter` prev/next track commands on both platforms. `EpisodeRef` + `EpisodeNavigator` + `buildEpisodeNavigation` (shared free function in `PlayLink.swift`). `PlayLink` carries `previousEpisode`, `nextEpisode`, `episodeNavigator`; passes through `VideoPlayerCoordinator` (tvOS) or `VideoPlayerView` (iOS) → `NativeVideoPresenter`
+**Subtitles**:
+- **iOS**: `enableSubtitlesInManifest: true` + `.hls` profiles → Jellyfin includes WebVTT renditions. `HLSManifestLoader` (`AVAssetResourceLoaderDelegate` with `cinemax-https://` custom scheme) strips `#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS` from playlists and ASS/SSA tags (`{\i1}`, `{\b}`, `{comments}`) from VTT segments. AVKit shows one unified native Subtitles menu. **Fallback**: `HLSManifestLoader` can also fail with `-12881` on iOS — `retryWithDirectURL` automatically retries with the direct HLS URL (no custom scheme). ASS tags won't be stripped on fallback. `hasRetriedDirectURL` resets on episode navigation.
+- **tvOS**: `HLSManifestLoader` does NOT work (`AVAssetResourceLoaderDelegate` causes `-12881` with `AVPlayerViewController`); HLS URL used directly. ASS tags may appear in subtitle text.
+- **`HLSManifestLoader` key constraint**: `contentInformationRequest.contentType` must be a **UTI**, not a MIME type. `"public.m3u-playlist"` for M3U8, `"org.w3.webvtt"` for VTT. For segment types, skip `contentType`.
 
-**Playback reporting**: `reportPlaybackStart`, `reportPlaybackProgress`, `reportPlaybackStopped` — called on start, periodically (via shared 1 s time observer, reports every ~10 s), and on dismiss/episode-nav. `itemId` / `startTime` on the presenter are `var` and are rebound in `navigateToEpisode(_:)` (startTime → `nil`) so the new episode reports under its own identity rather than the initial episode's.
+**Episode navigation**: `MPRemoteCommandCenter` prev/next track on both platforms. `EpisodeRef` + `EpisodeNavigator` + `buildEpisodeNavigation` (free function in `PlayLink.swift`). `PlayLink` carries `previousEpisode`, `nextEpisode`, `episodeNavigator` through `VideoPlayerCoordinator` (tvOS) or `VideoPlayerView` (iOS) → `NativeVideoPresenter`. `itemId` / `startTime` are `var` and rebound in `navigateToEpisode` (startTime → `nil`) so new episodes report under their own identity.
 
-**Auto-play next episode**: `AVPlayerItem.didPlayToEndTime` observer → `navigateToEpisode(next)` when `autoPlayNextEpisode` setting is on
+**Auto-play next**: `AVPlayerItem.didPlayToEndTime` → `navigateToEpisode(next)` when `autoPlayNextEpisode` is on.
 
-**Skip Intro / Credits**: Requires the **Intro Skipper** plugin (or similar) on the Jellyfin server. On playback start (and episode navigation), `NativeVideoPresenter` fetches media segments via `getMediaSegments(itemId:includeSegmentTypes: [.intro, .outro])`. A single `addPeriodicTimeObserver` (1 s interval) handles both segment detection and progress reporting. Visibility is **pure time-based**: `checkSegments` shows/hides based on whether `currentTime ∈ [segment.start, segment.end)`. Re-entry works naturally — rewinding back into a segment re-shows the button. Click action seeks to `segment.end`; no manual hide call, the next observer tick detects we're outside the segment and clears the button. Localization keys: `player.skipIntro`, `player.skipCredits`.
+**Skip Intro / Credits**: requires the **Intro Skipper** plugin. On start and episode navigation, fetches `getMediaSegments(itemId:includeSegmentTypes: [.intro, .outro])`. Visibility is **pure time-based**: `checkSegments` shows/hides based on `currentTime ∈ [segment.start, segment.end)`. Re-entry works naturally — rewinding re-shows. Click seeks to `segment.end`; the next tick clears. Keys: `player.skipIntro`, `player.skipCredits`.
 
-Rendering is platform-split:
-- **iOS**: a floating `UIButton` (with `UIBlurEffect` background, bottom-right corner of the player) added directly to `AVPlayerViewController.view`. Direct touch.
-- **tvOS**: native `AVPlayerViewController.contextualActions = [UIAction(…)]`. This is the only mechanism that produces a focusable action button coexisting with `AVPlayerViewController`'s transport-bar focus context. **Custom subviews / overlay modals / subclass `preferredFocusEnvironments` overrides cannot be focused on tvOS while AVPlayerViewController is on screen** — the player owns and locks its focus environment. Do not attempt to reintroduce a floating pill on tvOS; it will appear but be unreachable by the Siri Remote. Same rule applies to any future "in-player" affordance (next-episode card, chapter menu, etc.) — use `contextualActions` or other native player APIs rather than arbitrary subviews.
+Rendering:
+- **iOS**: floating `UIButton` (UIBlurEffect bg, bottom-right) added to `AVPlayerViewController.view`.
+- **tvOS**: `AVPlayerViewController.contextualActions = [UIAction(…)]`. This is the ONLY mechanism that produces a focusable action button coexisting with the transport-bar focus context. **Custom subviews / overlay modals / `preferredFocusEnvironments` overrides are unreachable on tvOS while AVPlayerViewController is on screen** — the player locks its focus environment. Applies to any future in-player affordance — use `contextualActions` or other native APIs.
 
-**Chapters** (tvOS only): built from `BaseItemDto.chapters` and applied via `AVPlayerItem.navigationMarkerGroups = [AVNavigationMarkersGroup(title:timedNavigationMarkers:)]`. Each marker carries `commonIdentifierTitle` + optional `commonIdentifierArtwork` (JPEG thumbnail fetched from `ImageURLBuilder.chapterImageURL(itemId:imageIndex:)` with the Jellyfin auth token). `AVNavigationMarkersGroup` lives in AVKit on tvOS only; iOS `AVPlayerViewController` has no native chapter scrubber so the iOS path is a scoped `#if os(tvOS)` no-op.
+**Chapters** (tvOS only): built from `BaseItemDto.chapters` and applied via `AVPlayerItem.navigationMarkerGroups = [AVNavigationMarkersGroup(...)]`. Each marker carries `commonIdentifierTitle` + optional `commonIdentifierArtwork` (JPEG from `ImageURLBuilder.chapterImageURL(itemId:imageIndex:)`). `AVNavigationMarkersGroup` is tvOS-only in AVKit; iOS has no native chapter scrubber so that path is `#if os(tvOS)` no-op.
 
-**Sleep timer**: `SleepTimerOption` enum (`Off` / 15 / 30 / 45 / 60 / 90 minutes) backed by `@AppStorage("sleepTimerDefaultMinutes")`. `SleepTimerOption.currentDefaultSeconds` returns 15 s when `debug.fastSleepTimer` is on (Settings → Interface → Debug), otherwise the stored option in seconds. `NativeVideoPresenter.startSleepTimerIfNeeded` runs on playback start and episode navigation — displays a moon-icon blur pill countdown indicator (`mm:ss`) bottom-left of the player, pauses + shows a "Still watching?" prompt when the timer fires. The prompt uses `UIAlertController` on tvOS (focus-friendly) and a custom blur card on iOS; "Keep watching" restarts the timer, "Stop playback" dismisses the player.
+**Sleep timer**: `SleepTimerOption` enum (`Off` / 15 / 30 / 45 / 60 / 90 min) backed by `@AppStorage("sleepTimerDefaultMinutes")`. `currentDefaultSeconds` returns 15 s when `debug.fastSleepTimer` is on, else stored option. Moon-icon blur pill `mm:ss` bottom-left. On fire, pauses + shows "Still watching?" — `UIAlertController` on tvOS, custom blur card on iOS. "Keep watching" restarts; "Stop" dismisses.
 
-**End-of-series completion**: When `AVPlayerItemDidPlayToEndTime` fires with autoplay on, no next episode, and `episodeNavigator != nil`, shows a centered "You finished {Series Name}" overlay. `currentSeriesName` is captured opportunistically from the same `getItem` call that fetches chapters. tvOS uses `UIAlertController`, iOS uses a custom blur card — same focus-context reason as the sleep prompt.
+**End-of-series completion**: when `didPlayToEndTime` fires with autoplay on, no next episode, `episodeNavigator != nil` — shows centered "You finished {Series Name}" overlay. `currentSeriesName` captured from the same `getItem` that fetches chapters. tvOS `UIAlertController`, iOS custom blur card.
 
-**Picture-in-Picture** (iOS): `AVPlayerViewController.allowsPictureInPicturePlayback = true` (default since iOS 14, set explicitly) and `canStartPictureInPictureAutomaticallyFromInline = true` (auto-PiP when the user backgrounds the app). The PiP lifecycle is owned by `IOSPlayerDelegate` (file-private inside `NativeVideoPresenter`): `willStart` flips `isInPictureInPicture = true` and clears `didRestoreFromPiP`; the modal then auto-dismisses, and `PlayerHostingVC.shouldFireOnDismiss` consults `isInPictureInPicture` to suppress cleanup. `restoreUserInterfaceForPictureInPictureStop…` flips `didRestoreFromPiP = true` and re-presents the player via `restoreFromPiP` (builds a new `PlayerHostingVC` around the same retained `playerVC`). `didStopPictureInPicture` runs the full cleanup path *only* when `didRestoreFromPiP` is false (user closed PiP without restoring). `PiPRestoreHandlerBox` (`@unchecked Sendable`) wraps the non-Sendable AVKit completion handler so Swift 6 region analysis allows it inside `MainActor.assumeIsolated`. `PlayerHostingVC.viewDidLoad` defensively detaches `playerVC` from any prior parent before adopting it, since restore reuses the same controller.
+**Picture-in-Picture** (iOS): `allowsPictureInPicturePlayback = true` + `canStartPictureInPictureAutomaticallyFromInline = true` (auto-PiP when user backgrounds app). Lifecycle in `IOSPlayerDelegate` (file-private in `NativeVideoPresenter`): `willStart` flips `isInPictureInPicture = true` and clears `didRestoreFromPiP`; modal auto-dismisses, `PlayerHostingVC.shouldFireOnDismiss` consults `isInPictureInPicture` to suppress cleanup. `restoreUserInterfaceForPictureInPictureStop…` flips `didRestoreFromPiP = true` and re-presents via `restoreFromPiP` (new `PlayerHostingVC` around the same retained `playerVC`). `didStopPictureInPicture` runs full cleanup **only** when `didRestoreFromPiP == false`. `PiPRestoreHandlerBox` (`@unchecked Sendable`) wraps the non-Sendable AVKit completion handler so Swift 6 region analysis accepts it inside `MainActor.assumeIsolated`. `PlayerHostingVC.viewDidLoad` defensively detaches `playerVC` from any prior parent — restore reuses the same controller.
 
-**AirPlay / external playback** (iOS): iOS `Info.plist` declares `UIBackgroundModes = [audio, airplay]` (set in `project.yml` — required so playback continues when the iPhone locks during a cast). `NativeVideoPresenter.present` calls `activatePlaybackAudioSession()` before handing the item to the player (`.playback` + `.moviePlayback`), sets `avPlayer.allowsExternalPlayback = true` and `usesExternalPlaybackWhileExternalScreenIsActive = true`, and deactivates the session in `cleanup()` with `.notifyOthersOnDeactivation`. The AirPlay picker is drawn natively by `AVPlayerViewController`'s transport bar — no custom button. `SearchViewModel`'s voice-search briefly flips the category to `.record`; do not start voice search during an active playback session.
+**AirPlay / external playback** (iOS): `UIBackgroundModes = [audio, airplay]` in `project.yml` — required so playback continues when iPhone locks during a cast. `present` calls `activatePlaybackAudioSession()` before handing the item to the player (`.playback` + `.moviePlayback`), sets `allowsExternalPlayback = true` and `usesExternalPlaybackWhileExternalScreenIsActive = true`, and deactivates in `cleanup()` with `.notifyOthersOnDeactivation`. Picker drawn natively by transport bar. `SearchViewModel` voice-search briefly flips category to `.record` — do not start voice search during active playback.
 
-**Playback error recovery**: `showPlaybackErrorAlert(error:)` presents a native `UIAlertController` with error-code-specific messages. `-12881 / -12886 / -16170` → transcode guidance, `-12938 / -1001 / -1004 / -1005 / -1009` → network guidance, fallback → generic. On iOS the alert only fires after the `retryWithDirectURL` fallback itself fails (so we don't interrupt the silent first-try recovery). `isShowingErrorAlert` flag prevents stacking.
+**Error recovery**: `showPlaybackErrorAlert(error:)` — `-12881 / -12886 / -16170` → transcode guidance, `-12938 / -1001 / -1004 / -1005 / -1009` → network, else generic. On iOS the alert fires only after `retryWithDirectURL` itself fails (so we don't interrupt silent first-try recovery). `isShowingErrorAlert` prevents stacking.
 
-**Debug tooling** (Settings → Interface → Debug, always visible not gated by `#if DEBUG`):
-- `debug.fastSleepTimer` — overrides sleep duration to 15 s
-- `debug.showSkipToEnd` — on iOS paints a purple "End" pill top-right of the player that seeks to `(duration − 15 s)`; on tvOS injects the action into `transportBarCustomMenuItems`. Useful for previewing the end-of-series overlay without sitting through an episode.
+**Debug tooling** (Settings → Interface → Debug, always visible, not `#if DEBUG`-gated):
+- `debug.fastSleepTimer` — overrides sleep duration to 15 s.
+- `debug.showSkipToEnd` — iOS purple "End" pill top-right; tvOS injects into `transportBarCustomMenuItems`. Seeks to `(duration − 15 s)` for previewing end-of-series overlay.
 
 ## Settings Screen
 
 ### Layout — two-level navigation
 
-**Landing page** (both platforms):
-- **tvOS**: Split layout — left panel (brand: `AppLogo` image + title + version), right panel (4 nav category buttons). Centered accent bloom in `.background {}` persists across all settings pages. No intermediate panel backgrounds — dark base + bloom + content only.
-- **iOS**: Vertical scroll — logo header, 4 nav buttons (first is accent-highlighted), device info footer. Uses `NavigationStack` + `navigationDestination(item:)`.
+**Landing**:
+- **tvOS**: split — left (brand: `AppLogo` + title + version), right (4 nav pills). Centered accent bloom in `.background {}` persists across all settings pages. No intermediate panel backgrounds.
+- **iOS**: vertical scroll — logo header, 4 nav buttons (first accent-highlighted), device info footer. `NavigationStack` + `navigationDestination(item:)`.
 
-**Detail pages** (per category: Appearance, Account, Server, Interface):
-- tvOS: `ScrollView` with back button at top. Menu (remote) button triggers `.onExitCommand { selectedCategory = nil }`.
-- iOS: Pushed via `NavigationStack`, standard back button.
+**Detail pages** (Appearance, Account, Server, Interface):
+- tvOS: `ScrollView` with back button at top. Menu button → `.onExitCommand { selectedCategory = nil }`.
+- iOS: pushed via `NavigationStack`.
 
-### tvOS focus rules for Settings
-- Each settings row is a **single focusable unit** — never individual sub-items within a row.
-- Accent color row: left/right arrows cycle colors; select cycles to next. Uses `onMoveCommand`.
-- Language row: left/right or select toggles fr↔en. Uses `onMoveCommand`.
-- Category buttons on landing: pill shape, focused state = `accentContainer` fill + scale 1.05 + glow shadow.
-- Back button focus: `.focused($focusedItem, equals: .back)`, highlighted with accent color.
+### tvOS focus rules
+- Each row is a **single focusable unit** — never individual sub-items.
+- Accent color row: left/right cycle colors; select cycles. Uses `onMoveCommand`.
+- Language row: left/right or select toggles fr↔en. `onMoveCommand`.
+- Category pills on landing: focused = `accentContainer` fill + scale 1.05 + glow.
+- Back button: `.focused($focusedItem, equals: .back)`, highlighted with accent.
 
 ### Settings row SSOT (`SettingsRowHelpers.swift` + platform extensions)
 
-Every boolean toggle in Settings is declared once as a `SettingsToggleRow` and rendered on both platforms from the same list. Four catalogue properties on `SettingsScreen` — `interfaceToggleRows`, `homePageToggleRows`, `detailPageToggleRows`, `debugToggleRows` — are the authoritative list of toggles. Adding or renaming a toggle is a one-line `.init(id:icon:label:value:)` edit; the two renderers can only differ in presentation, never in which rows exist.
+Every boolean toggle is declared once as `SettingsToggleRow` and rendered on both platforms from the same list. Four catalogue properties on `SettingsScreen` — `interfaceToggleRows`, `homePageToggleRows`, `detailPageToggleRows`, `debugToggleRows` — are authoritative. Adding/renaming a toggle is a one-line `.init(id:icon:label:value:)` edit.
 
-- `SettingsToggleRow` (platform-agnostic) — `id`, `icon`, `label`, `value: Binding<Bool>`, optional `tint`.
-- `iOSToggleRowsJoined(_ rows:accent:animated:)` — iOS `@MainActor @ViewBuilder` expander (rows + dividers between them).
-- `tvToggleList(_ rows:)` — tvOS `@ViewBuilder` expander. Ignores `row.tint`; tvOS icons use `themeManager.accent` uniformly. iOS-only debug-orange tint lives in the `tint:` field and is consumed by `iOSToggleRowsJoined` only.
-- `tvActionRow(id:icon:label:subtitle:showsChevron:action:)` — tvOS helper for "tappable row with icon + title + optional subtitle + optional chevron". Two overloads: one for generic `.toggle(id)` focus, one for any `SettingsFocus` case (e.g. `.refreshConnection`). Consolidates Refresh Catalogue, Refresh Connection, Licenses.
-- iOS row atoms (reused by `navigationRow` + `iOSToggleRow` + bespoke rows): `iOSSettingsRow` (padded container), `iOSRowIcon` (colored icon badge), `iOSSettingsDivider` (inset divider), `iOSSettingsSectionHeader` (uppercase section label), `iOSToggleRow` (icon + label + `CinemaToggleIndicator`), `navigationRow(icon:label:action:)` (icon + label + chevron + tap action — used for Profile Settings, Privacy/Security, Switch Account, Licenses).
-- tvOS row atom: `tvGlassToggle(icon:label:key:value:)` — the single-row counterpart invoked by `tvToggleList`.
+- `SettingsToggleRow` — `id`, `icon`, `label`, `value: Binding<Bool>`, optional `tint`.
+- `iOSToggleRowsJoined(_ rows:accent:animated:)` — iOS `@MainActor @ViewBuilder` expander (rows + dividers).
+- `tvToggleList(_ rows:)` — tvOS expander. Ignores `row.tint`; tvOS uses `themeManager.accent` uniformly. iOS-only debug-orange `tint:` consumed by `iOSToggleRowsJoined` only.
+- `tvActionRow(id:icon:label:subtitle:showsChevron:action:)` — tvOS "tappable row with icon + title + optional subtitle + optional chevron". Two overloads (generic `.toggle(id)` focus or any `SettingsFocus` case). Consolidates Refresh Catalogue, Refresh Connection, Licenses.
+- iOS row atoms (reused by `navigationRow` + `iOSToggleRow` + bespoke rows): `iOSSettingsRow`, `iOSRowIcon`, `iOSSettingsDivider`, `iOSSettingsSectionHeader`, `iOSToggleRow`, `navigationRow(icon:label:action:)`.
+- tvOS row atom: `tvGlassToggle(icon:label:key:value:)`.
 
 ### Assets
-- `AppLogo.imageset`: iOS uses `app_logo.png` (full icon with background); tvOS uses `app_logo_tv.png` (front parallax layer — transparent background, jellyfish only). No `clipShape` on tvOS logo — organic shape renders freely.
+- `AppLogo.imageset`: iOS `app_logo.png` (full icon); tvOS `app_logo_tv.png` (front parallax layer — transparent bg, jellyfish only). No `clipShape` on tvOS logo.
 
-### `@AppStorage` keys (shared between iOS and tvOS, declared in `SettingsScreen`)
+### `@AppStorage` keys (shared iOS/tvOS, declared in `SettingsScreen`)
 | Key | Default | Effect |
 |-----|---------|--------|
 | `motionEffects` | `true` | `motionEffectsEnabled` env key — disables all animations when off |
 | `forceSubtitles` | `false` | Auto-selects first `.legible` track; disables `appliesMediaSelectionCriteriaAutomatically` |
 | `render4K` | `true` | `maxBitrate` 120 Mbps (on) / 20 Mbps (off) |
-| `autoPlayNextEpisode` | `true` | Auto-navigates to next episode via `AVPlayerItem.didPlayToEndTime` in `NativeVideoPresenter` (both platforms) |
-| `sleepTimerDefaultMinutes` | `0` (Off) | Duration for the sleep timer that starts on playback. Options: 0 / 15 / 30 / 45 / 60 / 90 min via `SleepTimerOption` |
-| `uiScale` | `1.0` | Font scale 80–130%. Bumps `ThemeManager._accentRevision` to force re-render |
-| `darkMode` | `true` | **Must be toggled via `themeManager.darkModeEnabled`**, not directly — direct writes don't bump `_accentRevision` |
+| `autoPlayNextEpisode` | `true` | Auto-navigates next via `didPlayToEndTime` |
+| `sleepTimerDefaultMinutes` | `0` | Sleep timer duration (0/15/30/45/60/90) via `SleepTimerOption` |
+| `uiScale` | `1.0` | Font scale 80–130%. Bumps `_accentRevision` |
+| `darkMode` | `true` | **Toggle via `themeManager.darkModeEnabled`**, not directly |
 | `accentColor` | `"blue"` | Set via `themeManager.accentColorKey` for same reason |
-| `home.showContinueWatching` | `true` | Toggles the Continue Watching row on Home |
-| `home.showRecentlyAdded` | `true` | Toggles the Recently Added row on Home |
-| `home.showGenreRows` | `true` | Toggles the 4 dynamic genre rows on Home |
-| `home.showWatchingNow` | `true` | Toggles the Watching Now row on Home |
-| `detail.showQualityBadges` | `true` | Toggles the resolution/HDR/codec/audio pill row on `MediaDetailScreen` |
-| `debug.fastSleepTimer` | `false` | Overrides sleep duration to 15 s — for testing the "Still watching?" prompt |
-| `debug.showSkipToEnd` | `false` | Shows an "End" button in the player that seeks to `(duration − 15 s)` — for testing end-of-series overlay |
+| `home.showContinueWatching` | `true` | Continue Watching row |
+| `home.showRecentlyAdded` | `true` | Recently Added row |
+| `home.showGenreRows` | `true` | All 4 genre rows |
+| `home.showWatchingNow` | `true` | Watching Now row |
+| `detail.showQualityBadges` | `true` | Quality pill row on `MediaDetailScreen` |
+| `debug.fastSleepTimer` | `false` | Overrides sleep to 15 s |
+| `debug.showSkipToEnd` | `false` | "End" button seeking to `(duration − 15 s)` |
 
 ### Quick user switch
-`UserSwitchSheet` (launched from Settings → Account) — two-step flow: grid of server users with their primary images → password prompt → re-auth. Updates `AppState.accessToken` / `currentUserId` and calls `apiClient.reconnect(url:accessToken:)` without clearing the server URL, then emits a success toast and dismisses. Errors stay inline so the user can retry.
+`UserSwitchSheet` (Settings → Account) — two-step: user grid → password prompt → re-auth. Updates `AppState.accessToken` / `currentUserId`, calls `apiClient.reconnect(url:accessToken:)` without clearing server URL, emits success toast, dismisses. Errors stay inline.
 
-### Refresh Catalogue
-Settings → Server has a "Refresh Catalogue" row that calls `apiClient.clearCache()` and posts `.cinemaxShouldRefreshCatalogue`. `HomeScreen` and `MediaLibraryScreen` observe this notification and reload. Fires a success toast. Single source of truth for forcing a re-fetch — no per-page refresh buttons.
+### Refresh Catalogue (single trigger)
+Settings → Server has "Refresh Catalogue" → `apiClient.clearCache()` + posts `.cinemaxShouldRefreshCatalogue`. `HomeScreen` and `MediaLibraryScreen` observe this and reload. Success toast. **No per-page refresh buttons** — Settings is the single source of truth. iOS also gets `.refreshable { reload() }`.
 
 ### Debug section
-Settings → Interface → Debug holds testing toggles. Always visible (not gated by `#if DEBUG`) so QA / power users don't need a custom build. Icons are orange to signal developer territory.
+Always visible (not `#if DEBUG`-gated) so QA / power users don't need a custom build. Icons orange to signal developer territory.
 
 ## MediaDetailScreen
 
-- `MediaDetailViewModel` auto-resolves Episode/Season → parent Series (fetches by `seriesID`, loads seasons + episodes). Also calls `getNextUp()` for series to populate `nextUpEpisode`. `selectSeason()` uses a generation counter to discard stale results on rapid selection
-- `nextUpEpisodes: [BaseItemDto]` — when `nextUpEpisode.seasonID ≠ selectedSeasonId` (e.g. series season boundary), the next-up's season episodes are fetched separately so `episodeNavigation(for:)` can build prev/next refs for the resume button
-- Uses `resolvedType` (not initial `itemType`) for layout decisions
-- tvOS: overview text uses `.focusable()` for focus-driven scrolling past non-interactive content
-- **tvOS detail refresh**: `VideoPlayerCoordinator` has `lastDismissedAt: Date?`; updated via `onDismiss` callback in `NativeVideoPresenter` (triggered by `TVDismissDelegate`); `MediaDetailScreen` observes `.onChange(of: coordinator.lastDismissedAt)` to reload after the player is dismissed (iOS reloads automatically via `.task` on NavigationLink pop)
+- `MediaDetailViewModel` auto-resolves Episode/Season → parent Series (by `seriesID`, loads seasons + episodes) and calls `getNextUp()` to populate `nextUpEpisode`. `selectSeason()` uses a generation counter to discard stale results on rapid selection.
+- `nextUpEpisodes: [BaseItemDto]` — when `nextUpEpisode.seasonID ≠ selectedSeasonId`, the next-up's season is fetched separately so `episodeNavigation(for:)` can build prev/next for the resume button.
+- Use `resolvedType` (not initial `itemType`) for layout decisions.
+- tvOS overview text uses `.focusable()` for focus-driven scrolling past non-interactive content.
+- **tvOS detail refresh**: `VideoPlayerCoordinator.lastDismissedAt: Date?` updated via `onDismiss` (triggered by `TVDismissDelegate`); `MediaDetailScreen` observes `.onChange(of: coordinator.lastDismissedAt)` to reload after dismiss (iOS reloads automatically via `.task` on NavigationLink pop).
 
-**Resume / next-up logic in `actionButtons`**: the parent `actionButtons(_:)` method resolves data and delegates rendering to `PlayActionButtonsSection: View, Equatable` (defined at the bottom of `MediaDetailScreen.swift`). Custom `nonisolated static func ==` compares resume state + prev/next episode identity and explicitly ignores the `epNavigator` closure — so `.equatable()` short-circuits re-renders when unrelated view-model state (e.g. `selectedSeasonId`) changes but the play buttons' inputs haven't.
-- Movie with `playbackPositionTicks > 0` and not `isPlayed`: shows progress bar (accent fill, `playButtonWidth` wide) + `loc.remainingTime(minutes:)` text + "Lecture" button that resumes at saved position via `PlayLink(startTime:)`
-- Series: uses `viewModel.nextUpEpisode` (from `getNextUp`). In-progress episode → progress bar + remaining time + resume button. Finished/next episode → episode label + regular play button. Falls back to series-level play if no next-up
-- **Play from beginning**: when `showResume` is true, a secondary ghost-styled `PlayLink` button (`detail.playFromBeginning`, SF Symbol `backward.end.fill`) is rendered under the resume button with `startTime: nil`. Only shown when a resume position exists — otherwise the single primary button already starts from 0
-- `userData.playbackPositionTicks` and `runTimeTicks` are both `Int?` (not `Int64`); `isPlayed` is `userData.isPlayed: Bool?`
-- Episode rows show a thin accent progress bar overlay at the bottom of the thumbnail for partially-watched episodes
+**Resume / next-up in `actionButtons`**: parent `actionButtons(_:)` resolves data and delegates rendering to `PlayActionButtonsSection: View, Equatable` (bottom of `MediaDetailScreen.swift`). Custom `nonisolated static func ==` compares resume state + prev/next episode identity and explicitly ignores the `epNavigator` closure — so `.equatable()` short-circuits re-renders when unrelated VM state changes.
+- Movie with `playbackPositionTicks > 0` and not `isPlayed`: progress bar (accent, `playButtonWidth`) + `loc.remainingTime(minutes:)` + "Lecture" resuming via `PlayLink(startTime:)`.
+- Series: uses `viewModel.nextUpEpisode`. In-progress → progress bar + remaining + resume. Finished/next → episode label + play. Falls back to series-level play if no next-up.
+- **Play from beginning**: when `showResume`, a secondary ghost `PlayLink` (`detail.playFromBeginning`, `backward.end.fill`) under the resume button with `startTime: nil`.
+- `userData.playbackPositionTicks` and `runTimeTicks` are `Int?` (not `Int64`); `isPlayed` is `userData.isPlayed: Bool?`.
+- Episode rows show thin accent progress overlay at thumbnail bottom for partially-watched episodes.
 
-**Quality badges** (`MediaQualityBadges.swift`):
-- Horizontal pill row between `actionButtons` and overview text. Gated on `@AppStorage("detail.showQualityBadges")` (default `true`, toggleable in Settings > Interface > Detail Page)
-- Derived from `item.mediaSources?.first` — first `.video` stream for resolution/HDR/video codec, default audio stream (`defaultAudioStreamIndex`) for audio format/channels
-- Resolution: height thresholds → "4K" / "1080p" / "720p" / "SD"
-- HDR: `VideoRangeType` maps to "Dolby Vision" (any `dovi*` case), "HDR10+", "HDR10", "HDR" (for `hlg`); `VideoRange.hdr` as fallback. No badge for SDR
-- Video codec: "HEVC" (hevc/h265), "H.264", "AV1", "VP9", else uppercased raw codec
-- Audio format: first-hit priority — Atmos (from `profile`/`displayTitle`), TrueHD, "Dolby Digital+" (EAC3), "Dolby Digital" (AC3), DTS, AAC, FLAC, Opus, MP3, else uppercased raw codec
-- Channels: `channelLayout` uppercased (Stereo/Mono title-cased); fallback from `channels` count (8→"7.1", 6→"5.1", 2→"Stereo", 1→"Mono")
-- View returns `EmptyView()` when no streams produce any badges
+**Quality badges** (`MediaQualityBadges.swift`): pill row between `actionButtons` and overview. Gated on `@AppStorage("detail.showQualityBadges")`. Derived from `item.mediaSources?.first` — first `.video` stream for resolution/HDR/codec, default audio stream (`defaultAudioStreamIndex`) for format/channels.
+- Resolution by height: "4K" / "1080p" / "720p" / "SD".
+- HDR: `VideoRangeType` → "Dolby Vision" (any `dovi*`), "HDR10+", "HDR10", "HDR" (for `hlg`); `VideoRange.hdr` as fallback. No badge for SDR.
+- Video codec: "HEVC" (hevc/h265), "H.264", "AV1", "VP9", else uppercased raw.
+- Audio format (first-hit): Atmos (from `profile`/`displayTitle`), TrueHD, "Dolby Digital+" (EAC3), "Dolby Digital" (AC3), DTS, AAC, FLAC, Opus, MP3, else uppercased raw.
+- Channels: `channelLayout` uppercased (Stereo/Mono title-cased); fallback from count (8→7.1, 6→5.1, 2→Stereo, 1→Mono).
+- Returns `EmptyView()` when no streams produce badges.
 
-**Episode navigation wiring**:
-- `episodeNavigation(for:)` — O(1) lookup from precomputed `viewModel.episodeNavigationMap` (current season) or `viewModel.nextUpNavigationMap` (cross-season next-up). Maps are rebuilt in `MediaDetailViewModel` whenever episodes change
-- Both `actionButtons` (next-up episode) and each `episodeRow` pass `previousEpisode`, `nextEpisode`, `episodeNavigator` to `PlayLink`
+**Episode navigation wiring**: `episodeNavigation(for:)` is O(1) lookup from precomputed `viewModel.episodeNavigationMap` (current season) or `nextUpNavigationMap` (cross-season next-up). Both `actionButtons` and each `episodeRow` pass `previousEpisode`, `nextEpisode`, `episodeNavigator` to `PlayLink`.
 
-**Ratings row** (`ratingsRow`): backdrop-adjacent. Shows `communityRating` (yellow star + `%.1f`) and `criticRating` (Rotten-Tomatoes-style icon — green if ≥ 60, red otherwise — + `%d%%`). Either or both may be absent.
+**Ratings row**: backdrop-adjacent. `communityRating` (yellow star + `%.1f`) and `criticRating` (Rotten-Tomatoes-style — green if ≥ 60, red otherwise — + `%d%%`). Either or both optional.
 
-**Studio / Network label** (`studioLine`): below the overview. Up to 2 names from `item.studios`. Label reads "STUDIO" for movies, "NETWORK" for series. Returns `EmptyView` when the array is empty.
+**Studio / Network label** (`studioLine`): below overview. Up to 2 names from `item.studios`. Label "STUDIO" for movies, "NETWORK" for series. `EmptyView` when empty.
 
-**Episode metadata line** (`episodeMetadataLine`): shared helper used by both the tvOS `episodeRow` and iOS `iOSEpisodeCard`. Combines with ` • ` separator:
-- If in-progress (not `isPlayed`, `playbackPositionTicks > 0`, remaining > 0): "Xm remaining" via `loc.remainingTime(minutes:)`
-- Else if `runTimeTicks > 0`: total runtime via `detail.runtime.min`
-- Plus `premiereDate` formatted as `.dateTime.month(.abbreviated).day().year()` when present
+**Episode metadata line** (`episodeMetadataLine`): shared by tvOS `episodeRow` and iOS `iOSEpisodeCard`. Joined with ` • `:
+- In-progress (not `isPlayed`, `ticks > 0`, remaining > 0): "Xm remaining" via `loc.remainingTime(minutes:)`.
+- Else if `runTimeTicks > 0`: total runtime via `detail.runtime.min`.
+- Plus `premiereDate` as `.dateTime.month(.abbreviated).day().year()` when present.
 
 ## HomeScreen
 
-- `HomeViewModel` loads `resumeItems` (in-progress items) and `latestItems` in parallel via `TaskGroup`
-- `heroItem = resumeItems.first ?? latestItems.first`
-- **Resume navigation**: after the initial load, for each episode in `resumeItems`, the season's episode list is fetched (grouped by `seasonID` to avoid duplicate requests). Per season, `precomputeEpisodeRefs(_:)` (in `PlayLink.swift`) builds the `(refs, indexByID)` pair *once*, then each episode calls the O(1) `buildEpisodeNavigation(for:refs:indexByID:apiClient:userId:)` overload. Results land in `resumeNavigation: [String: (previous: EpisodeRef?, next: EpisodeRef?, navigator: EpisodeNavigator?)]`. `MediaDetailViewModel.makeNavigationMap(from:)` uses the same helper.
-- Both the hero `PlayLink` and each "Reprendre" card `PlayLink` pass:
-  - `startTime` — from `playbackPositionTicks / 10_000_000` (nil for items with no progress)
-  - `previousEpisode`, `nextEpisode`, `episodeNavigator` — looked up from `resumeNavigation[id]` (nil for movies)
+- `HomeViewModel` loads `resumeItems` + `latestItems` in parallel via `TaskGroup`.
+- `heroItem = resumeItems.first ?? latestItems.first`.
+- **Resume navigation**: for each resume episode, season's episode list is fetched (grouped by `seasonID` to dedupe). `precomputeEpisodeRefs(_:)` (in `PlayLink.swift`) builds `(refs, indexByID)` once per season; each episode calls the O(1) `buildEpisodeNavigation(for:refs:indexByID:apiClient:userId:)` overload. Results in `resumeNavigation: [String: (previous, next, navigator)]`. `MediaDetailViewModel.makeNavigationMap(from:)` uses the same helper.
+- Hero and each "Reprendre" `PlayLink` pass `startTime` (from `ticks / 10_000_000`, nil for no-progress items) + `previousEpisode`/`nextEpisode`/`episodeNavigator` from `resumeNavigation[id]` (nil for movies).
 
-**Genre rows**: `HomeViewModel.genreRows: [GenreRow]` where `GenreRow.state` is `.items([BaseItemDto])` or `.failed`. After loading resume/latest, fetches all genres via `getGenres(userId:includeItemTypes: [.movie, .series])`, shuffles and picks 4. Each genre's items are fetched in parallel via `TaskGroup` using `getItems(sortBy: [.random], genres: [genre], limit: 10, includeItemTypes: [.movie, .series])`. Empty-success rows are dropped; *failures* become `.failed` so the UI can render a retry capsule (wired to `HomeViewModel.retryGenre(_:using:)`, updates the row in place) — transient server errors don't just make content disappear. Non-failed rows render as `ContentRow` with `PosterCard` inside `NavigationLink` to `MediaDetailScreen`.
+**Genre rows**: `genreRows: [GenreRow]` where `state` is `.items([BaseItemDto])` or `.failed`. After resume/latest, fetches all genres via `getGenres(userId:includeItemTypes: [.movie, .series])`, shuffles, picks 4. Items fetched in parallel via `TaskGroup` (`getItems(sortBy: [.random], genres: [genre], limit: 10, includeItemTypes: [.movie, .series])`). Empty-success rows dropped; **failures become `.failed`** so UI renders a retry capsule (wired to `retryGenre(_:using:)`) — transient errors don't make content silently disappear.
 
-**Watching Now row**: `HomeViewModel.activeSessions` — fetched via `getActiveSessions(activeWithinSeconds: 60)`, filtered to drop the current user and sessions with no `nowPlayingItem`. Rendered with `WideCard` + a red "LIVE" pill overlay, navigates to the item's `MediaDetailScreen` on tap.
+**Watching Now**: `activeSessions` via `getActiveSessions(activeWithinSeconds: 60)`, filtered to drop current user and sessions without `nowPlayingItem`. `WideCard` + red "LIVE" pill overlay.
 
-**Configurable layout** (`@AppStorage`, declared in `SettingsScreen.swift`, UI in Settings > Interface > Home Page):
-| Key | Default | Row |
-|-----|---------|-----|
-| `home.showContinueWatching` | `true` | Continue Watching |
-| `home.showRecentlyAdded` | `true` | Recently Added |
-| `home.showGenreRows` | `true` | All 4 genre rows (block-level toggle) |
-| `home.showWatchingNow` | `true` | Watching Now (other users) |
+**Configurable layout** (all default `true`): `home.showContinueWatching`, `home.showRecentlyAdded`, `home.showGenreRows` (block-level), `home.showWatchingNow`. Hero is never gated.
 
-Hero is never gated — always renders when `heroItem` is non-nil.
+**Empty state**: when `heroItem`, resume, latest, and genre rows are all empty → `EmptyStateView` with Refresh action, wrapped in `ScrollView` so pull-to-refresh still works.
 
-**Refresh**: `.refreshable { await viewModel.reload(using: appState) }` on iOS. Both platforms observe `.cinemaxShouldRefreshCatalogue` (posted by Settings → Server → Refresh Catalogue) and call `viewModel.reload`. No in-page refresh pill — Settings is the single trigger. `HomeViewModel.reload(using:)` repopulates everything including genre rows, active sessions, and `resumeNavigation` (cleared before rebuild to avoid stale prev/next refs).
-
-**Empty state**: when `heroItem`, `resumeItems`, `latestItems` and `genreRows` are all empty, renders `EmptyStateView` with a "Your library is empty" message and a Refresh action wrapped in a `ScrollView` so pull-to-refresh still works.
-
-**Scroll-to-top on reappearance (tvOS)**: content is wrapped in `ScrollViewReader` with a zero-height `.id("home.top")` sentinel at the top. `.onAppear` fires `proxy.scrollTo("home.top", anchor: .top)` whenever the screen re-appears (after a deep nav pop or tab switch). This surfaces the system top tab bar which can otherwise stay hidden behind scrolled content. Same pattern applies in `MovieLibraryScreen`, `SearchScreen`, and Settings tvOS landing.
+**Scroll-to-top on reappearance (tvOS)**: content wrapped in `ScrollViewReader` with a zero-height `.id("home.top")` sentinel. `.onAppear` fires `proxy.scrollTo("home.top", anchor: .top)` so the system top tab bar resurfaces after deep-nav pop or tab switch. Same pattern in `MovieLibraryScreen`, `SearchScreen`, and Settings tvOS landing.
 
 ## SearchScreen
 
-- `SearchViewModel.search(using:)` debounces by 400 ms then calls `searchItems(userId:searchTerm:limit:30)`
-- **Decomposition**: `SearchScreen.swift` owns the screen shell; two file-private structs live at the bottom — `VoiceSearchButton` (iOS-only, owns its own `isPulsing` state) and `SearchResultsGrid` + `SearchResultCard` (grid + poster card). Keeps the screen struct readable and lets SwiftUI skip the grid diff when parent state changes.
-- iOS: microphone (`VoiceSearchButton`) launches `SpeechRecognitionHelper` (SFSpeechRecognizer + AVAudioEngine wrapper) for voice search
-- **Surprise Me**: two pills ("Surprise movie" / "Surprise series") in the search empty state. Backed by `fetchRandomMovie(using:)` / `fetchRandomSeries(using:)` which call `getItems(includeItemTypes: [.movie or .series], sortBy: [.random], limit: 1)`. Two separate methods (not one parameterized) because Swift 6 strict concurrency flags a `[BaseItemKind]` array built from a function parameter as non-Sendable when crossing to the API actor — literal `[.movie]` / `[.series]` arrays work fine. On success pushes `MediaDetailScreen` via `navigationDestination(item:)`; on empty library emits an error toast
-- **tvOS scroll-to-top**: wrapped in `ScrollViewReader` with a sentinel, `.onAppear` scrolls to top so the system tab bar resurfaces after a deep-nav pop
+- `SearchViewModel.search(using:)` debounces 400 ms → `searchItems(userId:searchTerm:limit:30)`.
+- **Decomposition**: `SearchScreen.swift` owns the shell; file-private structs at bottom — `VoiceSearchButton` (iOS-only, owns `isPulsing`) and `SearchResultsGrid` + `SearchResultCard`. Lets SwiftUI skip grid diff on parent state changes.
+- iOS mic → `SpeechRecognitionHelper` (SFSpeechRecognizer + AVAudioEngine wrapper).
+- **Surprise Me**: two pills in the empty state. `fetchRandomMovie(using:)` / `fetchRandomSeries(using:)` call `getItems(includeItemTypes: [.movie or .series], sortBy: [.random], limit: 1)`. Two separate methods (not parameterized) because Swift 6 flags a `[BaseItemKind]` built from a parameter as non-Sendable when crossing to the API actor — literal arrays work fine. Success pushes `MediaDetailScreen` via `navigationDestination(item:)`; empty library emits error toast.
 
 ## Localization
 
-- `LocalizationManager` (`@Observable`, injected from `AppNavigation`). Default: French (`fr`), also English (`en`)
-- All strings via `loc.localized("key")` or `loc.localized("key", args...)` — never hardcoded
-- Strings at `Resources/{lang}.lproj/Localizable.strings`
-- Reactivity: `@ObservationIgnored` + `@AppStorage` + `_revision` counter pattern (same as `ThemeManager`)
-- Plural-aware helpers live on `LocalizationManager` itself (e.g. `remainingTime(minutes:)` picks `home.remainingTime.hours` vs `.minutes`). Use the helper at every call site rather than branching inline.
+- `LocalizationManager` (`@Observable`, injected from `AppNavigation`). Default `fr`, also `en`.
+- All strings via `loc.localized("key")` / `loc.localized("key", args...)` — never hardcoded.
+- Strings at `Resources/{lang}.lproj/Localizable.strings`.
+- Reactivity: `@ObservationIgnored` + `@AppStorage` + `_revision` counter (same as `ThemeManager`).
+- Plural-aware helpers on `LocalizationManager` (e.g. `remainingTime(minutes:)` picks `home.remainingTime.hours` vs `.minutes`). Use the helper, not inline branching.
 
 ## Toasts
 
-- `ToastCenter` (`@Observable`, injected at `AppNavigation` root) — single-toast queue with auto-dismiss
-- `ToastOverlay` renders a top-anchored glass pill (level-tinted SF Symbol + title + optional message) that slides in from the top safe area
-- API: `.success(_:)`, `.error(_:)`, `.info(_:)`, all with optional `message:` and `duration:` parameters
-- Use for: action feedback (Refresh Catalogue, user switch success), recoverable error surfaces. Do NOT use for critical errors that need user decision — use `UIAlertController` instead
+- `ToastCenter` (`@Observable`, injected at `AppNavigation` root) — single-toast queue with auto-dismiss.
+- `ToastOverlay` renders a top-anchored glass pill (level-tinted SF Symbol + title + optional message).
+- API: `.success(_:)`, `.error(_:)`, `.info(_:)` with optional `message:` and `duration:`.
+- Use for action feedback and recoverable errors. NOT for critical errors needing a user decision — use `UIAlertController`.
 
 ## Empty states
 
-- `EmptyStateView` (icon + title + optional subtitle + optional action button)
-- Used by:
-  - Home when `heroItem` / resume / latest / genre rows are all empty
-  - Filtered library grid when sort + filter yields no results (offers "Clear filters" action that resets `LibrarySortFilterState()`)
-  - `UserSwitchSheet` when user list is empty
+`EmptyStateView` (icon + title + optional subtitle + optional action). Used by: Home when everything empty; filtered library grid when no results (offers "Clear filters" that resets `LibrarySortFilterState()`); `UserSwitchSheet` when empty.
 
 ## Dynamic Type (iOS)
 
-- `.dynamicTypeSize(.xSmall ... .accessibility2)` applied at `AppNavigation` root — honors the user's OS-level text-size preference while capping below accessibility sizes that would break hero/tab-bar layouts
-- `CinemaFont.dynamicBody / dynamicBodyLarge / dynamicLabel(_:)` variants use `UIFontMetrics(forTextStyle:).scaledValue(for:)` so the final size is `baseSize × CinemaScale.factor (app uiScale) × dynamicTypeMultiplier (OS)`
-- Apply dynamic variants only to reading-heavy surfaces (overviews, settings rows, list cells). Hero / display / headline titles keep the fixed `CinemaFont.body` / `.headline()` variants to protect layout
+- `.dynamicTypeSize(.xSmall ... .accessibility2)` at `AppNavigation` root — honors OS text-size preference while capping below accessibility sizes that break hero/tab-bar layouts.
+- `CinemaFont.dynamicBody / dynamicBodyLarge / dynamicLabel(_:)` use `UIFontMetrics(forTextStyle:).scaledValue(for:)` so final size is `baseSize × CinemaScale.factor (app uiScale) × dynamicTypeMultiplier (OS)`.
+- Apply dynamic variants only to reading-heavy surfaces. Hero/display/headline titles keep fixed `CinemaFont.body` / `.headline()` to protect layout.
 
 ## Image Patterns
 
-- `ImageURLBuilder` → `/Items/{id}/Images/{type}` URLs
-- **Backdrop sizing**: Use `ImageURLBuilder.screenPixelWidth` (device pixel width) for backdrops — never hardcode `1920`. Matches actual display density on all devices
-- **Image cache**: `AppNavigation.init()` configures `ImagePipeline.shared` with a 500 MB disk cache (`com.cinemax.images`)
-- **Backdrop fallback**: `item.parentBackdropItemID ?? item.seriesID ?? item.id`
-- **All image loading via `CinemaLazyImage`** — never use `LazyImage` directly. Params: `url`, `fallbackIcon: String?` (nil = no icon), `fallbackBackground: Color`, `showLoadingIndicator: Bool`
-- **Card containers**: `Color.clear` + `.aspectRatio()` + `.frame(maxWidth: .infinity)` + `.overlay { CinemaLazyImage }` + `.clipped()`
-- **Backdrop (full-bleed ZStack)**: `CinemaLazyImage` used directly inside a `ZStack` must have `.frame(maxWidth: .infinity, maxHeight: .infinity)` — without it, the ZStack sizes from the image's natural dimensions (e.g. 1920px), pushing the title VStack off-screen. Also use `LazyVStack(alignment: .leading)` as the outer container.
-- **PosterCard title alignment**: hidden `Text("M\nM").hidden()` placeholder + actual title overlaid top-aligned → uniform row height regardless of title length
+- `ImageURLBuilder` → `/Items/{id}/Images/{type}`.
+- **Backdrop sizing**: use `ImageURLBuilder.screenPixelWidth` — never hardcode `1920`.
+- **Image cache**: `AppNavigation.init()` configures `ImagePipeline.shared` with a 500 MB disk cache (`com.cinemax.images`).
+- **Backdrop fallback**: `item.parentBackdropItemID ?? item.seriesID ?? item.id`.
+- **All image loading via `CinemaLazyImage`** — never `LazyImage` directly. Params: `url`, `fallbackIcon: String?`, `fallbackBackground: Color`, `showLoadingIndicator: Bool`.
+- **Card containers**: `Color.clear` + `.aspectRatio()` + `.frame(maxWidth: .infinity)` + `.overlay { CinemaLazyImage }` + `.clipped()`.
+- **Backdrop (full-bleed ZStack)**: `CinemaLazyImage` inside a `ZStack` must have `.frame(maxWidth: .infinity, maxHeight: .infinity)` — otherwise ZStack sizes from the image's natural dimensions (e.g. 1920px), pushing the title VStack off-screen. Outer container must be `LazyVStack(alignment: .leading)`.
+- **PosterCard title alignment**: hidden `Text("M\nM").hidden()` placeholder + actual title overlaid top-aligned → uniform row height.
 
 ## App Icons
 
-- **iOS**: `Resources/Assets.xcassets/AppIcon.appiconset/` — 1024×1024 in three variants (light, dark, tinted)
-- **tvOS**: `Resources/Assets.xcassets/App Icon & Top Shelf Image.brandassets/` — 3-layer parallax imagestack + Top Shelf (1920×720) + Top Shelf Wide (2320×720)
-- **In-app logo**: `Resources/Assets.xcassets/AppLogo.imageset/` — iOS: full icon; tvOS: front parallax layer only (transparent bg)
-- **Standalone source**: `appIcon.png` at project root
+- **iOS**: `Resources/Assets.xcassets/AppIcon.appiconset/` — 1024×1024 in three variants (light, dark, tinted).
+- **tvOS**: `Resources/Assets.xcassets/App Icon & Top Shelf Image.brandassets/` — 3-layer parallax imagestack + Top Shelf (1920×720) + Top Shelf Wide (2320×720).
+- **In-app logo**: `Resources/Assets.xcassets/AppLogo.imageset/` — iOS full icon; tvOS front parallax layer only (transparent bg).
+- **Standalone source**: `appIcon.png` at project root.
 
 ## Build
 

--- a/Cinemax.xcodeproj/project.pbxproj
+++ b/Cinemax.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		2795FD90A8FA67405535C2B7 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 653AA083295D61DCACCEC0A1 /* PrivacyInfo.xcprivacy */; };
 		28247D55CC29D95670733239 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81F4A35762E8619A3D24747 /* EmptyStateView.swift */; };
 		2853B78C03BA5522E348B212 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 280786386ED204F8AAAF36B6 /* Assets.xcassets */; };
+		28607C1A48373994CB677989 /* AdaptiveLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98492ED27F16C895D0E1E0A /* AdaptiveLayout.swift */; };
 		28909321B0A490C0E70342E4 /* GlassTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59CE3A78C397CC15A81F1635 /* GlassTextField.swift */; };
 		289B6BE095E7F76554DAE841 /* TrackPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5D31C0A9CB664FEB840DA3 /* TrackPickerSheet.swift */; };
 		28A82A58BDED7ACD5B9221F8 /* HomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D8CB8B2A5B48928CFF4A61 /* HomeScreen.swift */; };
@@ -110,6 +111,7 @@
 		A3B5BCE46E4207582861DBBE /* TVSeriesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0A181A9E709E7700EC2E95 /* TVSeriesScreen.swift */; };
 		A457ECA5B1E6FC13546B3306 /* ErrorStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929537FA4254CCBD87E276B3 /* ErrorStateView.swift */; };
 		A5BDB9B097C212892B4AEB36 /* BaseItemDto+Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BDB8AB3BF62513D67C2E16 /* BaseItemDto+Metadata.swift */; };
+		A8C1C7C4A4E243D4F959D865 /* AdaptiveLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98492ED27F16C895D0E1E0A /* AdaptiveLayout.swift */; };
 		AE92C836D641772893016E26 /* SettingsRowHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4049AE456C81ACB9DD77BA6B /* SettingsRowHelpers.swift */; };
 		B17B6055000707C83658C8DF /* LoginScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE7C8046FBDB91EFDDC0805 /* LoginScreen.swift */; };
 		B69DEDB39F1ACCA6FBE1EFAC /* SettingsAppearanceView+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44CF59AA409F235181A7D841 /* SettingsAppearanceView+iOS.swift */; };
@@ -189,14 +191,14 @@
 		59CE3A78C397CC15A81F1635 /* GlassTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassTextField.swift; sourceTree = "<group>"; };
 		5BF56288932318BE6C754F7B /* CinemaGlassTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CinemaGlassTheme.swift; sourceTree = "<group>"; };
 		611E44F72064D91AE6DBCC6C /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
-		653AA083295D61DCACCEC0A1 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		653AA083295D61DCACCEC0A1 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		69FA0DC94A5D41FE4D6DC0A2 /* HomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelTests.swift; sourceTree = "<group>"; };
 		6EAA0B8314F73A80686E650D /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		71EDA47106672004DE07BDCF /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		74EFA596296688A96C374135 /* SleepTimerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepTimerController.swift; sourceTree = "<group>"; };
 		75FE585AF0EC0507240E8772 /* APICacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICacheTests.swift; sourceTree = "<group>"; };
 		78377E8E832D65F7226A2A06 /* AppNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNavigation.swift; sourceTree = "<group>"; };
-		7D88DF3FEF51CF7E5E1C948A /* Cinemax.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Cinemax.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7D88DF3FEF51CF7E5E1C948A /* Cinemax.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Cinemax.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7EB193219DC7306139A95B60 /* LibraryPosterCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryPosterCard.swift; sourceTree = "<group>"; };
 		7F79C18163C57966CF114BD2 /* SearchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModelTests.swift; sourceTree = "<group>"; };
 		8324C15002E8D55B4849D71F /* MediaDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDetailScreen.swift; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 		A6A30840A8AEBE5AA59B722F /* MovieLibraryScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieLibraryScreen.swift; sourceTree = "<group>"; };
 		A7C6E1A74D6EE64FD563385D /* CinemaxTVApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CinemaxTVApp.swift; sourceTree = "<group>"; };
 		A863021FF6B842EE2A0E27CA /* LoadingStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingStateView.swift; sourceTree = "<group>"; };
+		A98492ED27F16C895D0E1E0A /* AdaptiveLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveLayout.swift; sourceTree = "<group>"; };
 		AA0A181A9E709E7700EC2E95 /* TVSeriesScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVSeriesScreen.swift; sourceTree = "<group>"; };
 		AEA4717DCFEE46C5BE3F4787 /* PlayLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayLink.swift; sourceTree = "<group>"; };
 		B01CD5F39E429B665FA12B0C /* ServerSetupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSetupViewModelTests.swift; sourceTree = "<group>"; };
@@ -217,7 +220,7 @@
 		B171C71911F6E759AB1A0EDB /* MediaDetailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDetailViewModelTests.swift; sourceTree = "<group>"; };
 		B4426FD8BE586CC3296B2698 /* MediaQualityBadges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaQualityBadges.swift; sourceTree = "<group>"; };
 		BA0B2775D4776FF99A90FB12 /* WideCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WideCard.swift; sourceTree = "<group>"; };
-		BCC43AE61EC4C83ED88C63C1 /* CinemaxTV.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = CinemaxTV.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		BCC43AE61EC4C83ED88C63C1 /* CinemaxTV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CinemaxTV.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0E9157A106817FC0C04B450 /* SettingsScreen+tvOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsScreen+tvOS.swift"; sourceTree = "<group>"; };
 		C144D0A57021E0A0A783977B /* SearchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScreen.swift; sourceTree = "<group>"; };
 		C346F0B7AFF504DA6593370E /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
@@ -416,6 +419,7 @@
 			isa = PBXGroup;
 			children = (
 				F701053A07C8B6B1D912E9E6 /* Components */,
+				A98492ED27F16C895D0E1E0A /* AdaptiveLayout.swift */,
 				5BF56288932318BE6C754F7B /* CinemaGlassTheme.swift */,
 				D657D13170DAA4F01D4B99E8 /* FocusScaleModifier.swift */,
 				E9A353B49C5117D5F686F07B /* GlassModifiers.swift */,
@@ -537,8 +541,6 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 2620;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = 4A265CE224197B289D7A7B4E /* Build configuration list for PBXProject "Cinemax" */;
 			developmentRegion = fr;
@@ -609,6 +611,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				28607C1A48373994CB677989 /* AdaptiveLayout.swift in Sources */,
 				173F19747EE155F10F3B6115 /* AlphabeticalJumpBar.swift in Sources */,
 				2BC23AB09D961A04A91415F7 /* AppNavigation.swift in Sources */,
 				A5BDB9B097C212892B4AEB36 /* BaseItemDto+Metadata.swift in Sources */,
@@ -677,6 +680,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A8C1C7C4A4E243D4F959D865 /* AdaptiveLayout.swift in Sources */,
 				0A06186102AA10D92923583B /* AlphabeticalJumpBar.swift in Sources */,
 				8CE621C8D3CAD1DE98B6CA11 /* AppNavigation.swift in Sources */,
 				E71BC25CBB98F5DF97065B98 /* BaseItemDto+Metadata.swift in Sources */,
@@ -834,6 +838,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -889,6 +894,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "";
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = tvOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -908,6 +914,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -987,6 +994,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "";
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = tvOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Shared/DesignSystem/AdaptiveLayout.swift
+++ b/Shared/DesignSystem/AdaptiveLayout.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// Size-class-aware layout metrics for iOS.
+///
+/// Phone uses the existing compact values (unchanged). iPad (`horizontalSizeClass == .regular`)
+/// gets larger poster cards, denser adaptive grids, and roomier padding. tvOS is handled by
+/// the existing `#if os(tvOS)` branches at each call site and does not consult this helper.
+///
+/// Grids use `GridItem(.adaptive(minimum:))` on iPad so the column count auto-scales with
+/// available width (including sidebar, split view, Stage Manager). iPhone keeps its fixed
+/// column count so card sizing stays stable across its narrow range of widths.
+enum AdaptiveLayout {
+    /// Narrow compact horizontal class (iPhone) vs wide regular class (iPad).
+    enum Form {
+        case compact
+        case regular
+    }
+
+    static func form(horizontalSizeClass: UserInterfaceSizeClass?) -> Form {
+        horizontalSizeClass == .regular ? .regular : .compact
+    }
+
+    // MARK: - Horizontal-scroll card widths
+
+    /// 2:3 poster card in a horizontal-scroll row (HomeScreen recentlyAdded, genre rows).
+    static func posterCardWidth(for form: Form) -> CGFloat {
+        form == .regular ? 180 : 140
+    }
+
+    /// 16:9 wide card (HomeScreen continue-watching, watching-now).
+    static func wideCardWidth(for form: Form) -> CGFloat {
+        form == .regular ? 380 : 280
+    }
+
+    // MARK: - Grids (`LazyVGrid`)
+
+    /// Grid columns for 2:3 poster grids (search results, filtered library).
+    /// iPhone: fixed 3 flexible columns. iPad: adaptive minimum so landscape packs more.
+    static func posterGridColumns(for form: Form) -> [GridItem] {
+        switch form {
+        case .compact:
+            return Array(repeating: GridItem(.flexible(), spacing: 16), count: 3)
+        case .regular:
+            return [GridItem(.adaptive(minimum: 160), spacing: 16)]
+        }
+    }
+
+    /// Grid columns for browse-genre tiles (shorter, wider rectangles).
+    static func browseGenreColumns(for form: Form) -> [GridItem] {
+        switch form {
+        case .compact:
+            return Array(repeating: GridItem(.flexible(), spacing: CinemaSpacing.spacing3), count: 2)
+        case .regular:
+            return [GridItem(.adaptive(minimum: 220), spacing: CinemaSpacing.spacing3)]
+        }
+    }
+
+    /// Grid columns for the user-switch sheet. Smaller minimum since avatars are compact.
+    static func userGridColumns(for form: Form) -> [GridItem] {
+        switch form {
+        case .compact:
+            return Array(repeating: GridItem(.flexible(), spacing: CinemaSpacing.spacing3), count: 3)
+        case .regular:
+            return [GridItem(.adaptive(minimum: 150), spacing: CinemaSpacing.spacing3)]
+        }
+    }
+
+    // MARK: - Padding / content width
+
+    /// Horizontal screen padding for grids and scroll content.
+    static func horizontalPadding(for form: Form) -> CGFloat {
+        form == .regular ? CinemaSpacing.spacing6 : CinemaSpacing.spacing3
+    }
+
+    /// Maximum readable width for prose on large iPads (detail overviews, license body).
+    /// `nil` means "no cap — fill the container".
+    static func readingMaxWidth(for form: Form) -> CGFloat? {
+        form == .regular ? 900 : nil
+    }
+
+    // MARK: - Hero / backdrop heights
+
+    /// HomeScreen hero backdrop.
+    static func heroHeight(for form: Form) -> CGFloat {
+        form == .regular ? 500 : 360
+    }
+
+    /// MediaDetailScreen backdrop hero.
+    static func detailBackdropHeight(for form: Form) -> CGFloat {
+        form == .regular ? 460 : 310
+    }
+}

--- a/Shared/DesignSystem/FocusScaleModifier.swift
+++ b/Shared/DesignSystem/FocusScaleModifier.swift
@@ -36,6 +36,11 @@ struct CinemaFocusModifier: ViewModifier {
                 x: 0, y: 12
             )
             .animation(motionEnabled ? .easeInOut(duration: 0.2) : nil, value: isFocused)
+            #else
+            // iPad pointer hover. No-op on iPhone (no hover). `.lift` gives a gentle
+            // scale + shadow when motion is on; `.highlight` keeps the dim-only fallback
+            // when the user disables motion effects.
+            .hoverEffect(motionEnabled ? .lift : .highlight)
             #endif
     }
 }

--- a/Shared/Navigation/MainTabView.swift
+++ b/Shared/Navigation/MainTabView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct MainTabView: View {
-    @Environment(\.horizontalSizeClass) private var sizeClass
     @Environment(ThemeManager.self) private var themeManager
     @Environment(LocalizationManager.self) private var loc
     @State private var selectedTab: AppTab = .home
@@ -16,11 +15,7 @@ struct MainTabView: View {
             .environment(playerCoordinator)
             .task { playerCoordinator.localizationManager = loc }
         #else
-        if sizeClass == .regular {
-            sidebarLayout
-        } else {
-            tabBarLayout
-        }
+        iOSTabLayout
         #endif
     }
 
@@ -40,73 +35,49 @@ struct MainTabView: View {
     }
     #endif
 
-    // MARK: - Sidebar (iPad Landscape)
+    // MARK: - iOS / iPadOS — adaptive tab bar ↔ sidebar
 
-    private var sidebarLayout: some View {
-        NavigationSplitView {
-            sidebarContent
-        } detail: {
-            selectedTabView
-        }
-    }
-
-    private var sidebarContent: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(loc.localized("app.name"))
-                .font(.system(size: 24, weight: .bold))
-                .foregroundStyle(CinemaColor.onSurface)
-                .padding(.horizontal, 20)
-                .padding(.top, 20)
-                .padding(.bottom, 12)
-
-            ForEach(AppTab.allCases) { tab in
-                Button {
-                    selectedTab = tab
-                } label: {
-                    Label(loc.localized(tab.titleKey), systemImage: tab.icon)
-                        .font(.system(size: 17, weight: selectedTab == tab ? .semibold : .regular))
-                        .foregroundStyle(selectedTab == tab ? .white : CinemaColor.onSurfaceVariant)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.vertical, 12)
-                        .padding(.horizontal, 20)
-                        .background(
-                            selectedTab == tab
-                                ? Capsule().fill(themeManager.accentContainer)
-                                : nil
-                        )
-                }
-                .buttonStyle(.plain)
-                .padding(.horizontal, 8)
-            }
-
-            Spacer()
-        }
-        .frame(maxHeight: .infinity)
-        .background(CinemaColor.surfaceContainerLow.opacity(0.7))
-    }
-
-    // MARK: - Tab Bar (iPhone + iPad Portrait)
-
-    private var tabBarLayout: some View {
+    #if !os(tvOS)
+    /// Uses the iOS 18 `Tab` API with `.tabViewStyle(.sidebarAdaptable)` so iPhone gets
+    /// a bottom tab bar while iPad regular width gets a native sidebar. Replaces the
+    /// previous hand-built `NavigationSplitView` sidebar (which needed manual selection
+    /// highlight, capsule styling, and detail wiring).
+    private var iOSTabLayout: some View {
         TabView(selection: $selectedTab) {
-            ForEach(AppTab.allCases) { tab in
-                selectedView(for: tab)
-                    .tabItem {
-                        Label(loc.localized(tab.titleKey), systemImage: tab.icon)
-                    }
-                    .tag(tab)
+            Tab(value: AppTab.home) {
+                NavigationStack { HomeScreen() }
+            } label: {
+                Label(loc.localized("tab.home"), systemImage: "house.fill")
+            }
+            Tab(value: AppTab.movies) {
+                NavigationStack { MovieLibraryScreen() }
+            } label: {
+                Label(loc.localized("tab.movies"), systemImage: "film")
+            }
+            Tab(value: AppTab.tvShows) {
+                NavigationStack { TVSeriesScreen() }
+            } label: {
+                Label(loc.localized("tab.tvShows"), systemImage: "tv.fill")
+            }
+            Tab(value: AppTab.search, role: .search) {
+                NavigationStack { SearchScreen() }
+            } label: {
+                Label(loc.localized("tab.search"), systemImage: "magnifyingglass")
+            }
+            Tab(value: AppTab.settings) {
+                NavigationStack { SettingsScreen() }
+            } label: {
+                Label(loc.localized("tab.settings"), systemImage: "gearshape")
             }
         }
+        .tabViewStyle(.sidebarAdaptable)
         .tint(themeManager.accentContainer)
     }
+    #endif
 
-    // MARK: - Tab Content
+    // MARK: - Tab Content (tvOS only; iOS uses Tab blocks above)
 
-    @ViewBuilder
-    private var selectedTabView: some View {
-        selectedView(for: selectedTab)
-    }
-
+    #if os(tvOS)
     @ViewBuilder
     private func selectedView(for tab: AppTab) -> some View {
         switch tab {
@@ -122,6 +93,7 @@ struct MainTabView: View {
             NavigationStack { SettingsScreen() }
         }
     }
+    #endif
 }
 
 // MARK: - Tab Definition

--- a/Shared/Screens/HomeScreen.swift
+++ b/Shared/Screens/HomeScreen.swift
@@ -6,6 +6,9 @@ struct HomeScreen: View {
     @Environment(AppState.self) private var appState
     @Environment(ThemeManager.self) private var themeManager
     @Environment(LocalizationManager.self) private var loc
+    #if !os(tvOS)
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    #endif
     @State private var viewModel = HomeViewModel()
 
     @AppStorage("home.showContinueWatching") private var showContinueWatching: Bool = true
@@ -177,122 +180,121 @@ struct HomeScreen: View {
 
     @ViewBuilder
     private func heroSection(_ item: BaseItemDto) -> some View {
-        ZStack(alignment: .bottomLeading) {
-            // Backdrop — episodes/seasons don't have their own backdrop; use the parent (series)
-            if let backdropId = item.parentBackdropItemID ?? item.seriesID ?? item.id {
-                CinemaLazyImage(
-                    url: appState.imageBuilder.imageURL(itemId: backdropId, imageType: .backdrop, maxWidth: ImageURLBuilder.screenPixelWidth),
-                    fallbackIcon: nil,
-                    fallbackBackground: CinemaColor.surfaceContainerLow
-                )
-                .accessibilityHidden(true)
-            }
-
-            // Gradient overlays
-            CinemaGradient.heroOverlay
-
-            // Content
-            VStack(alignment: .leading, spacing: heroPadding > 60 ? 16 : 10) {
-                // Badges
-                HStack(spacing: 8) {
-                    if let rating = item.officialRating {
-                        RatingBadge(rating: rating)
-                    }
-
-                    metadataText(for: item)
-                }
-                .foregroundStyle(CinemaColor.onSurfaceVariant)
-
-                // Title
-                Text(item.name ?? "")
-                    .font(.system(size: heroTitleSize, weight: .black))
-                    .tracking(-1.5)
-                    .foregroundStyle(.white)
-                    .textCase(.uppercase)
-                    .lineLimit(2)
-
-                // Overview — hidden on iOS to keep hero compact
-                #if os(tvOS)
-                if let overview = item.overview {
-                    Text(overview)
-                        .font(.system(size: overviewFontSize))
-                        .foregroundStyle(CinemaColor.onSurfaceVariant)
-                        .lineLimit(3)
-                        .frame(maxWidth: maxOverviewWidth, alignment: .leading)
-                }
-                #endif
-
-                // Action buttons
-                HStack(spacing: 12) {
-                    if let id = item.id {
-                        let heroNav = viewModel.resumeNavigation[id]
-                        let heroStart: Double? = {
-                            guard let ticks = item.userData?.playbackPositionTicks, ticks > 0 else { return nil }
-                            return Double(ticks) / 10_000_000
-                        }()
-                        PlayLink(
-                            itemId: id, title: item.name ?? "",
-                            startTime: heroStart,
-                            previousEpisode: heroNav?.previous, nextEpisode: heroNav?.next,
-                            episodeNavigator: heroNav?.navigator
-                        ) {
-                            HStack(spacing: CinemaSpacing.spacing2) {
-                                Text(loc.localized("action.play"))
-                                    .font(.system(size: heroPadding > 60 ? 28 : 18, weight: .bold))
-                                Image(systemName: "play.fill")
-                                    .font(.system(size: heroPadding > 60 ? 26 : 16, weight: .bold))
-                            }
-                            .foregroundStyle(.white)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, heroPadding > 60 ? CinemaSpacing.spacing4 : CinemaSpacing.spacing2)
-                            .padding(.horizontal, CinemaSpacing.spacing4)
-                            #if os(iOS)
-                            .background(themeManager.accentContainer)
-                            .clipShape(RoundedRectangle(cornerRadius: CinemaRadius.large))
-                            #endif
-                        }
-                        #if os(tvOS)
-                        .buttonStyle(CinemaTVButtonStyle(cinemaStyle: .accent))
-                        #else
-                        .buttonStyle(.plain)
-                        #endif
-                        .frame(width: playButtonWidth)
-
-                        NavigationLink {
-                            MediaDetailScreen(itemId: id, itemType: item.type ?? .movie)
-                        } label: {
-                            HStack(spacing: CinemaSpacing.spacing2) {
-                                Text(loc.localized("action.moreInfo"))
-                                    .font(.system(size: heroPadding > 60 ? 28 : 18, weight: .bold))
-                                    .lineLimit(1)
-                                Image(systemName: "info.circle")
-                                    .font(.system(size: heroPadding > 60 ? 26 : 16, weight: .bold))
-                            }
-                            .foregroundStyle(CinemaColor.onSurface)
-                            .padding(.vertical, heroPadding > 60 ? CinemaSpacing.spacing4 : CinemaSpacing.spacing2)
-                            .padding(.horizontal, CinemaSpacing.spacing4)
-                            #if os(iOS)
-                            .background(.ultraThinMaterial)
-                            .clipShape(RoundedRectangle(cornerRadius: CinemaRadius.large))
-                            #endif
-                        }
-                        #if os(tvOS)
-                        .buttonStyle(CinemaTVButtonStyle(cinemaStyle: .ghost))
-                        #else
-                        .buttonStyle(.plain)
-                        #endif
-                        .fixedSize()
-                    }
+        // `Color.clear` sizing driver pinned to `heroHeight`, with backdrop, gradient,
+        // and content layered as overlays. Overlays can't grow the parent frame — so
+        // the hero is guaranteed to be exactly `heroHeight` regardless of what the
+        // backdrop or content try to do. Prevents the iPad-landscape regression where
+        // ZStack sized from the CinemaLazyImage's natural dimensions and pushed the
+        // action buttons off-screen.
+        Color.clear
+            .frame(maxWidth: .infinity)
+            .frame(height: heroHeight)
+            .overlay {
+                if let backdropId = item.parentBackdropItemID ?? item.seriesID ?? item.id {
+                    CinemaLazyImage(
+                        url: appState.imageBuilder.imageURL(itemId: backdropId, imageType: .backdrop, maxWidth: ImageURLBuilder.screenPixelWidth),
+                        fallbackIcon: nil,
+                        fallbackBackground: CinemaColor.surfaceContainerLow
+                    )
+                    .accessibilityHidden(true)
                 }
             }
-            .padding(.horizontal, heroPadding)
-            .padding(.top, heroPadding)
-            .padding(.bottom, heroPadding + CinemaSpacing.spacing6)
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .frame(maxWidth: .infinity)
-        .frame(height: heroHeight)
-        .clipped()
+            .overlay { CinemaGradient.heroOverlay.allowsHitTesting(false) }
+            .overlay(alignment: .bottomLeading) {
+                VStack(alignment: .leading, spacing: heroPadding > 60 ? 16 : 10) {
+                    HStack(spacing: 8) {
+                        if let rating = item.officialRating {
+                            RatingBadge(rating: rating)
+                        }
+
+                        metadataText(for: item)
+                    }
+                    .foregroundStyle(CinemaColor.onSurfaceVariant)
+
+                    Text(item.name ?? "")
+                        .font(.system(size: heroTitleSize, weight: .black))
+                        .tracking(-1.5)
+                        .foregroundStyle(.white)
+                        .textCase(.uppercase)
+                        .lineLimit(2)
+
+                    #if os(tvOS)
+                    if let overview = item.overview {
+                        Text(overview)
+                            .font(.system(size: overviewFontSize))
+                            .foregroundStyle(CinemaColor.onSurfaceVariant)
+                            .lineLimit(3)
+                            .frame(maxWidth: maxOverviewWidth, alignment: .leading)
+                    }
+                    #endif
+
+                    HStack(spacing: 12) {
+                        if let id = item.id {
+                            let heroNav = viewModel.resumeNavigation[id]
+                            let heroStart: Double? = {
+                                guard let ticks = item.userData?.playbackPositionTicks, ticks > 0 else { return nil }
+                                return Double(ticks) / 10_000_000
+                            }()
+                            PlayLink(
+                                itemId: id, title: item.name ?? "",
+                                startTime: heroStart,
+                                previousEpisode: heroNav?.previous, nextEpisode: heroNav?.next,
+                                episodeNavigator: heroNav?.navigator
+                            ) {
+                                HStack(spacing: CinemaSpacing.spacing2) {
+                                    Text(loc.localized("action.play"))
+                                        .font(.system(size: heroPadding > 60 ? 28 : 18, weight: .bold))
+                                    Image(systemName: "play.fill")
+                                        .font(.system(size: heroPadding > 60 ? 26 : 16, weight: .bold))
+                                }
+                                .foregroundStyle(.white)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, heroPadding > 60 ? CinemaSpacing.spacing4 : CinemaSpacing.spacing2)
+                                .padding(.horizontal, CinemaSpacing.spacing4)
+                                #if os(iOS)
+                                .background(themeManager.accentContainer)
+                                .clipShape(RoundedRectangle(cornerRadius: CinemaRadius.large))
+                                #endif
+                            }
+                            #if os(tvOS)
+                            .buttonStyle(CinemaTVButtonStyle(cinemaStyle: .accent))
+                            #else
+                            .buttonStyle(.plain)
+                            #endif
+                            .frame(width: playButtonWidth)
+
+                            NavigationLink {
+                                MediaDetailScreen(itemId: id, itemType: item.type ?? .movie)
+                            } label: {
+                                HStack(spacing: CinemaSpacing.spacing2) {
+                                    Text(loc.localized("action.moreInfo"))
+                                        .font(.system(size: heroPadding > 60 ? 28 : 18, weight: .bold))
+                                        .lineLimit(1)
+                                    Image(systemName: "info.circle")
+                                        .font(.system(size: heroPadding > 60 ? 26 : 16, weight: .bold))
+                                }
+                                .foregroundStyle(CinemaColor.onSurface)
+                                .padding(.vertical, heroPadding > 60 ? CinemaSpacing.spacing4 : CinemaSpacing.spacing2)
+                                .padding(.horizontal, CinemaSpacing.spacing4)
+                                #if os(iOS)
+                                .background(.ultraThinMaterial)
+                                .clipShape(RoundedRectangle(cornerRadius: CinemaRadius.large))
+                                #endif
+                            }
+                            #if os(tvOS)
+                            .buttonStyle(CinemaTVButtonStyle(cinemaStyle: .ghost))
+                            #else
+                            .buttonStyle(.plain)
+                            #endif
+                            .fixedSize()
+                        }
+                    }
+                }
+                .padding(.horizontal, heroPadding)
+                .padding(.bottom, heroPadding + CinemaSpacing.spacing6)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .clipped()
     }
 
     // MARK: - Continue Watching
@@ -498,7 +500,7 @@ struct HomeScreen: View {
         #if os(tvOS)
         820
         #else
-        360
+        AdaptiveLayout.heroHeight(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass))
         #endif
     }
 
@@ -522,7 +524,10 @@ struct HomeScreen: View {
         #if os(tvOS)
         CinemaSpacing.spacing20
         #else
-        CinemaSpacing.spacing4
+        // Under 60 intentionally — the hero's "big-button" branch triggers above 60 (tvOS only).
+        AdaptiveLayout.form(horizontalSizeClass: sizeClass) == .regular
+            ? CinemaSpacing.spacing6
+            : CinemaSpacing.spacing4
         #endif
     }
 
@@ -546,7 +551,7 @@ struct HomeScreen: View {
         #if os(tvOS)
         400
         #else
-        280
+        AdaptiveLayout.wideCardWidth(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass))
         #endif
     }
 
@@ -554,7 +559,7 @@ struct HomeScreen: View {
         #if os(tvOS)
         200
         #else
-        140
+        AdaptiveLayout.posterCardWidth(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass))
         #endif
     }
 

--- a/Shared/Screens/LibraryGenreRow.swift
+++ b/Shared/Screens/LibraryGenreRow.swift
@@ -12,6 +12,10 @@ struct LibraryGenreRow: View {
     let itemType: BaseItemKind
     let onViewAll: () -> Void
 
+    #if !os(tvOS)
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    #endif
+
     var body: some View {
         ContentRow(
             title: genre,
@@ -29,7 +33,7 @@ struct LibraryGenreRow: View {
         #if os(tvOS)
         200
         #else
-        140
+        AdaptiveLayout.posterCardWidth(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass))
         #endif
     }
 }

--- a/Shared/Screens/LibraryHeroSection.swift
+++ b/Shared/Screens/LibraryHeroSection.swift
@@ -9,61 +9,71 @@ struct LibraryHeroSection: View {
     @Environment(AppState.self) private var appState
     @Environment(ThemeManager.self) private var themeManager
     @Environment(LocalizationManager.self) private var loc
+    #if !os(tvOS)
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    #endif
 
     let item: BaseItemDto
     let itemType: BaseItemKind
 
     var body: some View {
-        ZStack(alignment: .bottomLeading) {
-            if let id = item.id {
-                CinemaLazyImage(
-                    url: appState.imageBuilder.imageURL(itemId: id, imageType: .backdrop, maxWidth: ImageURLBuilder.screenPixelWidth),
-                    fallbackIcon: nil,
-                    fallbackBackground: CinemaColor.surfaceContainerLow
-                )
-                .accessibilityHidden(true)
-            }
-
-            CinemaGradient.heroOverlay
-
-            VStack(alignment: .leading, spacing: heroContentSpacing) {
-                HStack(spacing: 8) {
-                    if let rating = item.officialRating {
-                        RatingBadge(rating: rating)
-                    }
-                    heroMetadataText
-                }
-                .foregroundStyle(CinemaColor.onSurfaceVariant)
-
-                Text(item.name ?? "")
-                    .font(.system(size: heroTitleSize, weight: .black))
-                    .tracking(-1.5)
-                    .foregroundStyle(.white)
-                    .textCase(.uppercase)
-                    .lineLimit(2)
-
-                #if os(tvOS)
-                if let overview = item.overview {
-                    Text(overview)
-                        .font(.system(size: overviewFontSize))
-                        .foregroundStyle(CinemaColor.onSurfaceVariant)
-                        .lineLimit(3)
-                        .frame(maxWidth: maxOverviewWidth, alignment: .leading)
-                }
-                #endif
-
+        // A `Color.clear` sizing driver pinned to `heroHeight`, with backdrop, gradient,
+        // and content all layered as overlays. Overlays CANNOT grow the parent, so the
+        // hero is guaranteed to be exactly `heroHeight` tall regardless of what the
+        // backdrop image or the content VStack try to do. `.clipped()` then bounds the
+        // overlays visually. Earlier ZStack-based attempts let the CinemaLazyImage's
+        // natural size leak through in iPad landscape, pushing the action buttons
+        // outside the visible hero bounds.
+        Color.clear
+            .frame(maxWidth: .infinity)
+            .frame(height: heroHeight)
+            .overlay {
                 if let id = item.id {
-                    heroActionButtons(id: id)
+                    CinemaLazyImage(
+                        url: appState.imageBuilder.imageURL(itemId: id, imageType: .backdrop, maxWidth: ImageURLBuilder.screenPixelWidth),
+                        fallbackIcon: nil,
+                        fallbackBackground: CinemaColor.surfaceContainerLow
+                    )
+                    .accessibilityHidden(true)
                 }
             }
-            .padding(.horizontal, heroPadding)
-            .padding(.top, heroPadding)
-            .padding(.bottom, heroPadding + CinemaSpacing.spacing6)
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .frame(maxWidth: .infinity)
-        .frame(height: heroHeight)
-        .clipped()
+            .overlay { CinemaGradient.heroOverlay.allowsHitTesting(false) }
+            .overlay(alignment: .bottomLeading) {
+                VStack(alignment: .leading, spacing: heroContentSpacing) {
+                    HStack(spacing: 8) {
+                        if let rating = item.officialRating {
+                            RatingBadge(rating: rating)
+                        }
+                        heroMetadataText
+                    }
+                    .foregroundStyle(CinemaColor.onSurfaceVariant)
+
+                    Text(item.name ?? "")
+                        .font(.system(size: heroTitleSize, weight: .black))
+                        .tracking(-1.5)
+                        .foregroundStyle(.white)
+                        .textCase(.uppercase)
+                        .lineLimit(2)
+
+                    #if os(tvOS)
+                    if let overview = item.overview {
+                        Text(overview)
+                            .font(.system(size: overviewFontSize))
+                            .foregroundStyle(CinemaColor.onSurfaceVariant)
+                            .lineLimit(3)
+                            .frame(maxWidth: maxOverviewWidth, alignment: .leading)
+                    }
+                    #endif
+
+                    if let id = item.id {
+                        heroActionButtons(id: id)
+                    }
+                }
+                .padding(.horizontal, heroPadding)
+                .padding(.bottom, heroPadding + CinemaSpacing.spacing6)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .clipped()
     }
 
     @ViewBuilder
@@ -142,7 +152,7 @@ struct LibraryHeroSection: View {
         #if os(tvOS)
         820
         #else
-        360
+        AdaptiveLayout.heroHeight(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass))
         #endif
     }
 

--- a/Shared/Screens/MediaDetailScreen.swift
+++ b/Shared/Screens/MediaDetailScreen.swift
@@ -8,6 +8,8 @@ struct MediaDetailScreen: View {
     @Environment(LocalizationManager.self) private var loc
     #if os(tvOS)
     @Environment(VideoPlayerCoordinator.self) private var coordinator
+    #else
+    @Environment(\.horizontalSizeClass) private var sizeClass
     #endif
     @State var viewModel: MediaDetailViewModel
     @State private var episodeOverview: EpisodeOverviewItem?
@@ -69,6 +71,7 @@ struct MediaDetailScreen: View {
                         Text(overview)
                             .font(CinemaFont.dynamicBody)
                             .foregroundStyle(CinemaColor.onSurfaceVariant)
+                            .frame(maxWidth: readingMaxWidth, alignment: .leading)
                             .padding(.horizontal, contentPadding)
                             #if os(tvOS)
                             .focusable()
@@ -77,6 +80,7 @@ struct MediaDetailScreen: View {
 
                     // Studio / Network
                     studioLine(item)
+                        .frame(maxWidth: readingMaxWidth, alignment: .leading)
                         .padding(.horizontal, contentPadding)
 
                     // Cast
@@ -689,7 +693,7 @@ struct MediaDetailScreen: View {
         #if os(tvOS)
         760
         #else
-        310
+        AdaptiveLayout.detailBackdropHeight(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass))
         #endif
     }
 
@@ -713,7 +717,17 @@ struct MediaDetailScreen: View {
         #if os(tvOS)
         CinemaSpacing.spacing20
         #else
-        CinemaSpacing.spacing4
+        AdaptiveLayout.horizontalPadding(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass))
+        #endif
+    }
+
+    /// Max width for prose blocks (overview, studio line) on wide screens so lines stay readable.
+    /// Horizontal carousels (cast, similar, episodes) intentionally ignore this and use full width.
+    private var readingMaxWidth: CGFloat {
+        #if os(tvOS)
+        .infinity
+        #else
+        AdaptiveLayout.readingMaxWidth(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass)) ?? .infinity
         #endif
     }
 

--- a/Shared/Screens/MovieLibraryScreen.swift
+++ b/Shared/Screens/MovieLibraryScreen.swift
@@ -8,6 +8,9 @@ struct MediaLibraryScreen: View {
     @Environment(AppState.self) private var appState
     @Environment(ThemeManager.self) private var themeManager
     @Environment(LocalizationManager.self) private var loc
+    #if !os(tvOS)
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    #endif
     @State private var viewModel: MediaLibraryViewModel
     @State private var showSortFilter = false
 
@@ -178,7 +181,7 @@ struct MediaLibraryScreen: View {
         #if os(tvOS)
         Array(repeating: GridItem(.flexible(), spacing: 32), count: 6)
         #else
-        Array(repeating: GridItem(.flexible(), spacing: 16), count: 3)
+        AdaptiveLayout.posterGridColumns(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass))
         #endif
     }
 
@@ -663,7 +666,7 @@ struct MediaLibraryScreen: View {
         #if os(tvOS)
         CinemaSpacing.spacing20
         #else
-        CinemaSpacing.spacing3
+        AdaptiveLayout.horizontalPadding(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass))
         #endif
     }
 
@@ -703,7 +706,7 @@ struct MediaLibraryScreen: View {
         #if os(tvOS)
         CinemaSpacing.spacing20
         #else
-        CinemaSpacing.spacing6
+        AdaptiveLayout.horizontalPadding(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass))
         #endif
     }
 
@@ -711,7 +714,7 @@ struct MediaLibraryScreen: View {
         #if os(tvOS)
         Array(repeating: GridItem(.flexible(), spacing: CinemaSpacing.spacing3), count: 4)
         #else
-        Array(repeating: GridItem(.flexible(), spacing: CinemaSpacing.spacing3), count: 2)
+        AdaptiveLayout.browseGenreColumns(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass))
         #endif
     }
 }

--- a/Shared/Screens/SearchScreen.swift
+++ b/Shared/Screens/SearchScreen.swift
@@ -9,6 +9,10 @@ struct SearchScreen: View {
     @Environment(ThemeManager.self) private var themeManager
     @Environment(LocalizationManager.self) private var loc
     @Environment(ToastCenter.self) private var toasts
+    #if !os(tvOS)
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    @FocusState private var searchFieldFocused: Bool
+    #endif
     @State private var viewModel = SearchViewModel()
 
     // Surprise Me state — two buttons (movie + series) in the empty state.
@@ -21,13 +25,13 @@ struct SearchScreen: View {
         let itemType: BaseItemKind
     }
 
-    private let columns: [GridItem] = {
+    private var columns: [GridItem] {
         #if os(tvOS)
         Array(repeating: GridItem(.flexible(), spacing: 32), count: 6)
         #else
-        Array(repeating: GridItem(.flexible(), spacing: 16), count: 3)
+        AdaptiveLayout.posterGridColumns(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass))
         #endif
-    }()
+    }
 
     var body: some View {
         ZStack {
@@ -64,6 +68,15 @@ struct SearchScreen: View {
             MediaDetailScreen(itemId: dest.id, itemType: dest.itemType)
         }
         #if os(iOS)
+        .background {
+            // ⌘F focuses the search field. Hidden button → keyboard-only affordance
+            // (the shortcut fires even though the button is off-screen).
+            Button("") { searchFieldFocused = true }
+                .keyboardShortcut("f", modifiers: .command)
+                .opacity(0)
+                .frame(width: 0, height: 0)
+                .accessibilityHidden(true)
+        }
         .navigationTitle(loc.localized("search.title"))
         .alert(loc.localized("search.permissionRequired"), isPresented: Bindable(viewModel).showPermissionAlert) {
             Button(loc.localized("search.openSettings")) {
@@ -96,6 +109,7 @@ struct SearchScreen: View {
             TextField(loc.localized("search.placeholder"), text: Bindable(viewModel).searchText)
                 #if os(iOS)
                 .textFieldStyle(.plain)
+                .focused($searchFieldFocused)
                 #endif
                 .font(.system(size: searchFontSize))
                 .foregroundStyle(CinemaColor.onSurface)
@@ -310,7 +324,7 @@ struct SearchScreen: View {
         #if os(tvOS)
         CinemaSpacing.spacing20
         #else
-        CinemaSpacing.spacing3
+        AdaptiveLayout.horizontalPadding(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass))
         #endif
     }
 

--- a/Shared/Screens/UserSwitchSheet.swift
+++ b/Shared/Screens/UserSwitchSheet.swift
@@ -17,6 +17,9 @@ struct UserSwitchSheet: View {
     @Environment(LocalizationManager.self) private var loc
     @Environment(ToastCenter.self) private var toasts
     @Environment(\.dismiss) private var dismiss
+    #if !os(tvOS)
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    #endif
 
     @State private var users: [UserDto] = []
     @State private var isLoading = true
@@ -235,7 +238,7 @@ struct UserSwitchSheet: View {
         #if os(tvOS)
         Array(repeating: GridItem(.flexible(), spacing: CinemaSpacing.spacing4), count: 4)
         #else
-        Array(repeating: GridItem(.flexible(), spacing: CinemaSpacing.spacing3), count: 3)
+        AdaptiveLayout.userGridColumns(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass))
         #endif
     }
 


### PR DESCRIPTION
Introduces `AdaptiveLayout` helper for size-class-aware metrics (poster/wide card widths, grid columns, hero heights, horizontal padding) and wires it through HomeScreen, MovieLibraryScreen, UserSwitchSheet, and friends so iPad regular width gets roomier cards and denser adaptive grids while iPhone keeps its existing compact values.

MainTabView now uses the iOS 18 `Tab` API with `.tabViewStyle(.sidebarAdaptable)`, giving iPad a native sidebar (regular width) and iPhone a bottom tab bar from the same declaration. SearchScreen adds a ⌘F keyboard shortcut that focuses the TextField, and FocusScaleModifier gains a `.hoverEffect` for iPad pointer.

Fixes the landscape-iPad regression where the hero's `CinemaLazyImage` natural size forced the ZStack taller than `heroHeight`, pushing the Lecture / Plus d'infos buttons off-screen. HomeScreen and LibraryHeroSection now use a `Color.clear` sizing driver pinned to `heroHeight` with backdrop, gradient, and content VStack all layered as `.overlay`s — overlays cannot grow the parent frame, so the hero is guaranteed bounded regardless of what the backdrop or content try to do. `heroHeight` itself is now adaptive (500pt iPad, 360pt iPhone) via `AdaptiveLayout`.