### PR TITLE
feat: offline downloads (VLCKit) + large-screen refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,9 @@ Native Jellyfin client for iOS 26+ and tvOS 26+. "Cinema Glass" design system (d
 - **iPad multitasking**: `UIRequiresFullScreen` removed (deprecated). iPad split view / Stage Manager allowed — hero/backdrop layouts not yet hardened for resize, expect glitches.
 - **Toolbar + Liquid Glass**: iOS 26 auto-renders `ToolbarItem` buttons with Liquid Glass. **Never** add `.buttonStyle(.glass)` / `.glassProminent` on toolbar items — nests double capsules. Signal active state via `.tint(themeManager.accent)` + `.fill` icon variant.
 
-**Dependencies**: `jellyfin-sdk-swift` v0.6.0, `Nuke`/`NukeUI` v12.9.0, `AVKit`/`AVPlayer`
+**Dependencies**: `jellyfin-sdk-swift` v0.6.0, `Nuke`/`NukeUI` v12.9.0, `AVKit`/`AVPlayer`, `VLCKitSPM` v3.6.0 ([tylerjonesio/vlckit-spm](https://github.com/tylerjonesio/vlckit-spm) — `import VLCKitSPM` re-exports `MobileVLCKit` on iOS / `TVVLCKit` on tvOS). VLC is iOS-only by linkage (only the `Cinemax` target depends on the SPM package).
 
-**API protocol split** (`Packages/CinemaxKit/.../APIClientProtocol.swift`): `APIClientProtocol = ServerAPI & AuthAPI & LibraryAPI & PlaybackAPI & AdminAPI`. View models needing multiple domains take `APIClientProtocol`; leaf controllers narrow to a slice (`PlaybackReporter` / `SkipSegmentController` → `any PlaybackAPI`). `AdminAPI` is a privilege boundary — gated on `AppState.isAdministrator`; server enforces authoritatively.
+**API protocol split** (`Packages/CinemaxKit/.../APIClientProtocol.swift`): `APIClientProtocol = ServerAPI & AuthAPI & LibraryAPI & PlaybackAPI & AdminAPI & DownloadAPI`. View models needing multiple domains take `APIClientProtocol`; leaf controllers narrow to a slice (`PlaybackReporter` / `SkipSegmentController` → `any PlaybackAPI`; `DownloadManager` → `any DownloadAPI`). `AdminAPI` is a privilege boundary — gated on `AppState.isAdministrator`; server enforces authoritatively.
 
 **Swift 6 `nonisolated` escape hatches** (safe when body only reads parameters):
 1. `View, Equatable` sub-type inside a `@MainActor` screen needs `nonisolated static func ==` — `Equatable` isn't main-actor-isolated. See `PlayActionButtonsSection` in `MediaDetailScreen.swift`.
@@ -36,14 +36,15 @@ Shared/
   DesignSystem/Components/  CinemaButton, CinemaLazyImage, PosterCard, WideCard, CastCircle, ContentRow, ProgressBarView, RatingBadge, GlassTextField, FlowLayout, ToastOverlay, EmptyStateView, ErrorStateView, LoadingStateView, AlphabeticalJumpBar, CinemaToggleIndicator, RainbowAccentSwatch, MediaQualityBadges, UserAvatar
   Navigation/               AppNavigation (auth routing), MainTabView
   Screens/                  Home/Login/ServerSetup/Search/MovieLibrary/TVSeries/PrivacySecurity (+ ConnectedDevicesList), MediaDetailScreen + sibling extractions (EpisodeCard/EpisodeRow/EpisodeMetadataLine/EpisodeOverviewSheet/CastSection/SimilarSection/ButtonStyles), VideoPlayerView, NativeVideoPresenter, HLSManifestLoader, PlayLink, sheets/helpers
-    VideoPlayer/            PlaybackReporter, SkipSegmentController, SleepTimerController, ChapterController, EndOfSeriesOverlayController, RemoteCommandController
+    VideoPlayer/            PlaybackReporter, SkipSegmentController, SleepTimerController, ChapterController, EndOfSeriesOverlayController, RemoteCommandController, VLCOfflinePresenter (iOS)
     Settings/               SettingsScreen + iOS/tvOS extensions, SettingsAppearanceView+iOS, SettingsRowHelpers, SettingsTV{AccentPicker,LanguagePicker,ProfileSection,ActionRow}
+    Downloads/              (iOS-only) DownloadButton, DownloadsScreen, OfflineLibraryView, OfflineMediaDetailView, DownloadItem+BaseItemDto
     Admin/                  (iOS-only) Dashboard/Users/Devices/Activity/Tasks/Plugins/Catalog/Playback/Network/Logs/ApiKeys/Metadata/Identify
     Admin/Components/       AdminLoadStateContainer, AdminFormScreen, AdminTabBar, AdminSectionGroup, AdminItemMenu, DestructiveConfirmSheet, AdminComingSoonScreen
-  ViewModels/               per-screen view models + VideoPlayerCoordinator
+  ViewModels/               per-screen view models + VideoPlayerCoordinator + DownloadManager (iOS) + NetworkMonitor
 iOS/ tvOS/                  app entry points
 Resources/{fr,en}.lproj/    Localization (fr default)
-Packages/CinemaxKit/        Models, Networking (JellyfinAPIClient, ImageURLBuilder), Persistence (KeychainService)
+Packages/CinemaxKit/        Models (incl. DownloadItem), Networking (JellyfinAPIClient, ImageURLBuilder, JellyfinAPIClient+Downloads), Persistence (KeychainService, DownloadStore, DownloadStorage)
 docs/design-system/         Canonical design system reference
 ```
 
@@ -240,7 +241,87 @@ Settings → Server: `apiClient.clearCache()` + posts `.cinemaxShouldRefreshCata
 ### Debug section
 Always visible (not `#if DEBUG`-gated) so QA/power users don't need a custom build. Icons orange.
 
-## Admin Section (iOS / iPadOS only)
+## Offline Downloads (iOS / iPadOS only)
+
+Mobile-only by product decision. Every download file is wrapped in `#if os(iOS)`; `SettingsCategory.downloads` carries `isIOSOnly = true` so `visibleCases(isAdmin:isTVOS:)` filters it out on tvOS.
+
+### URL negotiation (`JellyfinAPIClient+Downloads.swift`)
+
+`DownloadAPI.buildDownloadRequest(itemId:userId:)` is `async` — it POSTs PlaybackInfo with a **download-specific DeviceProfile** so Jellyfin hands back a single playable file:
+- **DirectPlayProfile**: `container = mp4,m4v,mov,m4a` × `videoCodec = h264,hevc` × broad audio. Direct hits → static-stream URL bound to a `playSessionId`.
+- **TranscodingProfile**: `protocol = .http` (single MP4, **NOT** HLS — HLS is multi-segment and unsuitable for download), `container = mp4`, `context = .static`, `videoCodec = h264`, `audioCodec = aac`. Source that can't direct-play (MKV / AVI / HEVC-in-Matroska) → Jellyfin opens a real transcoding session and returns `mediaSource.transcodingURL` (progressive MP4, `moov` atom at EOF — works once fully downloaded).
+- Last-resort fallback: `/Items/{id}/Download` (raw source bytes).
+
+**Never** use `?static=true` straight off — got us MKV files AVPlayer can't decode. **Never** use `/Videos/{id}/stream.mp4` without a PlaySessionId — without a negotiated session Jellyfin can return an audio-only mux (the QuickTime audio-icon bug).
+
+`resolvePlayableEpisode` + `rawPostPlaybackInfo` are `internal` on `JellyfinAPIClient` (not `private`) so `+Downloads.swift` can reuse them.
+
+### Manager (`Shared/ViewModels/DownloadManager.swift`)
+
+`@MainActor @Observable`. Owns a **background `URLSession`** with identifier `com.cinemax.downloads` and a max-concurrent throttle of 2. The session's `URLSessionDownloadDelegate` is a nested `Adapter: NSObject, @unchecked Sendable` that bridges callbacks back to MainActor via `Task { @MainActor [weak owner] in … }`.
+
+- **`attach(apiClient:userId:)`** wires the API client *and* caches the user id (PlaybackInfo negotiation requires it; queued / resumed tasks don't have a UI call site to provide it). Called from `AppNavigation.task` and re-fired on `appState.currentUserId` change (login / quick switch).
+- **`startTask(for:)`** is the hot path: if `entry.resumeData` exists it relaunches with that blob (URLSession's resume data already encodes the URL); otherwise it fires a detached Task that awaits a fresh PlaybackInfo negotiation, then calls `launchTask(itemId:request:)` back on MainActor.
+- **`enqueue(item:posterURL:backdropURL:)`** stores the catalog entry, kicks off **artwork prefetch** (a detached `URLSession.shared.data(from:)` writes JPEGs to `art/<id>-poster.jpg` and `<id>-backdrop.jpg` so offline screens have thumbnails even for items the user never opened online), and promotes the queue.
+- **`removeAll()`** cancels live tasks, drops the catalog, `DownloadStorage.wipeEverything()` nukes `files/ resume/ art/`. Exposed as "Remove all downloads" via the storage banner menu in `DownloadsScreen`.
+- **`reconcileOrphans`** runs on init — wipes any file in `files/` whose itemId isn't in the catalog. Catches the "catalog reset but media still on disk" drift.
+
+**Background-session relaunch**: `CinemaxAppDelegate.backgroundSessionCompletion` (set in `application(_:handleEventsForBackgroundURLSession:completionHandler:)`) is consumed by the adapter's `urlSessionDidFinishEvents(forBackgroundURLSession:)` so iOS knows our bookkeeping finished and can suspend us again.
+
+### Completion bookkeeping (`didFinish`)
+
+Container detection order (server is authoritative — we never re-encode locally):
+1. **`Content-Disposition: filename=…`** (Jellyfin's `/Items/{id}/Download` always sets this).
+2. **`Content-Type`** mime mapping.
+3. Catalog's initial guess (the source `mediaSource.container`).
+
+`extensionFromDisposition` parses both `filename=` and the RFC 5987 `filename*=UTF-8''…` form. The detected extension overwrites `DownloadItem.containerExt` and the file is moved to `files/<id>.<ext>`.
+
+**File size**: chunked transfer responses have no `Content-Length`, so URLSession reports `totalBytesExpectedToWrite = -1` and the in-flight `totalBytes` stays 0. After move, `didFinish` `stat`s the destination and overwrites BOTH `totalBytes` and `bytesReceived` from the on-disk size. **Don't `bytesReceived = totalBytes`** — that's how the "Zéro ko" labels regressed.
+
+### Storage (`Packages/CinemaxKit/.../Persistence/DownloadStorage.swift`)
+
+```
+Application Support/Cinemax/Downloads/
+  index.json                   ← `DownloadStore` catalog (atomic-write JSON)
+  files/  <itemId>.<ext>       ← finished media; `isExcludedFromBackup = true`
+  resume/ <itemId>.resume      ← URLSession resume blobs for paused / interrupted tasks
+  art/    <itemId>-poster.jpg
+          <itemId>-backdrop.jpg
+```
+
+The whole `Downloads` subtree is excluded from iCloud backup so a 30 GB offline library doesn't pollute the user's backup quota. `DownloadStorage.totalDiskUsage` walks BOTH `files/` AND `art/` so the storage banner matches what "Remove all" actually frees.
+
+### Playback dual path (offline)
+
+`VideoPlayerView.startIOSPlayback` checks `downloads.item(for: itemId)` BEFORE calling `getPlaybackInfo`:
+1. **AVKit-friendly container** (`DownloadItem.isOfflinePlayable` → `mp4, m4v, m4a, mov, ts, m2ts, 3gp, 3g2`) → AVPlayer via `NativeVideoPresenter` (full feature set: skip intro/outro, chapter markers, AirPlay, PiP, audio/subtitle menus).
+2. **Not AVKit-friendly** (mkv, avi, webm…) → `VLCOfflinePresenter` (libVLC modal — black bg, tap-to-toggle controls, scrubber, Done button). Same approach Swiftfin / Streamyfin use. Less chrome (no skip intro, no AirPlay) but it actually decodes Matroska instead of showing the QuickTime audio-only icon.
+
+`VLCOfflinePresenter` lives in `Shared/Screens/VideoPlayer/` next to `NativeVideoPresenter`. It uses `VLCMediaPlayer.drawable` (`UIView`), sets `:file-caching=3000` on the `VLCMedia` so scrubbing through multi-GB MKVs doesn't lag, and seeks to `startTime` exactly once after `mediaPlayerTimeChanged` reports a non-zero `length` (VLC needs media-parsed to honor seeks). Delegate methods are `nonisolated` because `VLCMediaPlayerDelegate` isn't main-actor-isolated; they bridge through `Task { @MainActor }`.
+
+### Network awareness (`Shared/ViewModels/NetworkMonitor.swift`)
+
+`@MainActor @Observable` around `NWPathMonitor`. Seeds `isOnline` synchronously from `monitor.currentPath` (after `start(queue:)` returns) so the very first SwiftUI render already reflects reality — the path handler then flips it in real time. Injected at `AppNavigation` root.
+
+**Fast-fail timeouts**: every `JellyfinClient` we build now takes `sessionConfiguration: Self.fastFailSessionConfiguration` (timeoutIntervalForRequest = 8, timeoutIntervalForResource = 20, `waitsForConnectivity = false`). The raw PlaybackInfo POST adds `request.timeoutInterval = 8`. Without these the default 60s timeout makes airplane-mode launches feel frozen.
+
+**Non-blocking launch**: `AppState.restoreSession` hydrates from keychain immediately and dispatches `fetchServerInfo` + `refreshCurrentUser` in a detached `Task` — the splash no longer waits on a server round-trip when the user is offline.
+
+### Offline UI surfaces
+
+- **`OfflineLibraryView`** (`scope: .all/.movies/.series`) replaces the regular tab content when `!network.isOnline`. Yellow banner + grid of downloaded posters. Cards push `MediaDetailScreen`, whose body short-circuits to `OfflineMediaDetailView` when `network.isOnline == false` AND `downloads.item(for:)` (or `downloads.episodes(forSeriesId:)`) returns a completed entry.
+- **`OfflineMediaDetailView`** renders directly from cached `DownloadItem` metadata (`overview`, `productionYear`, `genres`, `officialRating`, `communityRating`, `premiereDate`, `backdropItemID`) — no API call. Movie shows Play + Remove; episode shows series header + auto-grouped episode list from `episodes(forSeriesId:)`.
+- All offline image consumers (`DownloadsScreen.thumbnail`, `OfflineLibraryView.posterCard`, `OfflineMediaDetailView.header` + episode rows) check `downloads.localPosterURL(forItemId:)` / `localBackdropURL` first, fall back to the remote `imageBuilder` URL only when nothing's cached. Critical because Nuke's disk cache keys per-URL — a poster cached at `maxWidth=180` is a *different cache entry* from `maxWidth=360`, so a screen the user never visited online would otherwise miss.
+- **`SettingsCategory.downloads`** routes to `DownloadsScreen` (iOS only). Movies + per-series episode buckets, per-row Menu (pause / resume / retry / remove), tap-to-play `PlayLink` overlay on completed rows. Storage banner is a Menu with "Remove all downloads" (confirmation dialog).
+
+### Download surfaces on detail screens
+
+- **Movie detail / episode detail**: `DownloadButton` next to Play (icon-only, top-aligned). State machine reflects `DownloadStatus` — `arrow.down.circle` / progress ring (with pause overlay) / `play.circle` (paused) / `arrow.triangle.2.circlepath` (failed) / `checkmark.circle.fill` (completed → long-press menu → remove).
+- **Series detail**: same button surfaced as a `Menu` — "Download season" enqueues the currently selected season's episodes; "Download whole series" runs an async `fetchAllEpisodes` closure that loops `getEpisodes(seriesId:seasonId:)` across every season and enqueues them. The button captures `viewModel.seasons` and the API client by value so the closure stays `@Sendable`-clean.
+- **Per-episode** (iOS `MediaDetailEpisodeCard`): a small `DownloadButton` is inline next to the episode-number label so individual episodes can be queued without grabbing the whole season.
+
+
 
 Admin workflows mobile-only by product decision. `SettingsCategory.visibleCases(isAdmin:isTVOS:)` short-circuits when `isTVOS`; every file under `Shared/Screens/Admin/` is wrapped in `#if os(iOS)` so tvOS compiles an empty module.
 

--- a/Cinemax.xcodeproj/project.pbxproj
+++ b/Cinemax.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		1310DE32F30F89E58B00ADB4 /* MetadataImagesTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9405DE38F64738B12862F6B5 /* MetadataImagesTab.swift */; };
 		1371629A0798E77C642BC679 /* AdminDevicesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B79C648FDB6E0DBCD80CAEB /* AdminDevicesViewModel.swift */; };
 		1508DA79998A9C93F3A4C64A /* BackdropFallbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A855157B1CDF9464CA308220 /* BackdropFallbackView.swift */; };
+		1560A356EB2D2E835313ED49 /* DownloadButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF8782ADA4FEA223DAFF8AA /* DownloadButton.swift */; };
 		15B101DB7D9B770EAD24E7CA /* RemoteCommandController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2704DEBD38156198513A11C4 /* RemoteCommandController.swift */; };
 		1695AF73A0D756A11490FF4B /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611E44F72064D91AE6DBCC6C /* SearchViewModel.swift */; };
 		16C42CECBAAA1EA78363222D /* AdminDashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1A9840C693FD9D46644B69 /* AdminDashboardViewModel.swift */; };
@@ -54,6 +55,7 @@
 		28A82A58BDED7ACD5B9221F8 /* HomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D8CB8B2A5B48928CFF4A61 /* HomeScreen.swift */; };
 		2BC23AB09D961A04A91415F7 /* AppNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78377E8E832D65F7226A2A06 /* AppNavigation.swift */; };
 		2C598521E34C029BD36C4A3C /* AdminActivityScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE8FCB2FC95C053274F05B3 /* AdminActivityScreen.swift */; };
+		2C77FF318147F9857F29406E /* VLCOfflinePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF02FE7A482CD3F0B5EA28E /* VLCOfflinePresenter.swift */; };
 		2D505F5E99229EC948F2A7E0 /* TVSeriesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0A181A9E709E7700EC2E95 /* TVSeriesScreen.swift */; };
 		2E1A085843FA335D04A9B52B /* ToastCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5610FD34CD71B2F9E4D65FC6 /* ToastCenter.swift */; };
 		2F4C51078FC6EFB427650A5F /* AccentOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6972E29F4227F16D517B124A /* AccentOption.swift */; };
@@ -103,12 +105,14 @@
 		4F4CD1C6C966234FEA80B1A3 /* AdminLogsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461BC0222941D069E3A1AE4B /* AdminLogsScreen.swift */; };
 		4FF8A7EB4524A12010906B3D /* LibraryPosterCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB193219DC7306139A95B60 /* LibraryPosterCard.swift */; };
 		5115EECDD47EEF8054E73643 /* AccentOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6972E29F4227F16D517B124A /* AccentOption.swift */; };
+		52F51831022AFCDC5833B695 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5BC952DF89C9791E8414656 /* NetworkMonitor.swift */; };
 		53C1963BDCD2235326155AE6 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5F40A4DB82730AD3871CB7 /* SettingsScreen.swift */; };
 		558BB88F463A93FA7EBE9838 /* AdminUserDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C9346642E51488EB9DDC40 /* AdminUserDetailViewModel.swift */; };
 		574B9D39C15D539DEC66C125 /* AdminTabbedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE7EDAE1CB51A7F06D6BD83 /* AdminTabbedScreen.swift */; };
 		575A596CB9AB11EAB858E4F5 /* SleepTimerOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB0CBCFC322E533A14A4EBB /* SleepTimerOption.swift */; };
 		5782D05B40C908DB8241AAE6 /* CinemaxApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A70C2603459BCEE70535BB4 /* CinemaxApp.swift */; };
 		57D52614B1AC3B7D6A3847D8 /* MediaDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD57D8126029102A7AE191CF /* MediaDetailViewModel.swift */; };
+		597B704CE49B0E324058ABB5 /* DownloadButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF8782ADA4FEA223DAFF8AA /* DownloadButton.swift */; };
 		5ADC5808FB8451072D29D42E /* MediaDetailEpisodeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A548CB9FD413FC2170099AEF /* MediaDetailEpisodeRow.swift */; };
 		5C12CA8D5E0E99B858F9AE28 /* MediaDetailEpisodeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BC56A0134905744D8E1BFD2 /* MediaDetailEpisodeCard.swift */; };
 		5C29AEB096D8E2EFB1A7DBA2 /* IdentifyFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD9477588ED431D8A6A0878 /* IdentifyFormView.swift */; };
@@ -118,9 +122,11 @@
 		5FA751E81BBEE26DE820FA36 /* ServerSetupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0A552AFA2A46BB879FE87B /* ServerSetupViewModel.swift */; };
 		5FAF45D73A59C4EC9074CD1B /* AdminTabbedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE7EDAE1CB51A7F06D6BD83 /* AdminTabbedScreen.swift */; };
 		5FD3234EE63A765E0C82E5C7 /* MediaDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8324C15002E8D55B4849D71F /* MediaDetailScreen.swift */; };
+		6019A67C869CBAAB7B737A31 /* OfflineMediaDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7221CEFB5232DC40DB2FEA9 /* OfflineMediaDetailView.swift */; };
 		60C9BC65C7DCC678C8D21DA4 /* ServerDiscoverySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5392E5D6360E4430456477E9 /* ServerDiscoverySheet.swift */; };
 		615404387A1AE6CADC2CCC5C /* AdminLoadStateContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCF5A94AA4897A4644B777A /* AdminLoadStateContainer.swift */; };
 		629034F00C9B9A91F1DFDFAF /* ContentRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BAFD25D98FA0E18A0F441F5 /* ContentRow.swift */; };
+		62FBF47DA9ECCC8ABFA3E16A /* DownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C79415609E94D61DD15D56 /* DownloadManager.swift */; };
 		6349F4F7D8D0F28F0831E2E1 /* AdminSectionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0798A7868A025E73D1891D8B /* AdminSectionGroup.swift */; };
 		64406006E2A4AB13FDE38E19 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = AF177D070920EC62E7827637 /* Localizable.strings */; };
 		648763482602FDCD12A8DC88 /* AdminActivityScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE8FCB2FC95C053274F05B3 /* AdminActivityScreen.swift */; };
@@ -138,6 +144,7 @@
 		6F53D5318F61F2B34CE1E894 /* MetadataIdentifyTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70046F639E1635F36221E545 /* MetadataIdentifyTab.swift */; };
 		6F9AEB4561324499DA1F1F4E /* NativeVideoPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FE737816B4F86FC1A9D144 /* NativeVideoPresenter.swift */; };
 		6FD9760CC8B8978452CF4288 /* SleepTimerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74EFA596296688A96C374135 /* SleepTimerController.swift */; };
+		701DFA07F1097668B91466C4 /* OfflineLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2EFAFF62A7FD3BB0E198E06 /* OfflineLibraryView.swift */; };
 		70247C5A32673CC464D68A32 /* LocalizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32016E5B7B38AFDEB6E75857 /* LocalizationManager.swift */; };
 		70AA7510474C61BC215F7181 /* MediaQualityBadges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D53C46CC9C173E104ABA41C /* MediaQualityBadges.swift */; };
 		7155A56A5485AAF1DC82145D /* SkipSegmentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D0C0F047D7CB697E80F4CA5 /* SkipSegmentController.swift */; };
@@ -148,9 +155,11 @@
 		739326FEE82A167D45EA81AB /* LibraryPosterCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB193219DC7306139A95B60 /* LibraryPosterCard.swift */; };
 		74CBBF39B6E72933460424C5 /* ProgressBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DF8C441837A8A10C480077 /* ProgressBarView.swift */; };
 		7716D1FC3A2C0236A06E2537 /* IdentifyScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B577BCED94F9831A8C8171 /* IdentifyScreen.swift */; };
+		773140435D1F2EE8C7ABFC8F /* DownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C79415609E94D61DD15D56 /* DownloadManager.swift */; };
 		775886D386630AB477D44DBD /* LicensesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21750E7690B40CFD3168FACA /* LicensesView.swift */; };
 		7885F6C774A599528CADE04B /* AdminNetworkScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55122A5776984A5A63808F80 /* AdminNetworkScreen.swift */; };
 		7A87DBDBFBB8645F373C66EB /* AdvancedAdminLandingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13082AD25DB233BD0E63DB1C /* AdvancedAdminLandingScreen.swift */; };
+		7B3711E0E923428328978A20 /* DownloadItem+BaseItemDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3396BFED41A0A75342D7795 /* DownloadItem+BaseItemDto.swift */; };
 		7CF24A796713A4992BC74C3B /* RatingBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C632FC97E86299EBCAA2CA /* RatingBadge.swift */; };
 		7D2D1CAAA138FF339ED93EFF /* SleepTimerOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB0CBCFC322E533A14A4EBB /* SleepTimerOption.swift */; };
 		7E2D4D829FBE580AC7B23A9E /* MediaDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B171C71911F6E759AB1A0EDB /* MediaDetailViewModelTests.swift */; };
@@ -194,6 +203,7 @@
 		9B8FB2B8FF3571D82C9D62A8 /* IdentifyScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B577BCED94F9831A8C8171 /* IdentifyScreen.swift */; };
 		9CACAE33A8F87B0F5DB0EF28 /* AdminItemMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592DF5F22CD8B9D9D263F7FD /* AdminItemMenu.swift */; };
 		9D7DC4B535360291C3465976 /* VideoPlayerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14D3FE509DDFB9EA6569161 /* VideoPlayerCoordinator.swift */; };
+		9F738C0E3E4555E4F8BEC92E /* DownloadsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C318571F3DB0BCA88B80EE5 /* DownloadsScreen.swift */; };
 		9F7E13CC3312F27A84915032 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 280786386ED204F8AAAF36B6 /* Assets.xcassets */; };
 		A10493105D97CBA1AA49C895 /* PlayMethodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5015BA3559E63C6E9845F2B /* PlayMethodTests.swift */; };
 		A15DBD5254EFF4F2B820B5A3 /* IdentifyFlowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B79F879DA7A6AF02AB6D780 /* IdentifyFlowModel.swift */; };
@@ -204,6 +214,7 @@
 		A457ECA5B1E6FC13546B3306 /* ErrorStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929537FA4254CCBD87E276B3 /* ErrorStateView.swift */; };
 		A513E949FECD6154BA1B2778 /* AdminDevicesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B79C648FDB6E0DBCD80CAEB /* AdminDevicesViewModel.swift */; };
 		A5BDB9B097C212892B4AEB36 /* BaseItemDto+Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BDB8AB3BF62513D67C2E16 /* BaseItemDto+Metadata.swift */; };
+		A65575CB5ED23B6F9C3C8CE2 /* OfflineMediaDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7221CEFB5232DC40DB2FEA9 /* OfflineMediaDetailView.swift */; };
 		A7510BDC29E8467D2D6D0ACC /* AdminPlaybackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31BE49E5CAB346FED9224CE /* AdminPlaybackViewModel.swift */; };
 		A8C1C7C4A4E243D4F959D865 /* AdaptiveLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98492ED27F16C895D0E1E0A /* AdaptiveLayout.swift */; };
 		A931903AADD015C680539D9E /* MetadataBrowserScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F10EC9288051CE15DC9B29 /* MetadataBrowserScreen.swift */; };
@@ -213,11 +224,14 @@
 		B12D6D645F12BF0CC3051F8C /* AdminScheduledTasksScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2101C4E32EEC83662C75D00 /* AdminScheduledTasksScreen.swift */; };
 		B1670D6F0CBDC7204680E65B /* AdminPluginsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3762983CA570B7EB3C9E1F65 /* AdminPluginsScreen.swift */; };
 		B17B6055000707C83658C8DF /* LoginScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE7C8046FBDB91EFDDC0805 /* LoginScreen.swift */; };
+		B20795EA1819C55B049E4DD0 /* DownloadsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C318571F3DB0BCA88B80EE5 /* DownloadsScreen.swift */; };
 		B3364EC84FB825B78C977F06 /* AdminLogsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C9143719533910733C49F4 /* AdminLogsViewModel.swift */; };
+		B51B03597E31E0C20548439F /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5BC952DF89C9791E8414656 /* NetworkMonitor.swift */; };
 		B54B725BA68563ACADEC4B8C /* RemoteCommandController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2704DEBD38156198513A11C4 /* RemoteCommandController.swift */; };
 		B5C956B67897689F7B9157EF /* AdminCatalogScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B4D9D3C1CDC4B248270077 /* AdminCatalogScreen.swift */; };
 		B80500609E8D56844738FB4A /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611E44F72064D91AE6DBCC6C /* SearchViewModel.swift */; };
 		B8D3F4C802A068C1080367C5 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81F4A35762E8619A3D24747 /* EmptyStateView.swift */; };
+		B9C9C67DF817636EF69645E8 /* OfflineLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2EFAFF62A7FD3BB0E198E06 /* OfflineLibraryView.swift */; };
 		B9D0D547C401A615B891D139 /* AdminItemMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592DF5F22CD8B9D9D263F7FD /* AdminItemMenu.swift */; };
 		BB270B300542EB24C5BA62ED /* LibraryGenreRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E3375B86131BF66AFD5CAC /* LibraryGenreRow.swift */; };
 		BB60281C449D13F7F5398F6F /* CinemaLazyImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F3D66A0647688B34958DEF /* CinemaLazyImage.swift */; };
@@ -255,6 +269,7 @@
 		DE8FAD1B61B3357856AA5E55 /* LibrarySortFilterSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BB9B833D705FD5AFFFB56B /* LibrarySortFilterSheet.swift */; };
 		DFDBEF3D856DD4B602C58F59 /* CinemaGlassTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF56288932318BE6C754F7B /* CinemaGlassTheme.swift */; };
 		E01BB78AC2D8F4002A09E253 /* AdminDevicesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410E2B368E14B0EE19701528 /* AdminDevicesScreen.swift */; };
+		E0F705B2946022AA8BDF92A5 /* VLCKitSPM in Frameworks */ = {isa = PBXBuildFile; productRef = 28696D17C93D7C4ED9D8BF2E /* VLCKitSPM */; };
 		E47F32A6D835E3546B9E083C /* PrivacySecurityScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B000BF38B945DD465445ED /* PrivacySecurityScreen.swift */; };
 		E4AF1097C891473701C8C2C9 /* LoadingStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A863021FF6B842EE2A0E27CA /* LoadingStateView.swift */; };
 		E61CB24A8F271963C9893633 /* IdentifyResultsGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74AE99230CEB07F7CC4FCCFA /* IdentifyResultsGridView.swift */; };
@@ -265,7 +280,9 @@
 		EA0632228FDBF2CE744BDE18 /* CinemaLazyImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F3D66A0647688B34958DEF /* CinemaLazyImage.swift */; };
 		EAED3DC046B710CF7724F8B4 /* AdminPluginsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F479C56E760C0460D8B0C07 /* AdminPluginsViewModel.swift */; };
 		ED13C1990662ACCF3DE71910 /* MediaDetailSimilarSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5BE8C3505764A69391252DD /* MediaDetailSimilarSection.swift */; };
+		EEEF1BC5B0B322173FE2F596 /* DownloadItem+BaseItemDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3396BFED41A0A75342D7795 /* DownloadItem+BaseItemDto.swift */; };
 		EF860827AC026C15AEF6574B /* LoadingStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A863021FF6B842EE2A0E27CA /* LoadingStateView.swift */; };
+		F002C297C66F6985927EDFE6 /* VLCOfflinePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF02FE7A482CD3F0B5EA28E /* VLCOfflinePresenter.swift */; };
 		F253F28BCDA12B2EC62BE33E /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61944A0EB692FE3706F500B /* ThemeManager.swift */; };
 		F3341F518AE1332B113E44DD /* LibrarySortFilterSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BB9B833D705FD5AFFFB56B /* LibrarySortFilterSheet.swift */; };
 		F47CF188BB8E42F904E4CB9E /* LibraryHeroSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40DF377C72F0695AEC1CB0D6 /* LibraryHeroSection.swift */; };
@@ -306,6 +323,7 @@
 		09B000BF38B945DD465445ED /* PrivacySecurityScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySecurityScreen.swift; sourceTree = "<group>"; };
 		0B79F879DA7A6AF02AB6D780 /* IdentifyFlowModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifyFlowModel.swift; sourceTree = "<group>"; };
 		0BB0CBCFC322E533A14A4EBB /* SleepTimerOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepTimerOption.swift; sourceTree = "<group>"; };
+		0C318571F3DB0BCA88B80EE5 /* DownloadsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsScreen.swift; sourceTree = "<group>"; };
 		0E5C1E6AA06EF0B35E4B4CD2 /* ToastOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastOverlay.swift; sourceTree = "<group>"; };
 		0EB9A108C0F29A3010E8E65A /* AdminUserDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminUserDetailScreen.swift; sourceTree = "<group>"; };
 		0F5616DF4D32335730006F23 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -365,6 +383,7 @@
 		70046F639E1635F36221E545 /* MetadataIdentifyTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataIdentifyTab.swift; sourceTree = "<group>"; };
 		71EDA47106672004DE07BDCF /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		74AE99230CEB07F7CC4FCCFA /* IdentifyResultsGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifyResultsGridView.swift; sourceTree = "<group>"; };
+		74C79415609E94D61DD15D56 /* DownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadManager.swift; sourceTree = "<group>"; };
 		74EFA596296688A96C374135 /* SleepTimerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepTimerController.swift; sourceTree = "<group>"; };
 		75FE585AF0EC0507240E8772 /* APICacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICacheTests.swift; sourceTree = "<group>"; };
 		78377E8E832D65F7226A2A06 /* AppNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNavigation.swift; sourceTree = "<group>"; };
@@ -411,11 +430,14 @@
 		B01CD5F39E429B665FA12B0C /* ServerSetupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSetupViewModelTests.swift; sourceTree = "<group>"; };
 		B14D3FE509DDFB9EA6569161 /* VideoPlayerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerCoordinator.swift; sourceTree = "<group>"; };
 		B171C71911F6E759AB1A0EDB /* MediaDetailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDetailViewModelTests.swift; sourceTree = "<group>"; };
+		B3396BFED41A0A75342D7795 /* DownloadItem+BaseItemDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadItem+BaseItemDto.swift"; sourceTree = "<group>"; };
 		B66D79E78292DF655B3F508E /* SettingsScreen+iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsScreen+iOS.swift"; sourceTree = "<group>"; };
+		B7221CEFB5232DC40DB2FEA9 /* OfflineMediaDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineMediaDetailView.swift; sourceTree = "<group>"; };
 		BA0B2775D4776FF99A90FB12 /* WideCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WideCard.swift; sourceTree = "<group>"; };
 		BAF45837A14E93AA0A9739F5 /* SettingsTVAccentPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTVAccentPicker.swift; sourceTree = "<group>"; };
 		BCC43AE61EC4C83ED88C63C1 /* CinemaxTV.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = CinemaxTV.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF3A6F8801C8046B8B055A99 /* PrivacySecurityConnectedDevicesList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySecurityConnectedDevicesList.swift; sourceTree = "<group>"; };
+		BFF8782ADA4FEA223DAFF8AA /* DownloadButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadButton.swift; sourceTree = "<group>"; };
 		C144D0A57021E0A0A783977B /* SearchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScreen.swift; sourceTree = "<group>"; };
 		C23376A2C6A25FD3A7A74DBE /* ServerHelpSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerHelpSheet.swift; sourceTree = "<group>"; };
 		C346F0B7AFF504DA6593370E /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
@@ -441,16 +463,19 @@
 		DD57D8126029102A7AE191CF /* MediaDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDetailViewModel.swift; sourceTree = "<group>"; };
 		DDE7C8046FBDB91EFDDC0805 /* LoginScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginScreen.swift; sourceTree = "<group>"; };
 		DE7B27B99DB58FF2CAC5D765 /* MediaLibraryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLibraryViewModel.swift; sourceTree = "<group>"; };
+		E5BC952DF89C9791E8414656 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		E5BE8C3505764A69391252DD /* MediaDetailSimilarSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDetailSimilarSection.swift; sourceTree = "<group>"; };
 		E61944A0EB692FE3706F500B /* ThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
 		E81F4A35762E8619A3D24747 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		E9A353B49C5117D5F686F07B /* GlassModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassModifiers.swift; sourceTree = "<group>"; };
 		EFF999321A455C6A950736CB /* AdminApiKeysScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminApiKeysScreen.swift; sourceTree = "<group>"; };
 		F2101C4E32EEC83662C75D00 /* AdminScheduledTasksScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminScheduledTasksScreen.swift; sourceTree = "<group>"; };
+		F2EFAFF62A7FD3BB0E198E06 /* OfflineLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineLibraryView.swift; sourceTree = "<group>"; };
 		F31BE49E5CAB346FED9224CE /* AdminPlaybackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminPlaybackViewModel.swift; sourceTree = "<group>"; };
 		F4EBD3E46649C6D2B2201E5F /* SettingsTVLanguagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTVLanguagePicker.swift; sourceTree = "<group>"; };
 		F5015BA3559E63C6E9845F2B /* PlayMethodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayMethodTests.swift; sourceTree = "<group>"; };
 		FC5F40A4DB82730AD3871CB7 /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
+		FCF02FE7A482CD3F0B5EA28E /* VLCOfflinePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VLCOfflinePresenter.swift; sourceTree = "<group>"; };
 		FF0A552AFA2A46BB879FE87B /* ServerSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSetupViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -468,6 +493,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4134A3AE6228FC62801C9E93 /* CinemaxKit in Frameworks */,
+				E0F705B2946022AA8BDF92A5 /* VLCKitSPM in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -498,6 +524,18 @@
 				7B39729167A6F66BD6CC42BC /* CinemaxKitTests */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		0DACE2FE10871D2D3007EA36 /* Downloads */ = {
+			isa = PBXGroup;
+			children = (
+				BFF8782ADA4FEA223DAFF8AA /* DownloadButton.swift */,
+				B3396BFED41A0A75342D7795 /* DownloadItem+BaseItemDto.swift */,
+				0C318571F3DB0BCA88B80EE5 /* DownloadsScreen.swift */,
+				F2EFAFF62A7FD3BB0E198E06 /* OfflineLibraryView.swift */,
+				B7221CEFB5232DC40DB2FEA9 /* OfflineMediaDetailView.swift */,
+			);
+			path = Downloads;
 			sourceTree = "<group>";
 		};
 		33715C89291D3EE589E41915 /* Playback */ = {
@@ -649,6 +687,7 @@
 			isa = PBXGroup;
 			children = (
 				966BE0EA92A03684308CA6FA /* Admin */,
+				0DACE2FE10871D2D3007EA36 /* Downloads */,
 				617BA33C992B13701372DF33 /* Settings */,
 				B047DC9BB4F744ACF2542679 /* VideoPlayer */,
 				A25B07319865E0C6A31D44ED /* HLSManifestLoader.swift */,
@@ -699,10 +738,12 @@
 		9374720A7D9E701EF5CC8FEF /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				74C79415609E94D61DD15D56 /* DownloadManager.swift */,
 				C346F0B7AFF504DA6593370E /* HomeViewModel.swift */,
 				4D37B5166A4FB48D21B2F845 /* LoginViewModel.swift */,
 				DD57D8126029102A7AE191CF /* MediaDetailViewModel.swift */,
 				DE7B27B99DB58FF2CAC5D765 /* MediaLibraryViewModel.swift */,
+				E5BC952DF89C9791E8414656 /* NetworkMonitor.swift */,
 				611E44F72064D91AE6DBCC6C /* SearchViewModel.swift */,
 				FF0A552AFA2A46BB879FE87B /* ServerSetupViewModel.swift */,
 				B14D3FE509DDFB9EA6569161 /* VideoPlayerCoordinator.swift */,
@@ -789,6 +830,7 @@
 				2704DEBD38156198513A11C4 /* RemoteCommandController.swift */,
 				4D0C0F047D7CB697E80F4CA5 /* SkipSegmentController.swift */,
 				74EFA596296688A96C374135 /* SleepTimerController.swift */,
+				FCF02FE7A482CD3F0B5EA28E /* VLCOfflinePresenter.swift */,
 			);
 			path = VideoPlayer;
 			sourceTree = "<group>";
@@ -923,6 +965,7 @@
 			name = Cinemax;
 			packageProductDependencies = (
 				CC223F1A46FB5458A8F326AD /* CinemaxKit */,
+				28696D17C93D7C4ED9D8BF2E /* VLCKitSPM */,
 			);
 			productName = Cinemax;
 			productReference = 7D88DF3FEF51CF7E5E1C948A /* Cinemax.app */;
@@ -979,6 +1022,7 @@
 			mainGroup = 386B44D1F77FA0937C0FE5D1;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				8E36EFD06C0FC09731215FF1 /* XCRemoteSwiftPackageReference "vlckit-spm" */,
 				826064A2C2C9A89F5869EA13 /* XCLocalSwiftPackageReference "Packages/CinemaxKit" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -1085,6 +1129,10 @@
 				99AD4FD1823DDEAE384019A4 /* CinemaxTVApp.swift in Sources */,
 				4E6ACB12C22F88F40EF8DC8A /* ContentRow.swift in Sources */,
 				83A446B71A40107299A25266 /* DestructiveConfirmSheet.swift in Sources */,
+				597B704CE49B0E324058ABB5 /* DownloadButton.swift in Sources */,
+				EEEF1BC5B0B322173FE2F596 /* DownloadItem+BaseItemDto.swift in Sources */,
+				773140435D1F2EE8C7ABFC8F /* DownloadManager.swift in Sources */,
+				B20795EA1819C55B049E4DD0 /* DownloadsScreen.swift in Sources */,
 				B8D3F4C802A068C1080367C5 /* EmptyStateView.swift in Sources */,
 				F5C609E838767D61F28175C1 /* EndOfSeriesOverlayController.swift in Sources */,
 				A457ECA5B1E6FC13546B3306 /* ErrorStateView.swift in Sources */,
@@ -1130,6 +1178,9 @@
 				2F59062A0754C46430071661 /* MetadataImagesTab.swift in Sources */,
 				1F8DDF74B6AA98658B045CF5 /* MovieLibraryScreen.swift in Sources */,
 				FB6FC7ADD24BFD093F9D6098 /* NativeVideoPresenter.swift in Sources */,
+				B51B03597E31E0C20548439F /* NetworkMonitor.swift in Sources */,
+				B9C9C67DF817636EF69645E8 /* OfflineLibraryView.swift in Sources */,
+				6019A67C869CBAAB7B737A31 /* OfflineMediaDetailView.swift in Sources */,
 				D64C3AD31EC5F1CC8C2197F7 /* PlayLink.swift in Sources */,
 				3130BB68B43604CB9F31F65A /* PlaybackReporter.swift in Sources */,
 				850FA2A4714148E59074CC92 /* PosterCard.swift in Sources */,
@@ -1166,6 +1217,7 @@
 				289B6BE095E7F76554DAE841 /* TrackPickerSheet.swift in Sources */,
 				D0326AA0B9518681C4EB698B /* UserAvatar.swift in Sources */,
 				F7B273773AA4C5CAA1D8BD3F /* UserSwitchSheet.swift in Sources */,
+				F002C297C66F6985927EDFE6 /* VLCOfflinePresenter.swift in Sources */,
 				735403600F051C38E050FBDE /* VideoPlayerCoordinator.swift in Sources */,
 				CF9AC2FE2683ACF8F970C686 /* VideoPlayerView.swift in Sources */,
 				91132D1D741BF7CEFF44DBE3 /* WideCard.swift in Sources */,
@@ -1223,6 +1275,10 @@
 				5782D05B40C908DB8241AAE6 /* CinemaxApp.swift in Sources */,
 				629034F00C9B9A91F1DFDFAF /* ContentRow.swift in Sources */,
 				CFADE9D9D322D20A81C56A8F /* DestructiveConfirmSheet.swift in Sources */,
+				1560A356EB2D2E835313ED49 /* DownloadButton.swift in Sources */,
+				7B3711E0E923428328978A20 /* DownloadItem+BaseItemDto.swift in Sources */,
+				62FBF47DA9ECCC8ABFA3E16A /* DownloadManager.swift in Sources */,
+				9F738C0E3E4555E4F8BEC92E /* DownloadsScreen.swift in Sources */,
 				28247D55CC29D95670733239 /* EmptyStateView.swift in Sources */,
 				437AA27B26EE2A52E222B7BB /* EndOfSeriesOverlayController.swift in Sources */,
 				2FA754E7C1024D2E05A46524 /* ErrorStateView.swift in Sources */,
@@ -1268,6 +1324,9 @@
 				1310DE32F30F89E58B00ADB4 /* MetadataImagesTab.swift in Sources */,
 				FF21EDCBFAE6F61736975202 /* MovieLibraryScreen.swift in Sources */,
 				6F9AEB4561324499DA1F1F4E /* NativeVideoPresenter.swift in Sources */,
+				52F51831022AFCDC5833B695 /* NetworkMonitor.swift in Sources */,
+				701DFA07F1097668B91466C4 /* OfflineLibraryView.swift in Sources */,
+				A65575CB5ED23B6F9C3C8CE2 /* OfflineMediaDetailView.swift in Sources */,
 				38D0284F287A35C7FC3D4858 /* PlayLink.swift in Sources */,
 				0A93FBC398B8FD4F94C93E8D /* PlaybackReporter.swift in Sources */,
 				172A4AE31E117BAB19C89CA6 /* PosterCard.swift in Sources */,
@@ -1304,6 +1363,7 @@
 				3251D64F042EEB176008DAB9 /* TrackPickerSheet.swift in Sources */,
 				CBAEF4A3CF55793AB18B8A0D /* UserAvatar.swift in Sources */,
 				68A6C69AD81208E75BA03CF8 /* UserSwitchSheet.swift in Sources */,
+				2C77FF318147F9857F29406E /* VLCOfflinePresenter.swift in Sources */,
 				9D7DC4B535360291C3465976 /* VideoPlayerCoordinator.swift in Sources */,
 				0E09FF53825D339001BB6137 /* VideoPlayerView.swift in Sources */,
 				6D40EAF27B0800AE33161733 /* WideCard.swift in Sources */,
@@ -1622,7 +1682,23 @@
 		};
 /* End XCLocalSwiftPackageReference section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		8E36EFD06C0FC09731215FF1 /* XCRemoteSwiftPackageReference "vlckit-spm" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/tylerjonesio/vlckit-spm";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.6.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
+		28696D17C93D7C4ED9D8BF2E /* VLCKitSPM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8E36EFD06C0FC09731215FF1 /* XCRemoteSwiftPackageReference "vlckit-spm" */;
+			productName = VLCKitSPM;
+		};
 		9741846667BDD8F1C021426D /* CinemaxKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = CinemaxKit;

--- a/Cinemax.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cinemax.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8cf00ef9df004f6b852d2e18eb8d4dadc906cbc08c7e6d4cf507af42c4d601bc",
+  "originHash" : "c1114a8d98e3c5ecc9f781b103ea4218c72d280452d90442ddbed13cbbbcecc3",
   "pins" : [
     {
       "identity" : "get",
@@ -35,6 +35,15 @@
       "state" : {
         "revision" : "4ce950479707ea109f229d7230ec074a133b15d7",
         "version" : "0.2.1"
+      }
+    },
+    {
+      "identity" : "vlckit-spm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tylerjonesio/vlckit-spm",
+      "state" : {
+        "revision" : "e932bbd488872fdb74f6654d28c2f291eae03daf",
+        "version" : "3.6.0"
       }
     }
   ],

--- a/Packages/CinemaxKit/Sources/CinemaxKit/Models/DownloadItem.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Models/DownloadItem.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+public enum DownloadStatus: String, Codable, Sendable {
+    case queued
+    case downloading
+    case paused
+    case completed
+    case failed
+}
+
+public enum DownloadKind: String, Codable, Sendable {
+    case movie
+    case episode
+}
+
+/// One downloaded (or downloading) media file. Movies and episodes only —
+/// downloading a Series or Season fans out into one `DownloadItem` per episode.
+///
+/// `id` is the Jellyfin item id so the same DTO can be queried by both
+/// `DownloadStore` and `MediaDetailScreen` without translation.
+///
+/// The metadata block (overview, year, genres, ratings) is cached so the
+/// detail screen can render a full offline view without hitting the server.
+public struct DownloadItem: Codable, Identifiable, Sendable, Hashable {
+    public let id: String
+    public let kind: DownloadKind
+    public let title: String
+    public let posterTag: String?
+
+    public let seriesId: String?
+    public let seriesTitle: String?
+    public let seasonId: String?
+    public let seasonName: String?
+    public let seasonIndex: Int?
+    public let episodeIndex: Int?
+
+    public let remoteURL: URL
+    /// Container extension of the on-disk file. Pre-completion this holds the
+    /// catalog's initial guess (from the server media source); the manager
+    /// refines it from the response headers once the file lands.
+    public var containerExt: String
+    public let runtimeTicks: Int?
+
+    // Offline-render metadata — cached at enqueue time.
+    public let overview: String?
+    public let productionYear: Int?
+    public let genres: [String]
+    public let officialRating: String?
+    public let communityRating: Float?
+    public let premiereDate: Date?
+    public let backdropItemID: String?
+
+    public var status: DownloadStatus
+    public var bytesReceived: Int64
+    public var totalBytes: Int64
+    /// File name within the downloads directory. `nil` until a download finishes.
+    public var localFileName: String?
+    /// Persisted resume data so a paused or interrupted task can be picked back
+    /// up after relaunch.
+    public var resumeData: Data?
+    public var errorMessage: String?
+    public let createdAt: Date
+    public var completedAt: Date?
+
+    public init(
+        id: String,
+        kind: DownloadKind,
+        title: String,
+        posterTag: String?,
+        seriesId: String?,
+        seriesTitle: String?,
+        seasonId: String?,
+        seasonName: String?,
+        seasonIndex: Int?,
+        episodeIndex: Int?,
+        remoteURL: URL,
+        containerExt: String,
+        runtimeTicks: Int?,
+        overview: String? = nil,
+        productionYear: Int? = nil,
+        genres: [String] = [],
+        officialRating: String? = nil,
+        communityRating: Float? = nil,
+        premiereDate: Date? = nil,
+        backdropItemID: String? = nil,
+        status: DownloadStatus = .queued,
+        bytesReceived: Int64 = 0,
+        totalBytes: Int64 = 0,
+        localFileName: String? = nil,
+        resumeData: Data? = nil,
+        errorMessage: String? = nil,
+        createdAt: Date = Date(),
+        completedAt: Date? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.title = title
+        self.posterTag = posterTag
+        self.seriesId = seriesId
+        self.seriesTitle = seriesTitle
+        self.seasonId = seasonId
+        self.seasonName = seasonName
+        self.seasonIndex = seasonIndex
+        self.episodeIndex = episodeIndex
+        self.remoteURL = remoteURL
+        self.containerExt = containerExt
+        self.runtimeTicks = runtimeTicks
+        self.overview = overview
+        self.productionYear = productionYear
+        self.genres = genres
+        self.officialRating = officialRating
+        self.communityRating = communityRating
+        self.premiereDate = premiereDate
+        self.backdropItemID = backdropItemID
+        self.status = status
+        self.bytesReceived = bytesReceived
+        self.totalBytes = totalBytes
+        self.localFileName = localFileName
+        self.resumeData = resumeData
+        self.errorMessage = errorMessage
+        self.createdAt = createdAt
+        self.completedAt = completedAt
+    }
+
+    public var progress: Double {
+        guard totalBytes > 0 else { return 0 }
+        return min(1.0, Double(bytesReceived) / Double(totalBytes))
+    }
+
+    public var isTerminal: Bool {
+        status == .completed || status == .failed
+    }
+
+    /// AVKit's native demuxer supports MP4-family containers and HLS / MPEG-TS.
+    /// MKV / AVI / WebM downloads complete fine but `AVPlayer` opens them as
+    /// audio-only (no video track surfaced), which surprised users with the
+    /// QuickTime audio icon during playback. UI surfaces use this to warn at
+    /// enqueue time and to short-circuit playback with a clearer message.
+    public static let avkitFriendlyContainers: Set<String> = [
+        "mp4", "m4v", "m4a", "mov", "ts", "m2ts", "3gp", "3g2"
+    ]
+
+    public var isOfflinePlayable: Bool {
+        Self.avkitFriendlyContainers.contains(containerExt.lowercased())
+    }
+}

--- a/Packages/CinemaxKit/Sources/CinemaxKit/Networking/APIClientProtocol.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Networking/APIClientProtocol.swift
@@ -274,7 +274,7 @@ public protocol AdminAPI: Sendable {
 /// screens that touch multiple domains (e.g. `HomeViewModel`,
 /// `MediaDetailViewModel`) depend on this. Leaf components should prefer the
 /// narrower sub-protocol they actually need.
-public typealias APIClientProtocol = ServerAPI & AuthAPI & LibraryAPI & PlaybackAPI & AdminAPI
+public typealias APIClientProtocol = ServerAPI & AuthAPI & LibraryAPI & PlaybackAPI & AdminAPI & DownloadAPI
 
 // MARK: - Default arguments
 

--- a/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient+Downloads.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient+Downloads.swift
@@ -1,0 +1,176 @@
+import Foundation
+import JellyfinAPI
+
+/// Request shape passed to `URLSession.downloadTask(with:)` for offline
+/// downloads. Built by `JellyfinAPIClient.buildDownloadRequest` so callers
+/// don't need to know about the `MediaBrowser` auth header format.
+public struct DownloadStreamRequest: Sendable {
+    public let itemId: String
+    public let url: URL
+    public let authHeader: String
+
+    public init(itemId: String, url: URL, authHeader: String) {
+        self.itemId = itemId
+        self.url = url
+        self.authHeader = authHeader
+    }
+
+    public func asURLRequest() -> URLRequest {
+        var req = URLRequest(url: url)
+        req.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        return req
+    }
+}
+
+extension JellyfinAPIClient: DownloadAPI {
+    /// Negotiates an offline download URL.
+    ///
+    /// We POST `PlaybackInfo` with a download-specific `DeviceProfile`:
+    ///   - `DirectPlayProfile`: MP4-family containers with `h264 / hevc` video
+    ///     and a wide audio codec list — when the source matches, Jellyfin
+    ///     hands us a static-stream URL and the bytes are the original file.
+    ///   - `TranscodingProfile`: `protocol = .http`, `container = "mp4"`,
+    ///     `context = .static` — when the source needs transcoding (MKV, AVI,
+    ///     anything HEVC-in-Matroska), Jellyfin returns `transcodingUrl`
+    ///     which is a progressive MP4 endpoint backed by a real transcoding
+    ///     session keyed on `PlaySessionId`. URLSession downloads it as a
+    ///     single file; once complete the `moov` atom is at EOF and AVPlayer
+    ///     plays it back natively.
+    ///
+    /// The previous direct `/Items/{id}/Download` shortcut left MKV libraries
+    /// stuck because AVPlayer can't demux Matroska. Going through PlaybackInfo
+    /// lets the server do exactly the work it's there to do.
+    public func buildDownloadRequest(itemId: String, userId: String) async throws -> DownloadStreamRequest {
+        guard let client = getClient(), let serverURL = getServerURL() else {
+            throw JellyfinError.notConnected
+        }
+
+        // Walk Series/Season → Episode if the caller handed us a non-playable id.
+        let initialItem = try await getItem(userId: userId, itemId: itemId)
+        let resolved = try await resolvePlayableEpisode(item: initialItem, itemId: itemId, userId: userId)
+        let item = resolved.item
+        let effectiveItemId = resolved.itemId
+        let mediaSourceId = item.mediaSources?.first?.id
+
+        var body = PlaybackInfoDto(deviceProfile: Self.buildDownloadDeviceProfile())
+        body.isAutoOpenLiveStream = true
+        body.userID = userId
+        body.maxStreamingBitrate = 40_000_000
+        if let mediaSourceId {
+            body.mediaSourceID = mediaSourceId
+        }
+
+        let response = try await rawPostPlaybackInfo(
+            serverURL: serverURL,
+            itemId: effectiveItemId,
+            client: client,
+            body: body
+        )
+
+        let mediaSource: MediaSourceInfo? = response.mediaSources?.first(where: { $0.id == mediaSourceId })
+            ?? response.mediaSources?.first
+        let playSessionId = response.playSessionID
+        let header = Self.buildAuthHeader(client: client)
+
+        // Transcoding path — server hands us a session-bound progressive MP4 URL.
+        if let transcodingPath = mediaSource?.transcodingURL {
+            let base = serverURL.absoluteString.trimmingCharacters(in: ["/"])
+            if let url = URL(string: base + transcodingPath) {
+                return DownloadStreamRequest(itemId: itemId, url: url, authHeader: header)
+            }
+        }
+
+        // Direct-stream path — source is already AVKit-friendly, no transcode needed.
+        if let playSessionId,
+           var components = URLComponents(url: serverURL, resolvingAgainstBaseURL: false) {
+            components.path = "/Videos/\(effectiveItemId)/stream"
+            components.queryItems = [
+                URLQueryItem(name: "static", value: "true"),
+                URLQueryItem(name: "playSessionId", value: playSessionId),
+                URLQueryItem(name: "mediaSourceId", value: mediaSource?.id ?? effectiveItemId)
+            ]
+            if let tag = item.etag {
+                components.queryItems?.append(URLQueryItem(name: "tag", value: tag))
+            }
+            if let url = components.url {
+                return DownloadStreamRequest(itemId: itemId, url: url, authHeader: header)
+            }
+        }
+
+        // Last-resort fallback: official download endpoint. Preserves source
+        // container, so the offline-playable gate in `VideoPlayerView` is what
+        // catches anything AVKit can't decode.
+        var components = URLComponents(url: serverURL, resolvingAgainstBaseURL: false) ?? URLComponents()
+        components.path = "/Items/\(effectiveItemId)/Download"
+        components.queryItems = [
+            URLQueryItem(name: "mediaSourceId", value: mediaSource?.id ?? effectiveItemId),
+            URLQueryItem(name: "deviceId", value: deviceID)
+        ]
+        guard let url = components.url else {
+            throw JellyfinError.playbackFailed("Failed to build download URL for \(itemId)")
+        }
+        return DownloadStreamRequest(itemId: itemId, url: url, authHeader: header)
+    }
+
+    // MARK: - Helpers
+
+    /// `DeviceProfile` used exclusively for offline downloads. Differs from the
+    /// streaming profile in two ways:
+    ///   - `TranscodingProfile.protocol = .http` (single MP4 file, not HLS
+    ///     manifest + segments) so URLSession can hand the result to AVPlayer
+    ///     as a single asset.
+    ///   - `context = .static` — the server treats this as a download session,
+    ///     emits the `moov` atom at EOF (no fast-start optimisation), and uses
+    ///     `Content-Disposition: attachment` so we can detect the resulting
+    ///     container from response headers.
+    nonisolated(unsafe) private static let _downloadDirectPlayProfiles: [DirectPlayProfile] = [
+        DirectPlayProfile(
+            audioCodec: "aac,ac3,eac3,mp3,flac,alac",
+            container: "mp4,m4v,mov,m4a",
+            type: .video,
+            videoCodec: "h264,hevc"
+        )
+    ]
+    nonisolated(unsafe) private static let _downloadTranscodingProfiles: [TranscodingProfile] = [
+        TranscodingProfile(
+            audioCodec: "aac",
+            isBreakOnNonKeyFrames: false,
+            container: "mp4",
+            context: .static,
+            enableSubtitlesInManifest: false,
+            maxAudioChannels: "6",
+            minSegments: 0,
+            protocol: .http,
+            type: .video,
+            videoCodec: "h264"
+        )
+    ]
+
+    private static func buildDownloadDeviceProfile() -> DeviceProfile {
+        DeviceProfile(
+            directPlayProfiles: _downloadDirectPlayProfiles,
+            maxStreamingBitrate: 40_000_000,
+            transcodingProfiles: _downloadTranscodingProfiles
+        )
+    }
+
+    private static func buildAuthHeader(client: JellyfinClient) -> String {
+        var fields = [
+            "DeviceId": client.configuration.deviceID,
+            "Device": client.configuration.deviceName,
+            "Client": client.configuration.client,
+            "Version": client.configuration.version
+        ]
+        if let token = client.accessToken {
+            fields["Token"] = token
+        }
+        return "MediaBrowser " + fields.map { "\($0.key)=\($0.value)" }.joined(separator: ", ")
+    }
+}
+
+/// Protocol slice so the manager can depend on a narrow surface for tests.
+public protocol DownloadAPI: Sendable {
+    /// Negotiates a one-shot download URL for `itemId`. The returned request
+    /// is fed straight to `URLSession.downloadTask(with:)`.
+    func buildDownloadRequest(itemId: String, userId: String) async throws -> DownloadStreamRequest
+}

--- a/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient+Playback.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient+Playback.swift
@@ -188,7 +188,7 @@ extension JellyfinAPIClient {
     /// Movies (and any other already-playable kind) pass through unchanged.
     /// Series prefers the user's "Next Up" episode; falls back to the first
     /// episode of the first season. Season picks the first episode.
-    private func resolvePlayableEpisode(
+    internal func resolvePlayableEpisode(
         item: BaseItemDto,
         itemId: String,
         userId: String
@@ -235,7 +235,7 @@ extension JellyfinAPIClient {
     }
 
     /// Raw HTTP POST to PlaybackInfo, captures the full response body for diagnosis.
-    private func rawPostPlaybackInfo(
+    internal func rawPostPlaybackInfo(
         serverURL: URL,
         itemId: String,
         client: JellyfinClient,
@@ -270,6 +270,7 @@ extension JellyfinAPIClient {
         }
         #endif
 
+        request.timeoutInterval = 8
         let (data, urlResponse) = try await URLSession.shared.data(for: request)
         let httpResponse = urlResponse as? HTTPURLResponse
 

--- a/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient.swift
@@ -139,7 +139,8 @@ public final class JellyfinAPIClient: Sendable {
                 deviceName: deviceName,
                 deviceID: deviceID,
                 version: appVersion
-            )
+            ),
+            sessionConfiguration: Self.fastFailSessionConfiguration
         )
 
         let response = try await client.send(Paths.getPublicSystemInfo)
@@ -203,7 +204,8 @@ public final class JellyfinAPIClient: Sendable {
                     deviceName: deviceName,
                     deviceID: deviceID,
                     version: appVersion
-                )
+                ),
+                sessionConfiguration: Self.fastFailSessionConfiguration
             )
             setClient(authedClient, url: url)
         }
@@ -233,10 +235,26 @@ public final class JellyfinAPIClient: Sendable {
                 deviceName: deviceName,
                 deviceID: deviceID,
                 version: appVersion
-            )
+            ),
+            sessionConfiguration: Self.fastFailSessionConfiguration
         )
         setClient(client, url: url)
     }
+
+    /// URLSession configuration applied to every `JellyfinClient` we hand out.
+    /// Default system timeouts (~60s per request, 7 days per resource) make
+    /// the app feel frozen when the user goes offline mid-flow — these tight
+    /// values surface a `URLError` in ~8s so callers can fall back to cached
+    /// or downloaded content. NetworkMonitor in the app layer gives us the
+    /// fast path; this is the safety net for cases where the OS hasn't yet
+    /// flipped path status.
+    fileprivate static let fastFailSessionConfiguration: URLSessionConfiguration = {
+        let c = URLSessionConfiguration.default
+        c.timeoutIntervalForRequest = 8
+        c.timeoutIntervalForResource = 20
+        c.waitsForConnectivity = false
+        return c
+    }()
 
     private var deviceName: String {
         #if os(tvOS)

--- a/Packages/CinemaxKit/Sources/CinemaxKit/Persistence/DownloadStorage.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Persistence/DownloadStorage.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+/// File system layout for offline downloads.
+///
+///   Application Support/
+///     Cinemax/
+///       Downloads/
+///         index.json                  ← `DownloadStore` JSON catalog
+///         files/
+///           <itemId>.<ext>            ← finished media
+///         resume/
+///           <itemId>.resume           ← URLSession resume blobs for paused / interrupted tasks
+///
+/// Whole `Downloads` subtree is marked `isExcludedFromBackup` so a 30 GB
+/// offline library doesn't end up in iCloud.
+public enum DownloadStorage {
+    public static func downloadsRoot() throws -> URL {
+        let appSupport = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        let root = appSupport.appendingPathComponent("Cinemax/Downloads", isDirectory: true)
+        try ensureDirectory(at: root, excludeFromBackup: true)
+        try ensureDirectory(at: root.appendingPathComponent("files", isDirectory: true), excludeFromBackup: false)
+        try ensureDirectory(at: root.appendingPathComponent("resume", isDirectory: true), excludeFromBackup: false)
+        try ensureDirectory(at: root.appendingPathComponent("art", isDirectory: true), excludeFromBackup: false)
+        return root
+    }
+
+    public static func indexURL() throws -> URL {
+        try downloadsRoot().appendingPathComponent("index.json", isDirectory: false)
+    }
+
+    public static func filesDirectory() throws -> URL {
+        try downloadsRoot().appendingPathComponent("files", isDirectory: true)
+    }
+
+    public static func resumeDirectory() throws -> URL {
+        try downloadsRoot().appendingPathComponent("resume", isDirectory: true)
+    }
+
+    public static func artDirectory() throws -> URL {
+        try downloadsRoot().appendingPathComponent("art", isDirectory: true)
+    }
+
+    public static func mediaFileURL(itemId: String, ext: String) throws -> URL {
+        try filesDirectory().appendingPathComponent("\(itemId).\(ext)", isDirectory: false)
+    }
+
+    public static func resumeFileURL(itemId: String) throws -> URL {
+        try resumeDirectory().appendingPathComponent("\(itemId).resume", isDirectory: false)
+    }
+
+    /// Local cache path for an item's poster artwork. `kind` keys the file so
+    /// a movie poster and a series backdrop can coexist without clobbering
+    /// each other.
+    public enum ArtKind: String, Sendable {
+        case poster   // 2:3 primary image
+        case backdrop // 16:9 hero image
+    }
+
+    public static func artFileURL(itemId: String, kind: ArtKind) throws -> URL {
+        try artDirectory().appendingPathComponent("\(itemId)-\(kind.rawValue).jpg", isDirectory: false)
+    }
+
+    /// Removes every downloaded file (media, resume blobs, posters, and the
+    /// catalog itself). Used by "Remove all downloads" in Settings.
+    public static func wipeEverything() {
+        guard let root = try? downloadsRoot() else { return }
+        let fm = FileManager.default
+        if let contents = try? fm.contentsOfDirectory(at: root, includingPropertiesForKeys: nil) {
+            for url in contents {
+                try? fm.removeItem(at: url)
+            }
+        }
+        // Re-create the empty subtree so subsequent downloads have somewhere
+        // to land without a crash.
+        _ = try? downloadsRoot()
+    }
+
+    /// Deletes files in `files/` whose itemId isn't referenced by any of the
+    /// passed-in catalog entries. Used at app launch to drop orphaned media
+    /// left behind by aborted downloads or interrupted catalog writes.
+    public static func reconcileOrphans(against trackedIDs: Set<String>) {
+        guard let dir = try? filesDirectory(),
+              let contents = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil) else {
+            return
+        }
+        for url in contents {
+            let stem = url.deletingPathExtension().lastPathComponent
+            if !trackedIDs.contains(stem) {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+    }
+
+    public static func totalDiskUsage() -> Int64 {
+        // Walk both the media and art subtrees so the surfaced number matches
+        // what `wipeEverything` would free — otherwise the banner reads less
+        // than the actual on-disk footprint.
+        var total: Int64 = 0
+        for dir in [try? filesDirectory(), try? artDirectory()].compactMap({ $0 }) {
+            guard let enumerator = FileManager.default.enumerator(at: dir, includingPropertiesForKeys: [.fileSizeKey]) else { continue }
+            for case let url as URL in enumerator {
+                let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+                total += Int64(size)
+            }
+        }
+        return total
+    }
+
+    // MARK: - Helpers
+
+    private static func ensureDirectory(at url: URL, excludeFromBackup: Bool) throws {
+        var isDir: ObjCBool = false
+        if !FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir) {
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        }
+        if excludeFromBackup {
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            var mutable = url
+            try? mutable.setResourceValues(values)
+        }
+    }
+}

--- a/Packages/CinemaxKit/Sources/CinemaxKit/Persistence/DownloadStore.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Persistence/DownloadStore.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// JSON-backed catalog of `DownloadItem`s persisted to Application Support.
+///
+/// Designed as a thin, lock-protected facade — `DownloadManager` owns the
+/// state machine and calls in for atomic reads + writes. Same locking
+/// invariant as `JellyfinAPIClient`: every access goes through one of the
+/// accessor methods. Saves are debounced via direct synchronous writes;
+/// the catalog is tiny (one entry per download), so writing on every mutation
+/// is fine.
+public final class DownloadStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var items: [String: DownloadItem] = [:]
+    private let url: URL?
+
+    public init() {
+        let resolved = (try? DownloadStorage.indexURL())
+        self.url = resolved
+        if let url = resolved, let data = try? Data(contentsOf: url) {
+            if let decoded = try? JSONDecoder.cinemax.decode([DownloadItem].self, from: data) {
+                self.items = Dictionary(uniqueKeysWithValues: decoded.map { ($0.id, $0) })
+            }
+        }
+    }
+
+    public func all() -> [DownloadItem] {
+        lock.lock(); defer { lock.unlock() }
+        return Array(items.values)
+    }
+
+    public func item(id: String) -> DownloadItem? {
+        lock.lock(); defer { lock.unlock() }
+        return items[id]
+    }
+
+    /// Inserts or replaces an item. Persists to disk synchronously.
+    @discardableResult
+    public func upsert(_ item: DownloadItem) -> DownloadItem {
+        lock.lock()
+        items[item.id] = item
+        let snapshot = Array(items.values)
+        lock.unlock()
+        persist(snapshot)
+        return item
+    }
+
+    /// Mutates an existing item in place. No-op if the id isn't tracked.
+    @discardableResult
+    public func update(id: String, _ mutation: (inout DownloadItem) -> Void) -> DownloadItem? {
+        lock.lock()
+        guard var current = items[id] else {
+            lock.unlock()
+            return nil
+        }
+        mutation(&current)
+        items[id] = current
+        let snapshot = Array(items.values)
+        lock.unlock()
+        persist(snapshot)
+        return current
+    }
+
+    public func remove(id: String) {
+        lock.lock()
+        items.removeValue(forKey: id)
+        let snapshot = Array(items.values)
+        lock.unlock()
+        persist(snapshot)
+    }
+
+    /// Items downloading or queued — used to compute concurrency.
+    public func active() -> [DownloadItem] {
+        lock.lock(); defer { lock.unlock() }
+        return items.values.filter { $0.status == .downloading || $0.status == .queued }
+    }
+
+    // MARK: - Persistence
+
+    private func persist(_ snapshot: [DownloadItem]) {
+        guard let url else { return }
+        do {
+            let data = try JSONEncoder.cinemax.encode(snapshot.sorted(by: { $0.createdAt < $1.createdAt }))
+            try data.write(to: url, options: .atomic)
+        } catch {
+            // Loss of catalogue is recoverable from disk scan on next launch,
+            // so swallow rather than crash.
+        }
+    }
+}
+
+extension JSONDecoder {
+    static let cinemax: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }()
+}
+
+extension JSONEncoder {
+    static let cinemax: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        e.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return e
+    }()
+}

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -748,3 +748,51 @@
 "admin.plugins.versionLabel" = "v%@";
 "admin.dashboard.sessionClient" = "• %@";
 "admin.metadata.ratingDenominator" = "/ 10";
+
+// MARK: - Downloads (offline)
+
+"settings.downloads" = "Downloads";
+"settings.downloads.subtitle" = "Your offline movies & shows";
+"downloads.title" = "Downloads";
+"downloads.empty.title" = "No downloads yet";
+"downloads.empty.subtitle" = "Download a movie or episode to watch it offline.";
+"downloads.section.movies" = "Movies";
+"downloads.section.series" = "Shows";
+"downloads.totalSpace" = "%@ used";
+"downloads.status.queued" = "Queued";
+"downloads.status.downloading" = "Downloading";
+"downloads.status.paused" = "Paused";
+"downloads.status.completed" = "Downloaded";
+"downloads.status.failed" = "Failed";
+"downloads.progress" = "%d %%";
+"downloads.action.pause" = "Pause";
+"downloads.action.resume" = "Resume";
+"downloads.action.retry" = "Retry";
+"downloads.action.cancel" = "Cancel";
+"downloads.action.remove" = "Remove";
+"downloads.action.removeAll" = "Remove all";
+"downloads.confirmRemove.title" = "Remove this download?";
+"downloads.confirmRemove.message" = "The file will be deleted from this device.";
+"downloads.removeAll.title" = "Remove all downloads?";
+"downloads.removeAll.message" = "Every download and any leftover files will be deleted from this device.";
+
+"detail.download" = "Download";
+"detail.downloading" = "Downloading…";
+"detail.downloaded" = "Downloaded";
+"detail.download.cancel" = "Cancel download";
+"detail.download.removeFromDevice" = "Remove from device";
+"detail.download.queueSeason" = "Download season";
+"detail.download.queueSeries" = "Download series";
+
+"toast.download.queued" = "Download queued";
+"toast.download.queuedMany" = "%d episodes queued";
+"toast.download.removed" = "Download removed";
+"toast.download.error" = "Download failed";
+"toast.download.unsupportedContainer" = "Download started — but this format isn't playable offline on iOS.";
+"player.error.unsupportedOfflineContainer" = "This file (%@) can't be played offline on iOS. Re-encode it to MP4 on your Jellyfin server to enjoy it without a network.";
+
+// MARK: - Offline mode
+
+"offline.banner" = "Offline mode · downloaded content only";
+"offline.empty.title" = "You're offline";
+"offline.empty.subtitle" = "Download movies or episodes while you have a connection to find them here.";

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -748,4 +748,52 @@
 
 "admin.plugins.versionLabel" = "v%@";
 "admin.dashboard.sessionClient" = "• %@";
+
+// MARK: - Downloads (offline)
+
+"settings.downloads" = "Téléchargements";
+"settings.downloads.subtitle" = "Vos films et séries hors-ligne";
+"downloads.title" = "Téléchargements";
+"downloads.empty.title" = "Aucun téléchargement";
+"downloads.empty.subtitle" = "Téléchargez un film ou un épisode pour le regarder hors-ligne.";
+"downloads.section.movies" = "Films";
+"downloads.section.series" = "Séries";
+"downloads.totalSpace" = "%@ utilisés";
+"downloads.status.queued" = "En attente";
+"downloads.status.downloading" = "En cours";
+"downloads.status.paused" = "En pause";
+"downloads.status.completed" = "Téléchargé";
+"downloads.status.failed" = "Échec";
+"downloads.progress" = "%d %%";
+"downloads.action.pause" = "Mettre en pause";
+"downloads.action.resume" = "Reprendre";
+"downloads.action.retry" = "Réessayer";
+"downloads.action.cancel" = "Annuler";
+"downloads.action.remove" = "Supprimer";
+"downloads.action.removeAll" = "Tout supprimer";
+"downloads.confirmRemove.title" = "Supprimer ce téléchargement ?";
+"downloads.confirmRemove.message" = "Le fichier sera supprimé de cet appareil.";
+"downloads.removeAll.title" = "Tout supprimer ?";
+"downloads.removeAll.message" = "Tous les téléchargements et fichiers résiduels seront effacés de cet appareil.";
+
+"detail.download" = "Télécharger";
+"detail.downloading" = "Téléchargement…";
+"detail.downloaded" = "Téléchargé";
+"detail.download.cancel" = "Annuler le téléchargement";
+"detail.download.removeFromDevice" = "Supprimer de l'appareil";
+"detail.download.queueSeason" = "Télécharger la saison";
+"detail.download.queueSeries" = "Télécharger la série";
+
+"toast.download.queued" = "Téléchargement ajouté à la file";
+"toast.download.queuedMany" = "%d épisodes ajoutés à la file";
+"toast.download.removed" = "Téléchargement supprimé";
+"toast.download.error" = "Échec du téléchargement";
+"toast.download.unsupportedContainer" = "Téléchargement lancé, mais ce format n'est pas lisible hors-ligne sur iOS.";
+"player.error.unsupportedOfflineContainer" = "Ce fichier (%@) ne peut pas être lu hors-ligne sur iOS. Reconvertissez-le en MP4 sur votre serveur Jellyfin pour le regarder sans réseau.";
+
+// MARK: - Offline mode
+
+"offline.banner" = "Mode hors-ligne · Contenu téléchargé uniquement";
+"offline.empty.title" = "Vous êtes hors-ligne";
+"offline.empty.subtitle" = "Téléchargez des films ou des épisodes lorsque vous avez du réseau pour les retrouver ici.";
 "admin.metadata.ratingDenominator" = "/ 10";

--- a/Shared/Navigation/AppNavigation.swift
+++ b/Shared/Navigation/AppNavigation.swift
@@ -61,6 +61,11 @@ final class AppState {
 
     var imageServerURL: URL { serverURL ?? Self.placeholderServerURL }
 
+    /// Hydrates auth state from the keychain. Network probes (server info,
+    /// admin flag) are dispatched in the background so the UI doesn't wait
+    /// on them — important when the user launches the app offline, where
+    /// each probe would otherwise eat a request timeout before the launch
+    /// screen disappears.
     func restoreSession() async {
         guard let serverURL = keychain.getServerURL(),
               let session = keychain.getUserSession() else {
@@ -80,15 +85,17 @@ final class AppState {
         let storedAge = UserDefaults.standard.integer(forKey: SettingsKey.privacyMaxContentAge)
         apiClient.applyContentRatingLimit(maxAge: storedAge)
 
-        // Fetch server info without replacing the authenticated client
-        do {
-            let info = try await apiClient.fetchServerInfo()
-            self.serverInfo = info
-        } catch {
-            // Server may be temporarily unreachable, keep stored state
+        // Non-blocking: kick the server-info + admin-policy fetches behind the
+        // launch transition. They populate `serverInfo` / `isAdministrator`
+        // when (and if) they succeed; failures are non-fatal and leave the
+        // user authenticated with last-known values.
+        Task { [weak self] in
+            guard let self else { return }
+            if let info = try? await self.apiClient.fetchServerInfo() {
+                self.serverInfo = info
+            }
+            await self.refreshCurrentUser()
         }
-
-        await refreshCurrentUser()
     }
 
     /// Refreshes `currentUser` + `isAdministrator` from the server. Call on
@@ -140,6 +147,10 @@ struct AppNavigation: View {
     @State private var themeManager = ThemeManager()
     @State private var loc = LocalizationManager()
     @State private var toasts = ToastCenter()
+    @State private var network = NetworkMonitor()
+    #if os(iOS)
+    @State private var downloads = DownloadManager()
+    #endif
     @State private var hasCheckedSession = false
     @Environment(\.scenePhase) private var scenePhase
 
@@ -190,6 +201,10 @@ struct AppNavigation: View {
         .environment(themeManager)
         .environment(loc)
         .environment(toasts)
+        .environment(network)
+        #if os(iOS)
+        .environment(downloads)
+        #endif
         .environment(\.motionEffectsEnabled, motionEffects)
         // Respect the user's OS Dynamic Type setting while capping at a size
         // that won't collapse layouts (hero titles, tab bar). The app also has
@@ -199,7 +214,18 @@ struct AppNavigation: View {
         .task {
             await appState.restoreSession()
             hasCheckedSession = true
+            #if os(iOS)
+            downloads.attach(apiClient: appState.apiClient, userId: appState.currentUserId)
+            #endif
         }
+        #if os(iOS)
+        .onChange(of: appState.currentUserId) { _, newId in
+            // Re-attach when the active user changes (login, quick switch).
+            // The manager caches `userId` for queued-task negotiation, so it
+            // needs to know about the swap.
+            downloads.attach(apiClient: appState.apiClient, userId: newId)
+        }
+        #endif
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .background {
                 NotificationCenter.default.post(name: .cinemaxDidEnterBackground, object: nil)

--- a/Shared/Screens/Downloads/DownloadButton.swift
+++ b/Shared/Screens/Downloads/DownloadButton.swift
@@ -1,0 +1,267 @@
+#if os(iOS)
+import SwiftUI
+import CinemaxKit
+import JellyfinAPI
+
+/// Download affordance for `MediaDetailScreen` and similar surfaces.
+///
+/// Renders a single icon button whose state mirrors `DownloadManager.item(for:)`:
+///   * not downloaded → `arrow.down.circle`         (tap → enqueue)
+///   * downloading    → progress ring + `%`         (tap → pause)
+///   * paused / failed → `play.circle` / `arrow.triangle.2.circlepath` (tap → resume)
+///   * completed      → `checkmark.circle.fill`     (long-press menu → remove)
+///
+/// For a series, callers pass `bulk = .series(seasons:episodes:)` so the
+/// menu can offer "Download whole series" alongside "Download this season".
+struct DownloadButton: View {
+    @Environment(DownloadManager.self) private var downloads
+    @Environment(LocalizationManager.self) private var loc
+    @Environment(ToastCenter.self) private var toasts
+    @Environment(ThemeManager.self) private var themeManager
+    @Environment(AppState.self) private var appState
+
+    let item: BaseItemDto
+    var bulk: BulkContext? = nil
+
+    @State private var showRemoveConfirm = false
+    @State private var isFetchingSeries = false
+
+    enum BulkContext {
+        /// `episodes` is the current season's list; `seasonName` labels the menu item.
+        case season(episodes: [BaseItemDto], seasonName: String)
+        /// Series-level menu: pre-loaded current season + an async loader that
+        /// fans out across every season when the user picks "Download whole series".
+        /// The loader runs on-demand so we don't pre-fetch episode lists the user
+        /// might never need.
+        case series(currentSeasonEpisodes: [BaseItemDto],
+                    currentSeasonName: String,
+                    fetchAllEpisodes: @MainActor () async -> [BaseItemDto])
+    }
+
+    var body: some View {
+        Group {
+            switch bulk {
+            case .none:
+                simpleButton
+            case .season(let eps, _):
+                bulkMenu(seasonEpisodes: eps, fetchSeries: nil)
+            case .series(let cur, _, let fetchAll):
+                bulkMenu(seasonEpisodes: cur, fetchSeries: fetchAll)
+            }
+        }
+        .confirmationDialog(
+            loc.localized("downloads.confirmRemove.title"),
+            isPresented: $showRemoveConfirm,
+            titleVisibility: .visible
+        ) {
+            Button(loc.localized("downloads.action.remove"), role: .destructive) {
+                guard let id = item.id else { return }
+                downloads.remove(id)
+                toasts.info(loc.localized("toast.download.removed"))
+            }
+            Button(loc.localized("action.cancel"), role: .cancel) {}
+        } message: {
+            Text(loc.localized("downloads.confirmRemove.message"))
+        }
+    }
+
+    // MARK: - Simple (single-item) button
+
+    @ViewBuilder
+    private var simpleButton: some View {
+        let entry = item.id.flatMap { downloads.item(for: $0) }
+        Button {
+            handlePrimaryTap(entry: entry)
+        } label: {
+            iconView(entry: entry)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel(for: entry))
+    }
+
+    // MARK: - Bulk (season / series) menu
+
+    @ViewBuilder
+    private func bulkMenu(seasonEpisodes: [BaseItemDto], fetchSeries: (@MainActor () async -> [BaseItemDto])?) -> some View {
+        let entry = item.id.flatMap { downloads.item(for: $0) }
+        Menu {
+            Button {
+                enqueueMany(seasonEpisodes)
+            } label: {
+                Label(loc.localized("detail.download.queueSeason"), systemImage: "square.stack.3d.up")
+            }
+            if let fetchSeries {
+                Button {
+                    isFetchingSeries = true
+                    Task {
+                        let all = await fetchSeries()
+                        isFetchingSeries = false
+                        enqueueMany(all)
+                    }
+                } label: {
+                    Label(loc.localized("detail.download.queueSeries"), systemImage: "rectangle.stack")
+                }
+                .disabled(isFetchingSeries)
+            }
+        } label: {
+            iconView(entry: entry)
+        }
+        .accessibilityLabel(loc.localized("detail.download"))
+    }
+
+    // MARK: - Icon
+
+    @ViewBuilder
+    private func iconView(entry: DownloadItem?) -> some View {
+        ZStack {
+            Circle()
+                .fill(.ultraThinMaterial)
+                .frame(width: 44, height: 44)
+            switch entry?.status {
+            case .none:
+                Image(systemName: "arrow.down.circle")
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(themeManager.accent)
+            case .queued:
+                Image(systemName: "clock")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(themeManager.accent)
+            case .downloading:
+                ProgressRing(progress: entry?.progress ?? 0, tint: themeManager.accent)
+                    .frame(width: 28, height: 28)
+            case .paused:
+                Image(systemName: "play.circle")
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(themeManager.accent)
+            case .failed:
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(CinemaColor.error)
+            case .completed:
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(themeManager.accent)
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func handlePrimaryTap(entry: DownloadItem?) {
+        guard let id = item.id else { return }
+        switch entry?.status {
+        case .none:
+            enqueueSingle()
+        case .downloading, .queued:
+            downloads.pause(id)
+        case .paused, .failed:
+            downloads.resume(id)
+        case .completed:
+            showRemoveConfirm = true
+        }
+    }
+
+    private func enqueueSingle() {
+        guard let id = item.id, let userId = appState.currentUserId else { return }
+        // PlaybackInfo negotiation is async — fire-and-forget so the UI stays
+        // responsive. Toast feedback happens once the URL is in hand.
+        let item = item
+        let posterURLs = artworkURLs(for: item)
+        Task {
+            do {
+                let req = try await appState.apiClient.buildDownloadRequest(itemId: id, userId: userId)
+                guard let dl = DownloadItem.from(item: item, request: req) else {
+                    toasts.error(loc.localized("toast.download.error"))
+                    return
+                }
+                downloads.enqueue(dl, posterURL: posterURLs.0, backdropURL: posterURLs.1)
+                toasts.success(loc.localized("toast.download.queued"))
+            } catch {
+                toasts.error(loc.localized("toast.download.error"))
+            }
+        }
+    }
+
+    private func enqueueMany(_ episodes: [BaseItemDto]) {
+        guard let userId = appState.currentUserId else { return }
+        Task {
+            var queued = 0
+            for ep in episodes {
+                guard let epId = ep.id else { continue }
+                if downloads.item(for: epId) != nil { continue }
+                guard let req = try? await appState.apiClient.buildDownloadRequest(itemId: epId, userId: userId),
+                      let dl = DownloadItem.from(item: ep, request: req) else { continue }
+                let (poster, backdrop) = artworkURLs(for: ep)
+                downloads.enqueue(dl, posterURL: poster, backdropURL: backdrop)
+                queued += 1
+            }
+            emitBulkToast(queued: queued)
+        }
+    }
+
+    @MainActor
+    private func emitBulkToast(queued: Int) {
+        if queued == 0 {
+            toasts.info(loc.localized("toast.download.queued"))
+        } else if queued == 1 {
+            toasts.success(loc.localized("toast.download.queued"))
+        } else {
+            toasts.success(loc.localized("toast.download.queuedMany", queued))
+        }
+    }
+
+    private func accessibilityLabel(for entry: DownloadItem?) -> String {
+        switch entry?.status {
+        case .completed: loc.localized("detail.downloaded")
+        case .downloading, .queued: loc.localized("detail.downloading")
+        case .paused: loc.localized("downloads.action.resume")
+        case .failed: loc.localized("downloads.action.retry")
+        case .none: loc.localized("detail.download")
+        }
+    }
+
+    /// True when the item's source container is one AVPlayer can decode.
+    /// Anything else (MKV, AVI, WebM) downloads fine but renders audio-only —
+    /// callers use this to warn at enqueue and to gate playback. The check is
+    /// container-only; for codec mismatches AVPlayer surfaces its own error.
+    static func isLikelyOfflinePlayable(_ item: BaseItemDto) -> Bool {
+        guard let container = item.mediaSources?.first?.container else { return true }
+        let parts = container.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+        return parts.contains(where: { DownloadItem.avkitFriendlyContainers.contains($0) })
+    }
+
+    /// Builds (poster, backdrop) URLs for the artwork prefetch that runs
+    /// alongside the media download. Episodes pull the series poster so the
+    /// offline library renders a consistent show artwork, but keep their own
+    /// (episode-id) image as the backdrop fallback when no series backdrop
+    /// has been registered.
+    private func artworkURLs(for ep: BaseItemDto) -> (URL?, URL?) {
+        guard let id = ep.id else { return (nil, nil) }
+        let posterId = ep.seriesID ?? id
+        let backdropId = ep.backdropItemID ?? id
+        let poster = appState.imageBuilder.imageURL(itemId: posterId, imageType: .primary, maxWidth: 480)
+        let backdrop = appState.imageBuilder.imageURL(itemId: backdropId, imageType: .backdrop, maxWidth: 1280)
+        return (poster, backdrop)
+    }
+}
+
+/// Circular determinate progress indicator used inside `DownloadButton`.
+struct ProgressRing: View {
+    var progress: Double
+    var tint: Color
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(tint.opacity(0.25), lineWidth: 3)
+            Circle()
+                .trim(from: 0, to: max(0.02, progress))
+                .stroke(tint, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+            Image(systemName: "pause.fill")
+                .font(.system(size: 10, weight: .bold))
+                .foregroundStyle(tint)
+        }
+    }
+}
+#endif

--- a/Shared/Screens/Downloads/DownloadItem+BaseItemDto.swift
+++ b/Shared/Screens/Downloads/DownloadItem+BaseItemDto.swift
@@ -1,0 +1,48 @@
+#if os(iOS)
+import Foundation
+import CinemaxKit
+import JellyfinAPI
+
+extension DownloadItem {
+    /// Builds a `DownloadItem` for a single movie or episode `BaseItemDto`.
+    /// Returns `nil` for kinds that aren't directly playable (series, season,
+    /// folders) — those fan out via `episodes(in:)` and enqueue per-episode.
+    static func from(item: BaseItemDto, request: DownloadStreamRequest) -> DownloadItem? {
+        guard let id = item.id else { return nil }
+        let kind: DownloadKind
+        switch item.type {
+        case .movie: kind = .movie
+        case .episode: kind = .episode
+        default: return nil
+        }
+        // We download the *original* file (Jellyfin's /Items/{id}/Download),
+        // so the container needs to follow the source. The actual extension on
+        // disk is refined post-download from the server's Content-Disposition
+        // header — this value is just the initial guess used while the task is
+        // still in flight (e.g. for progress UIs that show size estimates).
+        let ext = (item.mediaSources?.first?.container?.split(separator: ",").first).map(String.init) ?? "mp4"
+        return DownloadItem(
+            id: id,
+            kind: kind,
+            title: item.name ?? "",
+            posterTag: item.imageTags?["Primary"],
+            seriesId: item.seriesID,
+            seriesTitle: item.seriesName,
+            seasonId: item.seasonID,
+            seasonName: item.seasonName,
+            seasonIndex: item.parentIndexNumber,
+            episodeIndex: item.indexNumber,
+            remoteURL: request.url,
+            containerExt: ext,
+            runtimeTicks: item.runTimeTicks,
+            overview: item.overview,
+            productionYear: item.productionYear,
+            genres: item.genres ?? [],
+            officialRating: item.officialRating,
+            communityRating: item.communityRating,
+            premiereDate: item.premiereDate,
+            backdropItemID: item.backdropItemID
+        )
+    }
+}
+#endif

--- a/Shared/Screens/Downloads/DownloadsScreen.swift
+++ b/Shared/Screens/Downloads/DownloadsScreen.swift
@@ -1,0 +1,351 @@
+#if os(iOS)
+import SwiftUI
+import CinemaxKit
+import JellyfinAPI
+
+/// Management surface for offline downloads.
+///
+/// Pushed from Settings → Downloads. Renders a grouped list of movies and
+/// per-series episode bundles, each with status / progress / per-row actions
+/// (pause, resume, retry, remove). Empty state nudges the user to the detail
+/// screens where the actual download button lives.
+struct DownloadsScreen: View {
+    @Environment(DownloadManager.self) private var downloads
+    @Environment(LocalizationManager.self) private var loc
+    @Environment(ThemeManager.self) private var themeManager
+    @Environment(AppState.self) private var appState
+    @Environment(ToastCenter.self) private var toasts
+
+    @State private var pendingRemoval: DownloadItem?
+    @State private var showRemoveAllConfirm = false
+
+    var body: some View {
+        ZStack {
+            CinemaColor.surface.ignoresSafeArea()
+            if downloads.items.isEmpty {
+                EmptyStateView(
+                    systemImage: "arrow.down.circle",
+                    title: loc.localized("downloads.empty.title"),
+                    subtitle: loc.localized("downloads.empty.subtitle")
+                )
+            } else {
+                content
+            }
+        }
+        .navigationTitle(loc.localized("downloads.title"))
+        .navigationBarTitleDisplayMode(.large)
+        .confirmationDialog(
+            loc.localized("downloads.confirmRemove.title"),
+            isPresented: Binding(
+                get: { pendingRemoval != nil },
+                set: { if !$0 { pendingRemoval = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button(loc.localized("downloads.action.remove"), role: .destructive) {
+                if let entry = pendingRemoval {
+                    downloads.remove(entry.id)
+                    toasts.info(loc.localized("toast.download.removed"))
+                }
+                pendingRemoval = nil
+            }
+            Button(loc.localized("action.cancel"), role: .cancel) { pendingRemoval = nil }
+        } message: {
+            Text(loc.localized("downloads.confirmRemove.message"))
+        }
+    }
+
+    // MARK: - Sections
+
+    private var content: some View {
+        let groups = grouped(downloads.items)
+        return ScrollView(showsIndicators: false) {
+            VStack(alignment: .leading, spacing: CinemaSpacing.spacing5) {
+                diskUsageBanner
+
+                if !groups.movies.isEmpty {
+                    section(title: loc.localized("downloads.section.movies"), rows: {
+                        ForEach(groups.movies) { entry in
+                            row(for: entry)
+                        }
+                    })
+                }
+
+                ForEach(groups.seriesOrder, id: \.self) { seriesKey in
+                    if let bucket = groups.series[seriesKey] {
+                        section(title: bucket.title, rows: {
+                            ForEach(bucket.episodes) { entry in
+                                row(for: entry)
+                            }
+                        })
+                    }
+                }
+            }
+            .padding(.horizontal, CinemaSpacing.spacing3)
+            .padding(.bottom, CinemaSpacing.spacing8)
+        }
+    }
+
+    private var diskUsageBanner: some View {
+        Menu {
+            Button(role: .destructive) {
+                showRemoveAllConfirm = true
+            } label: {
+                Label(loc.localized("downloads.action.removeAll"), systemImage: "trash")
+            }
+        } label: {
+            HStack {
+                Image(systemName: "internaldrive")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(themeManager.accent)
+                Text(loc.localized("downloads.totalSpace", formatBytes(downloads.totalDiskBytes)))
+                    .font(CinemaFont.label(.medium))
+                    .foregroundStyle(CinemaColor.onSurfaceVariant)
+                Spacer()
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(CinemaColor.outlineVariant)
+            }
+            .padding(CinemaSpacing.spacing3)
+            .glassPanel(cornerRadius: CinemaRadius.large)
+        }
+        .buttonStyle(.plain)
+        .confirmationDialog(
+            loc.localized("downloads.removeAll.title"),
+            isPresented: $showRemoveAllConfirm,
+            titleVisibility: .visible
+        ) {
+            Button(loc.localized("downloads.action.removeAll"), role: .destructive) {
+                downloads.removeAll()
+                toasts.info(loc.localized("toast.download.removed"))
+            }
+            Button(loc.localized("action.cancel"), role: .cancel) {}
+        } message: {
+            Text(loc.localized("downloads.removeAll.message"))
+        }
+    }
+
+    private func section<Content: View>(title: String, @ViewBuilder rows: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: CinemaSpacing.spacing2) {
+            iOSSettingsSectionHeader(title)
+            VStack(spacing: 0) {
+                rows()
+            }
+            .glassPanel(cornerRadius: CinemaRadius.extraLarge)
+        }
+    }
+
+    // MARK: - Row
+
+    @ViewBuilder
+    private func row(for entry: DownloadItem) -> some View {
+        VStack(spacing: 0) {
+            ZStack {
+                // Tappable layer — only active when the file is fully on disk.
+                // Sits underneath the inline action menu so the ellipsis still
+                // wins the gesture for live downloads.
+                if entry.status == .completed {
+                    PlayLink(
+                        itemId: entry.id,
+                        title: rowTitle(for: entry)
+                    ) {
+                        Color.clear.contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                HStack(alignment: .center, spacing: CinemaSpacing.spacing3) {
+                    thumbnail(for: entry)
+                        .frame(width: 72, height: 48)
+                        .clipShape(RoundedRectangle(cornerRadius: CinemaRadius.small))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: CinemaRadius.small)
+                                .strokeBorder(CinemaColor.onSurface.opacity(0.08), lineWidth: 1)
+                        )
+                        .overlay {
+                            if entry.status == .completed {
+                                Image(systemName: "play.fill")
+                                    .font(.system(size: 14, weight: .bold))
+                                    .foregroundStyle(.white)
+                                    .padding(6)
+                                    .background(Circle().fill(.black.opacity(0.55)))
+                            }
+                        }
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(rowTitle(for: entry))
+                            .font(CinemaFont.label(.large))
+                            .foregroundStyle(CinemaColor.onSurface)
+                            .lineLimit(1)
+                        Text(rowSubtitle(for: entry))
+                            .font(CinemaFont.label(.medium))
+                            .foregroundStyle(statusTint(for: entry.status))
+                            .lineLimit(1)
+                    }
+                    Spacer(minLength: CinemaSpacing.spacing2)
+                    trailingControl(for: entry)
+                }
+                .padding(.horizontal, CinemaSpacing.spacing3)
+                .padding(.vertical, CinemaSpacing.spacing3)
+            }
+
+            if entry.status == .downloading || (entry.status == .paused && entry.bytesReceived > 0) {
+                ProgressBarView(progress: entry.progress)
+                    .padding(.horizontal, CinemaSpacing.spacing3)
+                    .padding(.bottom, CinemaSpacing.spacing3)
+            }
+
+            if entry != lastEntry(in: entry) {
+                iOSSettingsDivider
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func thumbnail(for entry: DownloadItem) -> some View {
+        let imgID = (entry.kind == .episode ? entry.seriesId : entry.id) ?? entry.id
+        // Locally-cached art wins over the remote URL so offline users still
+        // see thumbnails. We key the on-disk poster by the download's own id,
+        // which matches what `enqueue` saves regardless of series/movie kind.
+        let url = downloads.localPosterURL(forItemId: entry.id)
+            ?? appState.imageBuilder.imageURL(itemId: imgID, imageType: .primary, maxWidth: 180)
+        CinemaLazyImage(
+            url: url,
+            fallbackIcon: entry.kind == .movie ? "film" : "tv",
+            fallbackBackground: CinemaColor.surfaceContainerHigh
+        )
+    }
+
+    @ViewBuilder
+    private func trailingControl(for entry: DownloadItem) -> some View {
+        Menu {
+            switch entry.status {
+            case .downloading, .queued:
+                Button {
+                    downloads.pause(entry.id)
+                } label: {
+                    Label(loc.localized("downloads.action.pause"), systemImage: "pause.fill")
+                }
+            case .paused:
+                Button {
+                    downloads.resume(entry.id)
+                } label: {
+                    Label(loc.localized("downloads.action.resume"), systemImage: "play.fill")
+                }
+            case .failed:
+                Button {
+                    downloads.resume(entry.id)
+                } label: {
+                    Label(loc.localized("downloads.action.retry"), systemImage: "arrow.triangle.2.circlepath")
+                }
+            case .completed:
+                EmptyView()
+            }
+            Button(role: .destructive) {
+                pendingRemoval = entry
+            } label: {
+                Label(loc.localized("downloads.action.remove"), systemImage: "trash")
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(themeManager.accent)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func rowTitle(for entry: DownloadItem) -> String {
+        switch entry.kind {
+        case .movie:
+            return entry.title
+        case .episode:
+            if let s = entry.seasonIndex, let e = entry.episodeIndex {
+                return String(format: "S%02d:E%02d · %@", s, e, entry.title) as String
+            }
+            return entry.title
+        }
+    }
+
+    private func rowSubtitle(for entry: DownloadItem) -> String {
+        switch entry.status {
+        case .queued:
+            return loc.localized("downloads.status.queued")
+        case .downloading:
+            return "\(loc.localized("downloads.status.downloading")) · \(Int(entry.progress * 100)) %"
+        case .paused:
+            return loc.localized("downloads.status.paused")
+        case .completed:
+            return "\(loc.localized("downloads.status.completed")) · \(formatBytes(entry.totalBytes > 0 ? entry.totalBytes : entry.bytesReceived))"
+        case .failed:
+            return entry.errorMessage ?? loc.localized("downloads.status.failed")
+        }
+    }
+
+    private func statusTint(for status: DownloadStatus) -> Color {
+        switch status {
+        case .failed: return CinemaColor.error
+        case .completed: return themeManager.accent
+        default: return CinemaColor.onSurfaceVariant
+        }
+    }
+
+    private func formatBytes(_ bytes: Int64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useMB, .useGB]
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: bytes)
+    }
+
+    // MARK: - Grouping
+
+    private struct GroupedDownloads {
+        var movies: [DownloadItem]
+        var series: [String: SeriesBucket]
+        /// Series keys in insertion order so the screen is stable across rebuilds.
+        var seriesOrder: [String]
+    }
+
+    private struct SeriesBucket {
+        var title: String
+        var episodes: [DownloadItem]
+    }
+
+    private func grouped(_ all: [DownloadItem]) -> GroupedDownloads {
+        var result = GroupedDownloads(movies: [], series: [:], seriesOrder: [])
+        let sorted = all.sorted { $0.createdAt < $1.createdAt }
+        for entry in sorted {
+            switch entry.kind {
+            case .movie:
+                result.movies.append(entry)
+            case .episode:
+                let key = entry.seriesId ?? entry.title
+                if result.series[key] == nil {
+                    result.series[key] = SeriesBucket(title: entry.seriesTitle ?? entry.title, episodes: [])
+                    result.seriesOrder.append(key)
+                }
+                result.series[key]?.episodes.append(entry)
+            }
+        }
+        // Episodes within a series sort by season + episode index for predictability.
+        for key in result.seriesOrder {
+            result.series[key]?.episodes.sort { lhs, rhs in
+                (lhs.seasonIndex ?? 0, lhs.episodeIndex ?? 0) < (rhs.seasonIndex ?? 0, rhs.episodeIndex ?? 0)
+            }
+        }
+        return result
+    }
+
+    /// Returns the entry that should *not* render a trailing divider — the last
+    /// one inside its section. Used to draw section-aware dividers without
+    /// nesting view hierarchies.
+    private func lastEntry(in entry: DownloadItem) -> DownloadItem {
+        let groups = grouped(downloads.items)
+        if entry.kind == .movie {
+            return groups.movies.last ?? entry
+        }
+        let key = entry.seriesId ?? entry.title
+        return groups.series[key]?.episodes.last ?? entry
+    }
+}
+
+#endif

--- a/Shared/Screens/Downloads/OfflineLibraryView.swift
+++ b/Shared/Screens/Downloads/OfflineLibraryView.swift
@@ -1,0 +1,153 @@
+#if os(iOS)
+import SwiftUI
+import CinemaxKit
+
+/// Drop-in replacement for the Home / Movies / TV-Shows tabs when the device
+/// is offline. Renders a banner + a grid of completed downloads scoped to
+/// what the tab would normally show.
+///
+/// Each card navigates back through `MediaDetailScreen` — that screen's own
+/// offline shortcut (`OfflineMediaDetailView`) handles the rendering, so we
+/// stay on the established navigation contract instead of inventing a
+/// parallel one.
+struct OfflineLibraryView: View {
+    enum Scope {
+        case all      // Home tab
+        case movies   // Movies tab
+        case series   // TV Shows tab
+    }
+
+    @Environment(DownloadManager.self) private var downloads
+    @Environment(LocalizationManager.self) private var loc
+    @Environment(ThemeManager.self) private var themeManager
+    @Environment(AppState.self) private var appState
+
+    let scope: Scope
+
+    var body: some View {
+        let completed = downloads.completedItems()
+        let movies = (scope == .series) ? [] : completed.movies
+        let series = (scope == .movies) ? [] : completed.series
+
+        ZStack {
+            CinemaColor.surface.ignoresSafeArea()
+
+            if movies.isEmpty && series.isEmpty {
+                ScrollView {
+                    VStack(spacing: CinemaSpacing.spacing4) {
+                        offlineBanner
+                        EmptyStateView(
+                            systemImage: "wifi.slash",
+                            title: loc.localized("offline.empty.title"),
+                            subtitle: loc.localized("offline.empty.subtitle")
+                        )
+                    }
+                    .padding(.top, CinemaSpacing.spacing3)
+                }
+            } else {
+                ScrollView(showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: CinemaSpacing.spacing5) {
+                        offlineBanner
+
+                        if !movies.isEmpty {
+                            sectionGrid(title: loc.localized("downloads.section.movies"), entries: movies)
+                        }
+                        if !series.isEmpty {
+                            ForEach(series, id: \.seriesId) { bucket in
+                                sectionGrid(
+                                    title: bucket.title,
+                                    entries: bucket.episodes
+                                )
+                            }
+                        }
+                    }
+                    .padding(.horizontal, CinemaSpacing.spacing3)
+                    .padding(.bottom, CinemaSpacing.spacing8)
+                }
+            }
+        }
+    }
+
+    // MARK: - Pieces
+
+    private var offlineBanner: some View {
+        HStack(spacing: CinemaSpacing.spacing2) {
+            Image(systemName: "wifi.slash")
+                .font(.system(size: 14, weight: .semibold))
+            Text(loc.localized("offline.banner"))
+                .font(CinemaFont.label(.medium))
+            Spacer()
+        }
+        .foregroundStyle(themeManager.accent)
+        .padding(.horizontal, CinemaSpacing.spacing3)
+        .padding(.vertical, CinemaSpacing.spacing2)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: CinemaRadius.large))
+        .overlay(
+            RoundedRectangle(cornerRadius: CinemaRadius.large)
+                .strokeBorder(themeManager.accent.opacity(0.25), lineWidth: 1)
+        )
+        .padding(.horizontal, CinemaSpacing.spacing2)
+    }
+
+    private func sectionGrid(title: String, entries: [DownloadItem]) -> some View {
+        VStack(alignment: .leading, spacing: CinemaSpacing.spacing2) {
+            iOSSettingsSectionHeader(title)
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 108), spacing: 12)],
+                spacing: CinemaSpacing.spacing3
+            ) {
+                ForEach(entries) { entry in
+                    posterCard(for: entry)
+                }
+            }
+            .padding(.horizontal, CinemaSpacing.spacing2)
+        }
+    }
+
+    @ViewBuilder
+    private func posterCard(for entry: DownloadItem) -> some View {
+        let posterId = entry.kind == .episode ? (entry.seriesId ?? entry.id) : entry.id
+        NavigationLink {
+            // Routing through MediaDetailScreen so that any subsequent navigation
+            // (back to Home etc.) lands in the same place online users expect.
+            MediaDetailScreen(itemId: entry.kind == .episode ? (entry.seriesId ?? entry.id) : entry.id,
+                              itemType: entry.kind == .episode ? .series : .movie)
+        } label: {
+            VStack(alignment: .leading, spacing: 6) {
+                Color.clear
+                    .aspectRatio(2/3, contentMode: .fit)
+                    .overlay {
+                        CinemaLazyImage(
+                            url: downloads.localPosterURL(forItemId: entry.id)
+                                ?? appState.imageBuilder.imageURL(itemId: posterId, imageType: .primary, maxWidth: 360),
+                            fallbackIcon: entry.kind == .movie ? "film" : "tv",
+                            fallbackBackground: CinemaColor.surfaceContainerHigh
+                        )
+                    }
+                    .clipped()
+                    .clipShape(RoundedRectangle(cornerRadius: CinemaRadius.medium))
+                    .overlay(alignment: .topTrailing) {
+                        Image(systemName: "arrow.down.circle.fill")
+                            .font(.system(size: 16, weight: .bold))
+                            .foregroundStyle(.white, themeManager.accent)
+                            .padding(6)
+                    }
+
+                Text(displayTitle(for: entry))
+                    .font(CinemaFont.label(.medium))
+                    .foregroundStyle(CinemaColor.onSurface)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func displayTitle(for entry: DownloadItem) -> String {
+        switch entry.kind {
+        case .movie: return entry.title
+        case .episode: return entry.seriesTitle ?? entry.title
+        }
+    }
+}
+#endif

--- a/Shared/Screens/Downloads/OfflineMediaDetailView.swift
+++ b/Shared/Screens/Downloads/OfflineMediaDetailView.swift
@@ -1,0 +1,267 @@
+#if os(iOS)
+import SwiftUI
+import CinemaxKit
+
+/// Lightweight stand-in for `MediaDetailScreen` used when the device is
+/// offline. Renders directly from the cached `DownloadItem` metadata so the
+/// user can browse / replay downloaded content without any server round-trip.
+///
+/// Two distinct shapes:
+///   - `entry.kind == .movie`     → single Play button + Remove
+///   - `entry.kind == .episode`   → series header, episode list for the same
+///                                  `seriesId`, per-episode Play / Remove
+struct OfflineMediaDetailView: View {
+    @Environment(DownloadManager.self) private var downloads
+    @Environment(LocalizationManager.self) private var loc
+    @Environment(ThemeManager.self) private var themeManager
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+
+    /// The download record this screen represents. For a series, callers
+    /// usually pass *any* episode entry from that series — the view picks
+    /// up the rest via `seriesId`.
+    let entry: DownloadItem
+
+    @State private var pendingRemoval: DownloadItem?
+
+    var body: some View {
+        ZStack {
+            CinemaColor.surface.ignoresSafeArea()
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: CinemaSpacing.spacing5) {
+                    header
+                    if let overview = entry.overview, !overview.isEmpty {
+                        Text(overview)
+                            .font(CinemaFont.dynamicBody)
+                            .foregroundStyle(CinemaColor.onSurfaceVariant)
+                            .padding(.horizontal, CinemaSpacing.spacing4)
+                    }
+                    metadataChips
+                        .padding(.horizontal, CinemaSpacing.spacing4)
+                    if entry.kind == .episode {
+                        seriesEpisodeList
+                    }
+                    Spacer(minLength: 80)
+                }
+                .padding(.top, CinemaSpacing.spacing4)
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .confirmationDialog(
+            loc.localized("downloads.confirmRemove.title"),
+            isPresented: Binding(
+                get: { pendingRemoval != nil },
+                set: { if !$0 { pendingRemoval = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button(loc.localized("downloads.action.remove"), role: .destructive) {
+                if let p = pendingRemoval {
+                    downloads.remove(p.id)
+                }
+                pendingRemoval = nil
+                // If the removed entry is what we were displaying and no
+                // other series episodes are left, pop back.
+                if downloads.item(for: entry.id) == nil
+                    && downloads.episodes(forSeriesId: entry.seriesId ?? "").isEmpty {
+                    dismiss()
+                }
+            }
+            Button(loc.localized("action.cancel"), role: .cancel) { pendingRemoval = nil }
+        } message: {
+            Text(loc.localized("downloads.confirmRemove.message"))
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: CinemaSpacing.spacing3) {
+            // Cover artwork — pulled from disk (Nuke) cache or the placeholder
+            // when no cached image exists.
+            ZStack(alignment: .bottomLeading) {
+                CinemaLazyImage(
+                    url: downloads.localBackdropURL(forItemId: entry.id)
+                        ?? appState.imageBuilder.imageURL(
+                            itemId: entry.backdropItemID ?? entry.seriesId ?? entry.id,
+                            imageType: .backdrop,
+                            maxWidth: ImageURLBuilder.backdropPixelWidth
+                        ),
+                    fallbackIcon: entry.kind == .movie ? "film" : "tv",
+                    fallbackBackground: CinemaColor.surfaceContainerLow
+                )
+                .frame(maxWidth: .infinity)
+                .frame(height: 220)
+                .clipped()
+                CinemaGradient.heroOverlay
+                VStack(alignment: .leading, spacing: CinemaSpacing.spacing1) {
+                    if let pill = sectionLabel {
+                        Text(pill)
+                            .font(CinemaFont.label(.medium))
+                            .foregroundStyle(themeManager.accent)
+                    }
+                    Text(headerTitle)
+                        .font(.system(size: 26, weight: .black))
+                        .tracking(-1)
+                        .foregroundStyle(.white)
+                        .lineLimit(2)
+                }
+                .padding(CinemaSpacing.spacing4)
+            }
+
+            // Action row: Play + Remove.
+            HStack(spacing: CinemaSpacing.spacing3) {
+                PlayLink(itemId: entry.id, title: entry.title) {
+                    HStack(spacing: CinemaSpacing.spacing2) {
+                        Image(systemName: "play.fill")
+                        Text(loc.localized("detail.play"))
+                            .font(.system(size: 18, weight: .bold))
+                    }
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, CinemaSpacing.spacing2)
+                    .background(themeManager.accentContainer)
+                    .clipShape(RoundedRectangle(cornerRadius: CinemaRadius.large))
+                }
+                .buttonStyle(.plain)
+                .frame(width: 160)
+
+                Button {
+                    pendingRemoval = entry
+                } label: {
+                    Image(systemName: "trash")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(CinemaColor.onSurface)
+                        .padding(CinemaSpacing.spacing2)
+                        .background(.ultraThinMaterial)
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
+
+                Spacer()
+            }
+            .padding(.horizontal, CinemaSpacing.spacing4)
+        }
+    }
+
+    private var headerTitle: String {
+        switch entry.kind {
+        case .movie:
+            return entry.title
+        case .episode:
+            return entry.seriesTitle ?? entry.title
+        }
+    }
+
+    private var sectionLabel: String? {
+        switch entry.kind {
+        case .movie: return nil
+        case .episode:
+            // For an episode-rooted offline view, show the season name as a
+            // pill above the series title (e.g. "Season 1 · Episode 4").
+            guard let season = entry.seasonName ?? entry.seasonIndex.map({ "Season \($0)" }) else { return nil }
+            if let num = entry.episodeIndex {
+                return "\(season) · \(loc.localized("detail.episode", num))"
+            }
+            return season
+        }
+    }
+
+    // MARK: - Metadata chips
+
+    private var metadataChips: some View {
+        let parts = [
+            entry.productionYear.map(String.init),
+            entry.runtimeTicks.map { ticks in
+                let minutes = ticks.jellyfinMinutes
+                return minutes > 60
+                    ? loc.localized("detail.runtime.hours", minutes / 60, minutes % 60)
+                    : loc.localized("detail.runtime.minutes", minutes)
+            },
+            entry.officialRating
+        ].compactMap { $0 }
+        return HStack(spacing: CinemaSpacing.spacing2) {
+            if !parts.isEmpty {
+                Text(parts.joined(separator: " · "))
+                    .font(CinemaFont.label(.medium))
+                    .foregroundStyle(CinemaColor.onSurfaceVariant)
+            }
+            if let rating = entry.communityRating {
+                HStack(spacing: 3) {
+                    Image(systemName: "star.fill").foregroundStyle(.yellow)
+                    Text(String(format: "%.1f", rating))
+                        .font(CinemaFont.label(.medium))
+                        .foregroundStyle(CinemaColor.onSurface)
+                }
+            }
+            if !entry.genres.isEmpty {
+                Text(entry.genres.prefix(3).joined(separator: " · "))
+                    .font(CinemaFont.label(.medium))
+                    .foregroundStyle(themeManager.accent)
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    // MARK: - Episode list (series view)
+
+    @ViewBuilder
+    private var seriesEpisodeList: some View {
+        let seriesEntries = downloads.episodes(forSeriesId: entry.seriesId ?? "")
+        if !seriesEntries.isEmpty {
+            VStack(alignment: .leading, spacing: CinemaSpacing.spacing2) {
+                iOSSettingsSectionHeader(loc.localized("downloads.section.series"))
+                VStack(spacing: 0) {
+                    ForEach(seriesEntries) { ep in
+                        episodeRow(ep)
+                        if ep != seriesEntries.last {
+                            iOSSettingsDivider
+                        }
+                    }
+                }
+                .glassPanel(cornerRadius: CinemaRadius.extraLarge)
+            }
+            .padding(.horizontal, CinemaSpacing.spacing3)
+        }
+    }
+
+    @ViewBuilder
+    private func episodeRow(_ ep: DownloadItem) -> some View {
+        ZStack {
+            PlayLink(itemId: ep.id, title: ep.title) {
+                Color.clear.contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            HStack(alignment: .center, spacing: CinemaSpacing.spacing3) {
+                CinemaLazyImage(
+                    url: downloads.localPosterURL(forItemId: ep.id)
+                        ?? appState.imageBuilder.imageURL(itemId: ep.id, imageType: .primary, maxWidth: 240),
+                    fallbackIcon: "play.circle",
+                    fallbackBackground: CinemaColor.surfaceContainerHigh
+                )
+                .frame(width: 96, height: 56)
+                .clipShape(RoundedRectangle(cornerRadius: CinemaRadius.small))
+
+                VStack(alignment: .leading, spacing: 3) {
+                    if let s = ep.seasonIndex, let e = ep.episodeIndex {
+                        Text(String(format: "S%02d:E%02d", s, e))
+                            .font(CinemaFont.label(.medium))
+                            .foregroundStyle(CinemaColor.onSurfaceVariant)
+                    }
+                    Text(ep.title)
+                        .font(CinemaFont.label(.large))
+                        .foregroundStyle(CinemaColor.onSurface)
+                        .lineLimit(1)
+                }
+                Spacer()
+                Image(systemName: "play.fill")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(themeManager.accent)
+            }
+            .padding(.horizontal, CinemaSpacing.spacing3)
+            .padding(.vertical, CinemaSpacing.spacing3)
+        }
+    }
+}
+#endif

--- a/Shared/Screens/HomeScreen.swift
+++ b/Shared/Screens/HomeScreen.swift
@@ -6,6 +6,7 @@ struct HomeScreen: View {
     @Environment(AppState.self) private var appState
     @Environment(ThemeManager.self) private var themeManager
     @Environment(LocalizationManager.self) private var loc
+    @Environment(NetworkMonitor.self) private var network
     #if !os(tvOS)
     @Environment(\.horizontalSizeClass) private var sizeClass
     #endif
@@ -20,6 +21,17 @@ struct HomeScreen: View {
         ZStack {
             CinemaColor.surface.ignoresSafeArea()
 
+            #if os(iOS)
+            if !network.isOnline {
+                OfflineLibraryView(scope: .all)
+            } else if viewModel.isLoading {
+                LoadingStateView()
+            } else if isHomeEmpty {
+                homeEmptyState
+            } else {
+                content
+            }
+            #else
             if viewModel.isLoading {
                 LoadingStateView()
             } else if isHomeEmpty {
@@ -27,6 +39,7 @@ struct HomeScreen: View {
             } else {
                 content
             }
+            #endif
         }
         #if os(iOS)
         .navigationTitle(loc.localized("tab.home"))

--- a/Shared/Screens/MediaDetailEpisodeCard.swift
+++ b/Shared/Screens/MediaDetailEpisodeCard.swift
@@ -93,10 +93,14 @@ struct MediaDetailEpisodeCard: View, Equatable {
 
                 // Info below image
                 VStack(alignment: .leading, spacing: 4) {
-                    if let num = episode.indexNumber {
-                        Text(loc.localized("detail.episode", num))
-                            .font(CinemaFont.label(.medium))
-                            .foregroundStyle(CinemaColor.onSurfaceVariant)
+                    HStack(alignment: .center, spacing: CinemaSpacing.spacing2) {
+                        if let num = episode.indexNumber {
+                            Text(loc.localized("detail.episode", num))
+                                .font(CinemaFont.label(.medium))
+                                .foregroundStyle(CinemaColor.onSurfaceVariant)
+                        }
+                        Spacer(minLength: 0)
+                        DownloadButton(item: episode)
                     }
                     Text(episode.name ?? "")
                         .font(.system(size: episodeTitleFontSize, weight: .bold))

--- a/Shared/Screens/MediaDetailScreen.swift
+++ b/Shared/Screens/MediaDetailScreen.swift
@@ -13,7 +13,9 @@ struct MediaDetailScreen: View {
     #endif
     @State var viewModel: MediaDetailViewModel
     @State private var episodeOverview: EpisodeOverviewItem?
+    @Environment(NetworkMonitor.self) private var network
     #if os(iOS)
+    @Environment(DownloadManager.self) private var downloads
     @Environment(\.dismiss) private var dismiss
     /// Lifted from `AdminItemMenu` so SwiftUI honors the destination —
     /// `adminMenuPill` is rendered inside `detailContent`'s `LazyVStack`,
@@ -27,10 +29,42 @@ struct MediaDetailScreen: View {
         _viewModel = State(initialValue: MediaDetailViewModel(itemId: itemId, itemType: itemType))
     }
 
+    #if os(iOS)
+    /// Resolves a `DownloadItem` that should drive the offline detail view.
+    /// Tries the item id directly first (movie / specific episode), then
+    /// falls back to "any episode whose `seriesId` matches" so navigating to
+    /// a series id while offline still works.
+    private func offlineEntry() -> DownloadItem? {
+        let id = viewModel.itemId
+        if let direct = downloads.item(for: id), direct.status == .completed {
+            return direct
+        }
+        if let firstEpisode = downloads.episodes(forSeriesId: id).first(where: { $0.status == .completed }) {
+            return firstEpisode
+        }
+        return nil
+    }
+    #endif
+
     var body: some View {
         ZStack {
             CinemaColor.surface.ignoresSafeArea()
 
+            #if os(iOS)
+            // Offline shortcut: if the user has a download for the item id
+            // (movie or any episode of a series the screen represents),
+            // render the offline detail and skip every server call.
+            if !network.isOnline,
+               let entry = offlineEntry() {
+                OfflineMediaDetailView(entry: entry)
+            } else if viewModel.isLoading {
+                LoadingStateView()
+            } else if let error = viewModel.errorMessage {
+                errorView(error)
+            } else if let item = viewModel.item {
+                detailContent(item)
+            }
+            #else
             if viewModel.isLoading {
                 LoadingStateView()
             } else if let error = viewModel.errorMessage {
@@ -38,6 +72,7 @@ struct MediaDetailScreen: View {
             } else if let item = viewModel.item {
                 detailContent(item)
             }
+            #endif
         }
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
@@ -327,26 +362,69 @@ struct MediaDetailScreen: View {
             return episodeNavigation(for: id)
         }
 
-        return PlayActionButtonsSection(
-            playItemId: playItemId,
-            playTitle: playTitle,
-            nextEpisodeLabel: nextEpisodeLabel,
-            startSeconds: startSeconds,
-            showResume: showResume,
-            progress: progress,
-            remainingText: remainingText,
-            epPrev: epNav?.previous,
-            epNext: epNav?.next,
-            epNavigator: epNav?.navigator,
-            playLabel: loc.localized("detail.play"),
-            playFromBeginningLabel: loc.localized("detail.playFromBeginning"),
-            buttonFontSize: buttonFontSize,
-            buttonVerticalPadding: buttonVerticalPadding,
-            playButtonWidth: playButtonWidth,
-            contentPadding: contentPadding
-        )
-        .equatable()
+        return HStack(alignment: .top, spacing: CinemaSpacing.spacing3) {
+            PlayActionButtonsSection(
+                playItemId: playItemId,
+                playTitle: playTitle,
+                nextEpisodeLabel: nextEpisodeLabel,
+                startSeconds: startSeconds,
+                showResume: showResume,
+                progress: progress,
+                remainingText: remainingText,
+                epPrev: epNav?.previous,
+                epNext: epNav?.next,
+                epNavigator: epNav?.navigator,
+                playLabel: loc.localized("detail.play"),
+                playFromBeginningLabel: loc.localized("detail.playFromBeginning"),
+                buttonFontSize: buttonFontSize,
+                buttonVerticalPadding: buttonVerticalPadding,
+                playButtonWidth: playButtonWidth,
+                contentPadding: 0
+            )
+            .equatable()
+            #if os(iOS)
+            downloadAffordance(for: item, resolvedNextEpisode: nextEp)
+                .padding(.top, nextEpisodeLabel != nil ? 18 : 0)
+            #endif
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, contentPadding)
     }
+
+    // MARK: - Download affordance (iOS)
+
+    #if os(iOS)
+    @ViewBuilder
+    private func downloadAffordance(for item: BaseItemDto, resolvedNextEpisode: BaseItemDto?) -> some View {
+        let isSeries = viewModel.resolvedType == .series
+        if isSeries {
+            let seasonName = viewModel.seasons.first { $0.id == viewModel.selectedSeasonId }?.name
+                ?? loc.localized("detail.season")
+            let seriesId = item.id ?? viewModel.itemId
+            let seasons = viewModel.seasons
+            DownloadButton(
+                item: resolvedNextEpisode ?? item,
+                bulk: .series(
+                    currentSeasonEpisodes: viewModel.episodes,
+                    currentSeasonName: seasonName,
+                    fetchAllEpisodes: { @MainActor [appState] in
+                        guard let userId = appState.currentUserId else { return [] }
+                        var all: [BaseItemDto] = []
+                        for season in seasons {
+                            guard let sid = season.id else { continue }
+                            if let eps = try? await appState.apiClient.getEpisodes(seriesId: seriesId, seasonId: sid, userId: userId) {
+                                all.append(contentsOf: eps)
+                            }
+                        }
+                        return all
+                    }
+                )
+            )
+        } else {
+            DownloadButton(item: item)
+        }
+    }
+    #endif
 
     // MARK: - Admin menu pill (iOS)
 

--- a/Shared/Screens/MovieLibraryScreen.swift
+++ b/Shared/Screens/MovieLibraryScreen.swift
@@ -8,6 +8,7 @@ struct MediaLibraryScreen: View {
     @Environment(AppState.self) private var appState
     @Environment(ThemeManager.self) private var themeManager
     @Environment(LocalizationManager.self) private var loc
+    @Environment(NetworkMonitor.self) private var network
     #if !os(tvOS)
     @Environment(\.horizontalSizeClass) private var sizeClass
     #endif
@@ -41,6 +42,17 @@ struct MediaLibraryScreen: View {
         ZStack {
             CinemaColor.surface.ignoresSafeArea()
 
+            #if os(iOS)
+            if !network.isOnline {
+                OfflineLibraryView(scope: itemType == .series ? .series : .movies)
+            } else if viewModel.isLoading {
+                loadingView
+            } else if let error = viewModel.errorMessage {
+                errorView(error)
+            } else {
+                mainContent
+            }
+            #else
             if viewModel.isLoading {
                 loadingView
             } else if let error = viewModel.errorMessage {
@@ -48,6 +60,7 @@ struct MediaLibraryScreen: View {
             } else {
                 mainContent
             }
+            #endif
         }
         #if os(iOS)
         // Lifted out of `AdminItemMenu` so SwiftUI honors it — the menu's

--- a/Shared/Screens/SearchScreen.swift
+++ b/Shared/Screens/SearchScreen.swift
@@ -9,6 +9,7 @@ struct SearchScreen: View {
     @Environment(ThemeManager.self) private var themeManager
     @Environment(LocalizationManager.self) private var loc
     @Environment(ToastCenter.self) private var toasts
+    @Environment(NetworkMonitor.self) private var network
     #if !os(tvOS)
     @Environment(\.horizontalSizeClass) private var sizeClass
     @FocusState private var searchFieldFocused: Bool
@@ -62,9 +63,15 @@ struct SearchScreen: View {
             // `Tab(role: .search)`) and integrates with system dictation,
             // Spotlight, and keyboard. Voice search is exposed as a leading
             // toolbar button. The body renders results / empty / listening states.
-            VStack(spacing: 0) {
-                listeningLabel
-                resultContent
+            // When offline, swap in the downloads-only library instead of
+            // searching against an unreachable server.
+            if !network.isOnline {
+                OfflineLibraryView(scope: .all)
+            } else {
+                VStack(spacing: 0) {
+                    listeningLabel
+                    resultContent
+                }
             }
             #endif
         }

--- a/Shared/Screens/Settings/SettingsScreen+iOS.swift
+++ b/Shared/Screens/Settings/SettingsScreen+iOS.swift
@@ -153,15 +153,17 @@ extension SettingsScreen {
 
     @ViewBuilder
     func settingsDetailView(for category: SettingsCategory) -> some View {
-        // Admin landings manage their own scrolling + background so users can
-        // navigate into admin sub-screens without the wrapping ScrollView
-        // fighting the push transitions. Non-admin categories keep the
-        // original ScrollView wrapper.
+        // Admin landings + Downloads manage their own scrolling + background so
+        // pushed sub-screens (or, for Downloads, a custom ScrollView with a
+        // disk-usage banner) aren't fighting the wrapping ScrollView. The
+        // remaining static-form categories keep the original wrapper.
         switch category {
         case .administration:
             AdminLandingScreen()
         case .advancedAdmin:
             AdvancedAdminLandingScreen()
+        case .downloads:
+            DownloadsScreen()
         default:
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: CinemaSpacing.spacing5) {
@@ -174,7 +176,7 @@ extension SettingsScreen {
                         iOSServerDetail
                     case .interface:
                         iOSInterfaceDetail
-                    case .administration, .advancedAdmin:
+                    case .administration, .advancedAdmin, .downloads:
                         EmptyView() // handled above
                     }
                 }

--- a/Shared/Screens/Settings/SettingsScreen+tvOS.swift
+++ b/Shared/Screens/Settings/SettingsScreen+tvOS.swift
@@ -242,9 +242,10 @@ extension SettingsScreen {
                     tvServerDetail
                 case .interface:
                     tvInterfaceDetail
-                case .administration, .advancedAdmin:
-                    // Never selected on tvOS — admin categories are filtered out
-                    // of the landing pill list. Render nothing as a safety net.
+                case .administration, .advancedAdmin, .downloads:
+                    // Never selected on tvOS — admin + downloads categories
+                    // are filtered out of the landing pill list. Render
+                    // nothing as a safety net.
                     EmptyView()
                 }
             }

--- a/Shared/Screens/Settings/SettingsScreen.swift
+++ b/Shared/Screens/Settings/SettingsScreen.swift
@@ -16,6 +16,8 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
     case account
     case server
     case interface
+    /// Offline downloads — iOS only. Hidden on tvOS (no offline use case).
+    case downloads
     // Admin-only categories — gated by `AppState.isAdministrator` at the
     // render site so non-admins never see these rows. Server still enforces
     // authorization on every admin endpoint; client-side gating is UX only.
@@ -30,6 +32,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .account:        "person"
         case .server:         "server.rack"
         case .interface:      "tv"
+        case .downloads:      "arrow.down.circle"
         case .administration: "shield.lefthalf.filled"
         case .advancedAdmin:  "wrench.and.screwdriver"
         }
@@ -41,6 +44,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .account:        loc.localized("settings.account")
         case .server:         loc.localized("settings.server")
         case .interface:      loc.localized("settings.interface")
+        case .downloads:      loc.localized("settings.downloads")
         case .administration: loc.localized("admin.landing.title")
         case .advancedAdmin:  loc.localized("admin.advanced.title")
         }
@@ -65,11 +69,17 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         }
     }
 
+    /// iOS-only categories. Hidden on tvOS (Downloads = mobile-only feature).
+    var isIOSOnly: Bool {
+        self == .downloads
+    }
+
     /// Filters `allCases` by admin visibility and platform. Use this instead of
     /// raw `allCases` in rendering code — keeps gating in one place.
     @MainActor static func visibleCases(isAdmin: Bool, isTVOS: Bool) -> [SettingsCategory] {
         allCases.filter { category in
             if isTVOS && category.isAdminOnly { return false }
+            if isTVOS && category.isIOSOnly { return false }
             if category.isAdminOnly && !isAdmin { return false }
             return true
         }

--- a/Shared/Screens/VideoPlayer/VLCOfflinePresenter.swift
+++ b/Shared/Screens/VideoPlayer/VLCOfflinePresenter.swift
@@ -1,0 +1,373 @@
+#if os(iOS)
+import UIKit
+import VLCKitSPM
+import OSLog
+import CinemaxKit
+
+private let logger = Logger(subsystem: "com.cinemax", category: "VLCPlayback")
+
+/// Plays offline files AVKit can't demux (MKV / AVI / WebM / HEVC-in-Matroska)
+/// using libVLC. Same role `NativeVideoPresenter` plays for streaming —
+/// instantiate, call `present(localURL:title:startTime:)`, lifetime is
+/// managed by the modal it puts up.
+///
+/// Built deliberately small: a black-background view controller, a tap-to-
+/// toggle controls overlay, scrubber + time labels, and a Done button. The
+/// rich AVKit chrome (subtitles UI, chapter markers, sleep timer prompt) is
+/// out of scope here — the VLC path exists so the file *plays at all*, and
+/// users with AVKit-compatible libraries still get the polished AVPlayer
+/// experience.
+@MainActor
+final class VLCOfflinePresenter: NSObject {
+    private let title: String
+    private let startTime: Double?
+    private let loc: LocalizationManager
+    private let onDismiss: (() -> Void)?
+
+    private weak var hostingVC: VLCPlayerViewController?
+
+    init(title: String, startTime: Double?, loc: LocalizationManager, onDismiss: (() -> Void)?) {
+        self.title = title
+        self.startTime = startTime
+        self.loc = loc
+        self.onDismiss = onDismiss
+    }
+
+    /// Presents the player modally on top of the active scene. Plays
+    /// immediately; the controls overlay autohides after 3 s of inactivity.
+    func present(localURL: URL) {
+        guard let topVC = Self.topMostViewController() else {
+            logger.error("VLC present: no top VC found")
+            onDismiss?()
+            return
+        }
+        let vc = VLCPlayerViewController(localURL: localURL, title: title, startTime: startTime, loc: loc, onDismiss: onDismiss)
+        vc.modalPresentationStyle = .overFullScreen
+        vc.modalTransitionStyle = .crossDissolve
+        hostingVC = vc
+        topVC.present(vc, animated: true)
+    }
+
+    // MARK: - Helpers
+
+    private static func topMostViewController() -> UIViewController? {
+        guard let scene = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .first(where: { $0.activationState == .foregroundActive }) ?? UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene }).first,
+              let root = scene.windows.first(where: { $0.isKeyWindow })?.rootViewController else {
+            return nil
+        }
+        var top: UIViewController = root
+        while let presented = top.presentedViewController {
+            top = presented
+        }
+        return top
+    }
+}
+
+// MARK: - View controller
+
+private final class VLCPlayerViewController: UIViewController, VLCMediaPlayerDelegate {
+    private let localURL: URL
+    private let titleText: String
+    private let startTime: Double?
+    private let loc: LocalizationManager
+    private let onDismiss: (() -> Void)?
+
+    private let mediaPlayer = VLCMediaPlayer()
+    private let videoView = UIView()
+    private let controlsContainer = UIView()
+    private let titleLabel = UILabel()
+    private let doneButton = UIButton(type: .system)
+    private let playPauseButton = UIButton(type: .system)
+    private let slider = UISlider()
+    private let timeLabel = UILabel()
+    private let durationLabel = UILabel()
+
+    /// Hides the chrome after 3 s of no interaction. Tap restores it.
+    private var hideControlsWorkItem: DispatchWorkItem?
+    /// Once the first time observer reports a non-zero position we know the
+    /// media is loaded; only then is it safe to seek to `startTime`.
+    private var didSeekToStart = false
+
+    init(localURL: URL, title: String, startTime: Double?, loc: LocalizationManager, onDismiss: (() -> Void)?) {
+        self.localURL = localURL
+        self.titleText = title
+        self.startTime = startTime
+        self.loc = loc
+        self.onDismiss = onDismiss
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not used") }
+
+    // MARK: Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+        setupVideoView()
+        setupControls()
+        setupGestures()
+        startPlayback()
+        scheduleHideControls()
+    }
+
+    override var prefersStatusBarHidden: Bool { true }
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask { .allButUpsideDown }
+    override var prefersHomeIndicatorAutoHidden: Bool { true }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        mediaPlayer.stop()
+        mediaPlayer.delegate = nil
+        hideControlsWorkItem?.cancel()
+        if isBeingDismissed {
+            onDismiss?()
+        }
+    }
+
+    // MARK: - UI setup
+
+    private func setupVideoView() {
+        videoView.translatesAutoresizingMaskIntoConstraints = false
+        videoView.backgroundColor = .black
+        view.addSubview(videoView)
+        NSLayoutConstraint.activate([
+            videoView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            videoView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            videoView.topAnchor.constraint(equalTo: view.topAnchor),
+            videoView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        mediaPlayer.drawable = videoView
+    }
+
+    private func setupControls() {
+        controlsContainer.translatesAutoresizingMaskIntoConstraints = false
+        controlsContainer.backgroundColor = .black.withAlphaComponent(0.45)
+        view.addSubview(controlsContainer)
+        NSLayoutConstraint.activate([
+            controlsContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            controlsContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            controlsContainer.topAnchor.constraint(equalTo: view.topAnchor),
+            controlsContainer.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        // Done button
+        var doneConfig = UIButton.Configuration.plain()
+        doneConfig.title = loc.localized("action.done")
+        doneConfig.baseForegroundColor = .white
+        doneButton.configuration = doneConfig
+        doneButton.translatesAutoresizingMaskIntoConstraints = false
+        doneButton.addTarget(self, action: #selector(doneTapped), for: .touchUpInside)
+        controlsContainer.addSubview(doneButton)
+
+        // Title
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.text = titleText
+        titleLabel.font = .systemFont(ofSize: 16, weight: .semibold)
+        titleLabel.textColor = .white
+        titleLabel.textAlignment = .center
+        titleLabel.lineBreakMode = .byTruncatingTail
+        controlsContainer.addSubview(titleLabel)
+
+        // Play/pause centre button
+        var playConfig = UIButton.Configuration.plain()
+        playConfig.image = UIImage(systemName: "pause.fill", withConfiguration: UIImage.SymbolConfiguration(pointSize: 64, weight: .bold))
+        playConfig.baseForegroundColor = .white
+        playPauseButton.configuration = playConfig
+        playPauseButton.translatesAutoresizingMaskIntoConstraints = false
+        playPauseButton.addTarget(self, action: #selector(playPauseTapped), for: .touchUpInside)
+        controlsContainer.addSubview(playPauseButton)
+
+        // Bottom bar: scrubber + time labels
+        slider.translatesAutoresizingMaskIntoConstraints = false
+        slider.minimumTrackTintColor = .white
+        slider.maximumTrackTintColor = UIColor.white.withAlphaComponent(0.3)
+        slider.addTarget(self, action: #selector(scrubberChanged), for: .valueChanged)
+        slider.addTarget(self, action: #selector(scrubberDone), for: [.touchUpInside, .touchUpOutside])
+        controlsContainer.addSubview(slider)
+
+        timeLabel.translatesAutoresizingMaskIntoConstraints = false
+        timeLabel.text = "0:00"
+        timeLabel.font = .monospacedDigitSystemFont(ofSize: 13, weight: .medium)
+        timeLabel.textColor = .white
+        controlsContainer.addSubview(timeLabel)
+
+        durationLabel.translatesAutoresizingMaskIntoConstraints = false
+        durationLabel.text = "0:00"
+        durationLabel.font = .monospacedDigitSystemFont(ofSize: 13, weight: .medium)
+        durationLabel.textColor = .white
+        controlsContainer.addSubview(durationLabel)
+
+        let safe = view.safeAreaLayoutGuide
+        NSLayoutConstraint.activate([
+            doneButton.leadingAnchor.constraint(equalTo: safe.leadingAnchor, constant: 8),
+            doneButton.topAnchor.constraint(equalTo: safe.topAnchor, constant: 8),
+            titleLabel.centerYAnchor.constraint(equalTo: doneButton.centerYAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: doneButton.trailingAnchor, constant: 16),
+            titleLabel.trailingAnchor.constraint(equalTo: safe.trailingAnchor, constant: -16),
+
+            playPauseButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            playPauseButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+
+            timeLabel.leadingAnchor.constraint(equalTo: safe.leadingAnchor, constant: 16),
+            timeLabel.bottomAnchor.constraint(equalTo: safe.bottomAnchor, constant: -16),
+            durationLabel.trailingAnchor.constraint(equalTo: safe.trailingAnchor, constant: -16),
+            durationLabel.bottomAnchor.constraint(equalTo: safe.bottomAnchor, constant: -16),
+            slider.leadingAnchor.constraint(equalTo: timeLabel.trailingAnchor, constant: 12),
+            slider.trailingAnchor.constraint(equalTo: durationLabel.leadingAnchor, constant: -12),
+            slider.centerYAnchor.constraint(equalTo: timeLabel.centerYAnchor)
+        ])
+    }
+
+    private func setupGestures() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(viewTapped))
+        // Tap on the video itself toggles chrome — gestures on the controls
+        // (buttons / slider) win because UIControl consumes touches first.
+        videoView.addGestureRecognizer(tap)
+        videoView.isUserInteractionEnabled = true
+    }
+
+    // MARK: - Playback
+
+    private func startPlayback() {
+        let media = VLCMedia(url: localURL)
+        // File-cache option speeds up scrubbing through large MKV files; VLC's
+        // default (300 ms) makes the slider feel laggy on multi-GB downloads.
+        media.addOption(":file-caching=3000")
+        mediaPlayer.media = media
+        mediaPlayer.delegate = self
+        mediaPlayer.play()
+    }
+
+    // MARK: - Controls
+
+    @objc private func doneTapped() {
+        mediaPlayer.stop()
+        dismiss(animated: true)
+    }
+
+    @objc private func playPauseTapped() {
+        if mediaPlayer.isPlaying {
+            mediaPlayer.pause()
+            setPlayPauseIcon(playing: false)
+        } else {
+            mediaPlayer.play()
+            setPlayPauseIcon(playing: true)
+        }
+        scheduleHideControls()
+    }
+
+    @objc private func viewTapped() {
+        if controlsContainer.alpha > 0 {
+            hideControlsImmediately()
+        } else {
+            showControls()
+            scheduleHideControls()
+        }
+    }
+
+    /// Tracks whether the user is actively dragging the scrubber so the
+    /// playback time observer doesn't fight their thumb.
+    private var isScrubbing = false
+
+    @objc private func scrubberChanged() {
+        isScrubbing = true
+        let length = mediaPlayer.media?.length.intValue ?? 0
+        guard length > 0 else { return }
+        let targetMs = Int32(Float(length) * slider.value)
+        // Live time label update for nicer feedback during drag.
+        timeLabel.text = Self.formatMs(targetMs)
+    }
+
+    @objc private func scrubberDone() {
+        let length = mediaPlayer.media?.length.intValue ?? 0
+        guard length > 0 else { isScrubbing = false; return }
+        let target = VLCTime(int: Int32(Float(length) * slider.value))
+        mediaPlayer.time = target
+        isScrubbing = false
+        scheduleHideControls()
+    }
+
+    private func setPlayPauseIcon(playing: Bool) {
+        var config = playPauseButton.configuration ?? UIButton.Configuration.plain()
+        config.image = UIImage(systemName: playing ? "pause.fill" : "play.fill",
+                               withConfiguration: UIImage.SymbolConfiguration(pointSize: 64, weight: .bold))
+        playPauseButton.configuration = config
+    }
+
+    // MARK: - Auto-hide chrome
+
+    private func scheduleHideControls() {
+        hideControlsWorkItem?.cancel()
+        let work = DispatchWorkItem { [weak self] in self?.hideControlsImmediately() }
+        hideControlsWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0, execute: work)
+    }
+
+    private func hideControlsImmediately() {
+        UIView.animate(withDuration: 0.25) {
+            self.controlsContainer.alpha = 0
+        }
+    }
+
+    private func showControls() {
+        UIView.animate(withDuration: 0.2) {
+            self.controlsContainer.alpha = 1
+        }
+    }
+
+    // MARK: - VLCMediaPlayerDelegate
+
+    nonisolated func mediaPlayerStateChanged(_ aNotification: Notification) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let state = self.mediaPlayer.state
+            switch state {
+            case .error:
+                logger.error("VLC media player entered error state for \(self.localURL.lastPathComponent, privacy: .public)")
+                self.dismiss(animated: true)
+            case .ended:
+                self.dismiss(animated: true)
+            case .paused:
+                self.setPlayPauseIcon(playing: false)
+            case .playing:
+                self.setPlayPauseIcon(playing: true)
+            default:
+                break
+            }
+        }
+    }
+
+    nonisolated func mediaPlayerTimeChanged(_ aNotification: Notification) {
+        Task { @MainActor [weak self] in
+            guard let self, !self.isScrubbing else { return }
+            let currentMs = self.mediaPlayer.time.intValue
+            let lengthMs = self.mediaPlayer.media?.length.intValue ?? 0
+            self.timeLabel.text = Self.formatMs(currentMs)
+            self.durationLabel.text = Self.formatMs(lengthMs)
+            if lengthMs > 0 {
+                self.slider.value = Float(currentMs) / Float(lengthMs)
+            }
+            // Seek to the requested start once VLC has populated `length` and
+            // we can trust the seekability. Done exactly once per session.
+            if !self.didSeekToStart, let start = self.startTime, start > 0, lengthMs > 0 {
+                self.didSeekToStart = true
+                self.mediaPlayer.time = VLCTime(int: Int32(start * 1000))
+            }
+        }
+    }
+
+    // MARK: - Format
+
+    private static func formatMs(_ ms: Int32) -> String {
+        let total = Int(max(0, ms) / 1000)
+        let h = total / 3600
+        let m = (total % 3600) / 60
+        let s = total % 60
+        return h > 0 ? String(format: "%d:%02d:%02d", h, m, s) : String(format: "%d:%02d", m, s)
+    }
+}
+#endif

--- a/Shared/Screens/VideoPlayerView.swift
+++ b/Shared/Screens/VideoPlayerView.swift
@@ -10,6 +10,9 @@ struct VideoPlayerView: View {
     @Environment(AppState.self) private var appState
     @Environment(LocalizationManager.self) private var loc
     @Environment(\.dismiss) private var dismiss
+    #if os(iOS)
+    @Environment(DownloadManager.self) private var downloads
+    #endif
     @AppStorage(SettingsKey.autoPlayNextEpisode) private var autoPlayNextEpisode: Bool = SettingsKey.Default.autoPlayNextEpisode
     @AppStorage(SettingsKey.render4K) private var render4K: Bool = SettingsKey.Default.render4K
 
@@ -22,6 +25,7 @@ struct VideoPlayerView: View {
 
     #if os(iOS)
     @State private var presenter: NativeVideoPresenter?
+    @State private var vlcPresenter: VLCOfflinePresenter?
     @State private var didPresent = false
     #endif
 
@@ -84,10 +88,41 @@ struct VideoPlayerView: View {
 
         do {
             let bitrate = render4K ? 120_000_000 : 20_000_000
-            let info = try await appState.apiClient.getPlaybackInfo(itemId: itemId, userId: userId, maxBitrate: bitrate)
-            #if DEBUG
-            logger.info("iOS play: method=\(info.playMethod.rawValue), url=\(redactedURL(info.url))")
-            #endif
+            // Offline-completed file gets two routes:
+            //   1. AVKit-friendly container → AVPlayer (full feature set —
+            //      skip intro/outro, chapter markers, AirPlay, PiP).
+            //   2. MKV / AVI / WebM → libVLC via `VLCOfflinePresenter`.
+            //      Smaller feature set but it actually decodes the file
+            //      instead of the QuickTime audio-only icon AVKit shows.
+            // Streaming always uses AVPlayer because the Jellyfin streaming
+            // pipeline targets HLS that AVKit handles natively.
+            let info: PlaybackInfo
+            if let entry = downloads.item(for: itemId), entry.status == .completed,
+               let local = downloads.localURL(forItemId: itemId) {
+                if entry.isOfflinePlayable {
+                    info = PlaybackInfo(
+                        url: local,
+                        playSessionId: nil,
+                        mediaSourceId: itemId,
+                        playMethod: .directStream,
+                        audioTracks: [], subtitleTracks: [],
+                        selectedAudioIndex: nil, selectedSubtitleIndex: nil,
+                        authToken: nil
+                    )
+                    #if DEBUG
+                    logger.info("iOS play (offline AVKit): \(local.lastPathComponent)")
+                    #endif
+                } else {
+                    // Hand off to libVLC and skip the rest of the AVKit path.
+                    presentVLC(localURL: local)
+                    return
+                }
+            } else {
+                info = try await appState.apiClient.getPlaybackInfo(itemId: itemId, userId: userId, maxBitrate: bitrate)
+                #if DEBUG
+                logger.info("iOS play: method=\(info.playMethod.rawValue), url=\(redactedURL(info.url))")
+                #endif
+            }
 
             let p = NativeVideoPresenter(
                 itemId: itemId, title: title, startTime: startTime,
@@ -106,6 +141,18 @@ struct VideoPlayerView: View {
             logger.error("iOS playback error: \(error.localizedDescription)")
             errorMessage = error.localizedDescription
         }
+    }
+
+    private func presentVLC(localURL: URL) {
+        let p = VLCOfflinePresenter(
+            title: title,
+            startTime: startTime,
+            loc: loc,
+            onDismiss: { dismiss() }
+        )
+        vlcPresenter = p
+        didPresent = true
+        p.present(localURL: localURL)
     }
 
     private func iOSErrorView(error: String) -> some View {

--- a/Shared/ViewModels/DownloadManager.swift
+++ b/Shared/ViewModels/DownloadManager.swift
@@ -1,0 +1,581 @@
+#if os(iOS)
+import Foundation
+import CinemaxKit
+import OSLog
+import Observation
+
+private let logger = Logger(subsystem: "com.cinemax", category: "Downloads")
+
+/// Background URLSession orchestrator for offline media.
+///
+/// Lives on `MainActor` so SwiftUI screens can observe `items` directly. The
+/// URLSession's delegate methods fire on the operation queue, not the main
+/// actor, so an inner `Adapter` (`@unchecked Sendable`) bridges each callback
+/// back via `Task { @MainActor in ... }`.
+///
+/// Resume contract — see `attach`:
+///   1. Tasks left running by the OS during a background launch are
+///      rediscovered via `getAllTasks` and re-bound to their `DownloadItem`s
+///      by `taskDescription = itemId`.
+///   2. Items whose status was `.downloading` but have no matching task got
+///      killed mid-flight (force-quit, OOM). If their persisted `resumeData`
+///      is present, we relaunch with it; otherwise we mark them `.paused`
+///      and let the user trigger a fresh start from the Downloads screen.
+@MainActor
+@Observable
+final class DownloadManager {
+    static let maxConcurrent = 2
+    static let sessionIdentifier = "com.cinemax.downloads"
+
+    private(set) var items: [DownloadItem] = []
+
+    private let store: DownloadStore
+    private weak var apiClientRef: AnyObject?
+    private var apiClient: (any DownloadAPI)? {
+        apiClientRef as? any DownloadAPI
+    }
+    /// Cached at `attach(apiClient:userId:)`. PlaybackInfo negotiation requires
+    /// the signed-in user id, but the manager outlives any individual
+    /// `enqueue` caller, so the user is held here for subsequent
+    /// `promoteQueueIfPossible` / `resume` paths that don't have it in scope.
+    private var cachedUserId: String?
+
+    private var session: URLSession!
+    private var adapter: Adapter!
+    /// Task pointers keyed by item id so we can pause / cancel them. URLSession
+    /// owns the lifetime; we only keep weak-equivalent references.
+    private var tasksByItemId: [String: URLSessionDownloadTask] = [:]
+
+    init(store: DownloadStore = DownloadStore()) {
+        self.store = store
+        self.items = store.all()
+        let adapter = Adapter()
+        self.adapter = adapter
+
+        let config = URLSessionConfiguration.background(withIdentifier: Self.sessionIdentifier)
+        config.sessionSendsLaunchEvents = true
+        config.isDiscretionary = false
+        config.allowsCellularAccess = true
+        config.waitsForConnectivity = true
+
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        self.session = URLSession(configuration: config, delegate: adapter, delegateQueue: queue)
+        adapter.owner = self
+
+        // Wipe files that aren't referenced by any catalog entry. Catches the
+        // "I cleared the catalog but the file was already on disk" drift we
+        // saw in the field (banner reported 6 GB used while the catalog only
+        // showed a 2 GB entry).
+        DownloadStorage.reconcileOrphans(against: Set(items.map(\.id)))
+    }
+
+    /// Wires the API client + signed-in user id so we can negotiate fresh
+    /// PlaybackInfo sessions for queued or resumed downloads, and reconciles
+    /// any tasks already running in the background session.
+    func attach(apiClient: any DownloadAPI, userId: String?) {
+        self.apiClientRef = apiClient as AnyObject
+        self.cachedUserId = userId
+        Task { await self.reconcile() }
+    }
+
+    // MARK: - Queries
+
+    func item(for id: String) -> DownloadItem? {
+        items.first { $0.id == id }
+    }
+
+    func isDownloaded(itemId: String) -> Bool {
+        item(for: itemId)?.status == .completed
+    }
+
+    /// Returns every completed (or in-flight) episode download whose
+    /// `seriesId` matches `id`. Used by offline-mode detail screens to render
+    /// a season-grouped episode list without hitting the API.
+    func episodes(forSeriesId id: String) -> [DownloadItem] {
+        items.filter { $0.seriesId == id }
+            .sorted { lhs, rhs in
+                (lhs.seasonIndex ?? 0, lhs.episodeIndex ?? 0)
+                    < (rhs.seasonIndex ?? 0, rhs.episodeIndex ?? 0)
+            }
+    }
+
+    /// True when the user has *any* completed download — used to decide
+    /// whether to render an offline library or an empty / error state.
+    var hasAnyCompletedDownload: Bool {
+        items.contains { $0.status == .completed }
+    }
+
+    /// Every completed download split by kind. Ordered by completion date
+    /// (most recent first) so "newest" works as the natural ordering for
+    /// offline library listings.
+    func completedItems() -> (movies: [DownloadItem], series: [(seriesId: String, title: String, episodes: [DownloadItem])]) {
+        let completed = items.filter { $0.status == .completed }
+        let movies = completed.filter { $0.kind == .movie }
+            .sorted { ($0.completedAt ?? $0.createdAt) > ($1.completedAt ?? $1.createdAt) }
+        var bySeries: [String: [DownloadItem]] = [:]
+        var seriesOrder: [String] = []
+        for entry in completed where entry.kind == .episode {
+            let key = entry.seriesId ?? entry.id
+            if bySeries[key] == nil { seriesOrder.append(key) }
+            bySeries[key, default: []].append(entry)
+        }
+        let series = seriesOrder.compactMap { key -> (String, String, [DownloadItem])? in
+            guard let eps = bySeries[key]?.sorted(by: {
+                ($0.seasonIndex ?? 0, $0.episodeIndex ?? 0) < ($1.seasonIndex ?? 0, $1.episodeIndex ?? 0)
+            }) else { return nil }
+            let title = eps.first?.seriesTitle ?? eps.first?.title ?? ""
+            return (key, title, eps)
+        }
+        return (movies, series)
+    }
+
+    /// Local file URL for a completed download, if any. Returns `nil` for
+    /// queued / downloading / paused / failed entries — the caller falls
+    /// back to streaming.
+    func localURL(forItemId itemId: String) -> URL? {
+        guard let item = item(for: itemId),
+              item.status == .completed,
+              let name = item.localFileName,
+              let dir = try? DownloadStorage.filesDirectory() else { return nil }
+        let url = dir.appendingPathComponent(name, isDirectory: false)
+        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+    }
+
+    var totalDiskBytes: Int64 { DownloadStorage.totalDiskUsage() }
+
+    /// Returns the on-disk poster file URL when we've already cached the
+    /// artwork during enqueue. Offline screens prefer this over a remote URL
+    /// so airplane-mode users still see thumbnails.
+    func localPosterURL(forItemId id: String) -> URL? {
+        guard let url = try? DownloadStorage.artFileURL(itemId: id, kind: .poster),
+              FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return url
+    }
+
+    func localBackdropURL(forItemId id: String) -> URL? {
+        guard let url = try? DownloadStorage.artFileURL(itemId: id, kind: .backdrop),
+              FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return url
+    }
+
+    // MARK: - Mutations
+
+    /// Adds an item to the queue. If concurrency is below `maxConcurrent` it
+    /// starts immediately; otherwise it sits as `.queued`.
+    ///
+    /// `posterURL` / `backdropURL` are optional artwork sources the manager
+    /// fetches in the background so the user can see thumbnails offline.
+    /// Callers that don't have them ready can pass `nil` and the offline
+    /// screens fall back to a styled placeholder.
+    func enqueue(_ item: DownloadItem, posterURL: URL? = nil, backdropURL: URL? = nil) {
+        if items.contains(where: { $0.id == item.id }) {
+            // Already tracked — surface as a no-op so callers can be idempotent.
+            return
+        }
+        store.upsert(item)
+        items = store.all()
+        cachePoster(for: item.id, posterURL: posterURL, backdropURL: backdropURL)
+        promoteQueueIfPossible()
+    }
+
+    /// Wipes everything: cancels in-flight tasks, drops the catalog, deletes
+    /// every file under the downloads tree. Exposed to the user as
+    /// "Remove all downloads" in Settings → Downloads.
+    func removeAll() {
+        for (_, task) in tasksByItemId {
+            task.cancel()
+        }
+        tasksByItemId.removeAll()
+        for entry in items {
+            store.remove(id: entry.id)
+        }
+        DownloadStorage.wipeEverything()
+        items = []
+    }
+
+    // MARK: - Artwork prefetch
+
+    /// Fetches poster + backdrop JPEGs and writes them next to the media
+    /// file. Fire-and-forget — failure leaves the offline screens to render
+    /// a placeholder rather than blocking the actual media download.
+    private func cachePoster(for id: String, posterURL: URL?, backdropURL: URL?) {
+        let work: [(URL, DownloadStorage.ArtKind)] = [
+            posterURL.map { ($0, .poster) },
+            backdropURL.map { ($0, .backdrop) }
+        ].compactMap { $0 }
+        guard !work.isEmpty else { return }
+        Task.detached {
+            for (url, kind) in work {
+                guard let (data, response) = try? await URLSession.shared.data(from: url),
+                      let http = response as? HTTPURLResponse,
+                      (200..<300).contains(http.statusCode) else { continue }
+                guard let dest = try? DownloadStorage.artFileURL(itemId: id, kind: kind) else { continue }
+                try? data.write(to: dest, options: .atomic)
+            }
+        }
+    }
+
+    func pause(_ id: String) {
+        guard let task = tasksByItemId[id] else {
+            // No live task — just flip status. Nothing to cancel.
+            store.update(id: id) { $0.status = .paused }
+            items = store.all()
+            return
+        }
+        task.cancel(byProducingResumeData: { [weak self] data in
+            Task { @MainActor in
+                self?.applyPause(id: id, resumeData: data)
+            }
+        })
+    }
+
+    private func applyPause(id: String, resumeData: Data?) {
+        store.update(id: id) { item in
+            item.status = .paused
+            item.resumeData = resumeData
+        }
+        tasksByItemId.removeValue(forKey: id)
+        items = store.all()
+        promoteQueueIfPossible()
+    }
+
+    /// Resumes a paused / failed download. If we have resume data, the
+    /// URLSession picks up where it left off; otherwise we start fresh.
+    func resume(_ id: String) {
+        guard let entry = items.first(where: { $0.id == id }) else { return }
+        if entry.status == .downloading || entry.status == .queued { return }
+        // Throttle: if at capacity, mark queued and let promotion fire later.
+        let activeCount = items.filter { $0.status == .downloading }.count
+        if activeCount >= Self.maxConcurrent {
+            store.update(id: id) { $0.status = .queued; $0.errorMessage = nil }
+            items = store.all()
+            return
+        }
+        startTask(for: entry)
+    }
+
+    /// Cancels and removes the entry entirely. Deletes the partial / finished
+    /// file from disk too.
+    func remove(_ id: String) {
+        if let task = tasksByItemId.removeValue(forKey: id) {
+            task.cancel()
+        }
+        if let entry = items.first(where: { $0.id == id }) {
+            if let name = entry.localFileName,
+               let dir = try? DownloadStorage.filesDirectory() {
+                try? FileManager.default.removeItem(at: dir.appendingPathComponent(name))
+            }
+            if let resumeURL = try? DownloadStorage.resumeFileURL(itemId: id) {
+                try? FileManager.default.removeItem(at: resumeURL)
+            }
+        }
+        store.remove(id: id)
+        items = store.all()
+        promoteQueueIfPossible()
+    }
+
+    // MARK: - Internal task plumbing
+
+    private func startTask(for entry: DownloadItem) {
+        guard let apiClient else {
+            logger.error("startTask: no API client yet — leaving \(entry.id, privacy: .public) queued")
+            store.update(id: entry.id) { $0.status = .queued }
+            items = store.all()
+            return
+        }
+        if let data = entry.resumeData {
+            // Resume tasks don't need a fresh PlaybackInfo session — the
+            // URLSession resume blob already carries the in-flight URL.
+            let task = session.downloadTask(withResumeData: data)
+            task.taskDescription = entry.id
+            tasksByItemId[entry.id] = task
+            store.update(id: entry.id) { item in
+                item.status = .downloading
+                item.errorMessage = nil
+                item.resumeData = nil
+            }
+            items = store.all()
+            task.resume()
+            return
+        }
+        guard let userId = cachedUserId else {
+            logger.error("startTask: no userId yet — leaving \(entry.id, privacy: .public) queued")
+            store.update(id: entry.id) { $0.status = .queued }
+            items = store.all()
+            return
+        }
+        // PlaybackInfo negotiation is async — fire a detached task and bridge
+        // the result back through the main actor.
+        store.update(id: entry.id) { item in
+            item.status = .downloading
+            item.errorMessage = nil
+        }
+        items = store.all()
+        let entryId = entry.id
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let req = try await apiClient.buildDownloadRequest(itemId: entryId, userId: userId)
+                self.launchTask(itemId: entryId, request: req)
+            } catch {
+                self.markFailed(itemId: entryId, error: error)
+            }
+        }
+    }
+
+    private func launchTask(itemId: String, request: DownloadStreamRequest) {
+        let task = session.downloadTask(with: request.asURLRequest())
+        task.taskDescription = itemId
+        tasksByItemId[itemId] = task
+        task.resume()
+    }
+
+    private func markFailed(itemId: String, error: Error) {
+        store.update(id: itemId) { item in
+            item.status = .failed
+            item.errorMessage = error.localizedDescription
+        }
+        items = store.all()
+        promoteQueueIfPossible()
+    }
+
+    private func promoteQueueIfPossible() {
+        let activeCount = items.filter { $0.status == .downloading }.count
+        guard activeCount < Self.maxConcurrent else { return }
+        let queued = items.filter { $0.status == .queued }.sorted { $0.createdAt < $1.createdAt }
+        for entry in queued.prefix(Self.maxConcurrent - activeCount) {
+            startTask(for: entry)
+        }
+    }
+
+    private func reconcile() async {
+        let running = await session.allTasks
+        var attached: Set<String> = []
+        for task in running {
+            guard let id = task.taskDescription, let dl = task as? URLSessionDownloadTask else { continue }
+            tasksByItemId[id] = dl
+            attached.insert(id)
+        }
+        // Items marked downloading whose task didn't survive: try resume data,
+        // else flip to paused so the user can retry.
+        for entry in items where entry.status == .downloading && !attached.contains(entry.id) {
+            if entry.resumeData != nil {
+                startTask(for: entry)
+            } else {
+                store.update(id: entry.id) { item in
+                    item.status = .paused
+                    item.errorMessage = nil
+                }
+            }
+        }
+        items = store.all()
+        promoteQueueIfPossible()
+    }
+
+    // MARK: - Delegate callbacks (called by Adapter, on MainActor)
+
+    fileprivate func didWrite(taskId: String, received: Int64, total: Int64) {
+        store.update(id: taskId) { item in
+            item.bytesReceived = received
+            if total > 0 { item.totalBytes = total }
+            item.status = .downloading
+        }
+        // Avoid rebuilding the full list on every progress tick — replace in place.
+        if let idx = items.firstIndex(where: { $0.id == taskId }) {
+            var copy = items[idx]
+            copy.bytesReceived = received
+            if total > 0 { copy.totalBytes = total }
+            copy.status = .downloading
+            items[idx] = copy
+        }
+    }
+
+    fileprivate func didFinish(taskId: String, sourceURL: URL) {
+        guard let entry = store.item(id: taskId) else {
+            try? FileManager.default.removeItem(at: sourceURL)
+            return
+        }
+        // Container detection order (server is authoritative — we never
+        // re-encode locally, so this needs to match the actual file bytes):
+        //   1. `Content-Disposition: attachment; filename="…ext"` — Jellyfin's
+        //      `/Items/{id}/Download` always sets this.
+        //   2. `Content-Type` mime mapping.
+        //   3. Fall back to the catalog's initial guess.
+        let response = tasksByItemId[taskId]?.response as? HTTPURLResponse
+        let disposition = response?.value(forHTTPHeaderField: "Content-Disposition") ?? ""
+        let mime = response?.value(forHTTPHeaderField: "Content-Type") ?? ""
+        let ext = Self.extensionFromDisposition(disposition)
+            ?? Self.extensionForMime(mime)
+            ?? entry.containerExt
+        let fileName = "\(taskId).\(ext)"
+        do {
+            let dest = try DownloadStorage.filesDirectory().appendingPathComponent(fileName, isDirectory: false)
+            if FileManager.default.fileExists(atPath: dest.path) {
+                try FileManager.default.removeItem(at: dest)
+            }
+            try FileManager.default.moveItem(at: sourceURL, to: dest)
+            // Belt-and-braces: per-file backup exclusion in case the parent
+            // tree wasn't fully marked.
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            var mutable = dest
+            try? mutable.setResourceValues(values)
+
+            // `Content-Length` is missing on chunked transfer responses, so
+            // the in-flight `totalBytes` is 0. The on-disk size is the only
+            // reliable source after move — read it explicitly so the row
+            // doesn't show "Zéro ko".
+            let onDiskSize: Int64 = {
+                guard let attrs = try? FileManager.default.attributesOfItem(atPath: dest.path),
+                      let size = attrs[.size] as? Int64 else { return 0 }
+                return size
+            }()
+
+            store.update(id: taskId) { item in
+                item.status = .completed
+                item.localFileName = fileName
+                item.containerExt = ext
+                if onDiskSize > 0 {
+                    item.totalBytes = onDiskSize
+                    item.bytesReceived = onDiskSize
+                } else {
+                    // Last-resort safeguard — keep whatever the last delegate
+                    // tick reported instead of nuking it to 0.
+                    item.bytesReceived = max(item.bytesReceived, item.totalBytes)
+                }
+                item.completedAt = Date()
+                item.resumeData = nil
+                item.errorMessage = nil
+            }
+        } catch {
+            store.update(id: taskId) { item in
+                item.status = .failed
+                item.errorMessage = error.localizedDescription
+            }
+        }
+        tasksByItemId.removeValue(forKey: taskId)
+        items = store.all()
+        promoteQueueIfPossible()
+    }
+
+    fileprivate func didFail(taskId: String, error: Error?) {
+        // Successful completion arrives here too, after didFinish — so only
+        // touch the entry if it isn't already terminal.
+        guard let entry = store.item(id: taskId) else { return }
+        if entry.status == .completed { return }
+        if let error {
+            let ns = error as NSError
+            let resumeData = ns.userInfo[NSURLSessionDownloadTaskResumeData] as? Data
+            store.update(id: taskId) { item in
+                if ns.code == NSURLErrorCancelled {
+                    // User-initiated cancel — already handled via pause path.
+                    if item.status != .paused { item.status = .paused }
+                } else {
+                    item.status = .failed
+                    item.errorMessage = error.localizedDescription
+                }
+                item.resumeData = resumeData
+            }
+        }
+        tasksByItemId.removeValue(forKey: taskId)
+        items = store.all()
+        promoteQueueIfPossible()
+    }
+
+    // MARK: - Helpers
+
+    /// Parses `filename="movie.mkv"` out of a `Content-Disposition` header.
+    /// Returns the extension (without the dot) lowercased, or `nil` if the
+    /// header is missing / malformed.
+    private static func extensionFromDisposition(_ value: String) -> String? {
+        guard !value.isEmpty else { return nil }
+        // Tolerate `filename=`, `filename="…"`, and the `filename*=` variant.
+        let lower = value.lowercased()
+        guard let range = lower.range(of: "filename") else { return nil }
+        let tail = String(value[range.upperBound...])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // Drop optional `*=` / `=` then strip quotes.
+        let stripped = tail
+            .replacingOccurrences(of: "*=", with: "=")
+            .drop(while: { $0 == "=" || $0.isWhitespace })
+            .replacingOccurrences(of: "\"", with: "")
+            .replacingOccurrences(of: "'", with: "")
+        // `filename*=UTF-8''movie.mkv` style — drop locale prefix.
+        let candidate = stripped.split(separator: ";").first.map(String.init) ?? String(stripped)
+        let name = candidate.split(separator: "/").last.map(String.init) ?? candidate
+        guard let dot = name.lastIndex(of: "."), dot < name.index(before: name.endIndex) else { return nil }
+        let ext = name[name.index(after: dot)...].lowercased()
+        // Sanity: an extension shouldn't be longer than 5 chars or contain weird bytes.
+        guard ext.count <= 5, ext.allSatisfy({ $0.isLetter || $0.isNumber }) else { return nil }
+        return ext
+    }
+
+    private static func extensionForMime(_ mime: String) -> String? {
+        let lower = mime.lowercased()
+        if lower.contains("matroska") || lower.contains("mkv") { return "mkv" }
+        if lower.contains("mp4") { return "mp4" }
+        if lower.contains("quicktime") { return "mov" }
+        if lower.contains("webm") { return "webm" }
+        if lower.contains("mpegts") || lower.contains("mp2t") { return "ts" }
+        if lower.contains("x-msvideo") { return "avi" }
+        return nil
+    }
+
+    // MARK: - Delegate adapter
+
+    private final class Adapter: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+        weak var owner: DownloadManager?
+
+        func urlSession(_ session: URLSession,
+                        downloadTask: URLSessionDownloadTask,
+                        didWriteData bytesWritten: Int64,
+                        totalBytesWritten: Int64,
+                        totalBytesExpectedToWrite: Int64) {
+            guard let id = downloadTask.taskDescription else { return }
+            let total = totalBytesExpectedToWrite > 0 ? totalBytesExpectedToWrite : 0
+            Task { @MainActor [weak owner] in
+                owner?.didWrite(taskId: id, received: totalBytesWritten, total: total)
+            }
+        }
+
+        func urlSession(_ session: URLSession,
+                        downloadTask: URLSessionDownloadTask,
+                        didFinishDownloadingTo location: URL) {
+            // The session destroys `location` on return, so move synchronously
+            // to a staging path before hopping actors.
+            guard let id = downloadTask.taskDescription else { return }
+            let staging = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "cinemax-dl-\(UUID().uuidString)"
+            )
+            do {
+                try FileManager.default.moveItem(at: location, to: staging)
+            } catch {
+                // Couldn't even stage — let didComplete surface the error.
+                return
+            }
+            Task { @MainActor [weak owner] in
+                owner?.didFinish(taskId: id, sourceURL: staging)
+            }
+        }
+
+        func urlSession(_ session: URLSession,
+                        task: URLSessionTask,
+                        didCompleteWithError error: (any Error)?) {
+            guard let id = task.taskDescription else { return }
+            Task { @MainActor [weak owner] in
+                owner?.didFail(taskId: id, error: error)
+            }
+        }
+
+        func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+            Task { @MainActor in
+                let handler = CinemaxAppDelegate.backgroundSessionCompletion
+                CinemaxAppDelegate.backgroundSessionCompletion = nil
+                handler?()
+            }
+        }
+    }
+}
+
+#endif

--- a/Shared/ViewModels/NetworkMonitor.swift
+++ b/Shared/ViewModels/NetworkMonitor.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Network
+import Observation
+
+/// Live reachability state, injected into the environment so any screen can
+/// branch on `isOnline` without each one spinning up its own `NWPathMonitor`.
+///
+/// `NWPathMonitor` reports status synchronously after `start(queue:)` — we
+/// read the first path on init so the very first frame already knows whether
+/// the user is online. Subsequent updates flip `isOnline` in real time.
+@MainActor
+@Observable
+final class NetworkMonitor {
+    private(set) var isOnline: Bool = true
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "com.cinemax.networkmonitor", qos: .utility)
+
+    init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            let online = path.status == .satisfied
+            Task { @MainActor [weak self] in
+                self?.isOnline = online
+            }
+        }
+        monitor.start(queue: queue)
+        // Seed with the current path so the first SwiftUI render already
+        // reflects reality. `currentPath` is populated synchronously after
+        // start returns.
+        isOnline = monitor.currentPath.status == .satisfied
+    }
+
+    deinit {
+        monitor.cancel()
+    }
+}

--- a/Tests/CinemaxKitTests/MockAPIClient.swift
+++ b/Tests/CinemaxKitTests/MockAPIClient.swift
@@ -303,6 +303,14 @@ final class MockAPIClient: APIClientProtocol, @unchecked Sendable {
             authToken: "mock-token"
         )
     }
+
+    // MARK: - Downloads
+
+    func buildDownloadRequest(itemId: String, userId: String) async throws -> DownloadStreamRequest {
+        if shouldThrow { throw stubbedError }
+        let url = URL(string: "http://localhost/Videos/\(itemId)/stream")!
+        return DownloadStreamRequest(itemId: itemId, url: url, authHeader: "MediaBrowser Token=mock")
+    }
 }
 
 // MARK: - Mock Keychain

--- a/iOS/CinemaxApp.swift
+++ b/iOS/CinemaxApp.swift
@@ -1,10 +1,30 @@
 import SwiftUI
+import UIKit
 
 @main
 struct CinemaxApp: App {
+    @UIApplicationDelegateAdaptor(CinemaxAppDelegate.self) private var appDelegate
+
     var body: some Scene {
         WindowGroup {
             AppNavigation()
         }
+    }
+}
+
+/// Captures the system-supplied completion handler for background URLSession
+/// events. Required so iOS knows our background-download bookkeeping (move to
+/// `Application Support/Downloads/files/`, update the catalog) finished and the
+/// process can be suspended again.
+final class CinemaxAppDelegate: NSObject, UIApplicationDelegate {
+    /// Set by the OS when the app is woken to handle background-download
+    /// events. Read & cleared by `DownloadManager.Adapter` once
+    /// `urlSessionDidFinishEvents(forBackgroundURLSession:)` fires.
+    nonisolated(unsafe) static var backgroundSessionCompletion: (() -> Void)?
+
+    func application(_ application: UIApplication,
+                     handleEventsForBackgroundURLSession identifier: String,
+                     completionHandler: @escaping () -> Void) {
+        Self.backgroundSessionCompletion = completionHandler
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -15,6 +15,12 @@ options:
 packages:
   CinemaxKit:
     path: Packages/CinemaxKit
+  # VLCKit (libVLC) for offline playback of containers AVPlayer can't decode
+  # (MKV / AVI / WebM). Same approach Swiftfin uses — AVPlayer drives streaming
+  # and AVKit-friendly offline files; VLC handles everything else.
+  VLCKitSPM:
+    url: https://github.com/tylerjonesio/vlckit-spm
+    from: "3.6.0"
 
 settings:
   base:
@@ -37,6 +43,8 @@ targets:
       - path: Resources
     dependencies:
       - package: CinemaxKit
+      - package: VLCKitSPM
+        product: VLCKitSPM
     info:
       path: iOS/Info.plist
       properties:


### PR DESCRIPTION
## Summary

Two commits on this branch, both shipped to `feature/release-1.0.0`:

- **`5384e2e` refactor:** split the largest screens (`MediaDetailScreen`, `PrivacySecurityScreen`, `SettingsScreen+tvOS`) into per-section files and fixed latent player + image-cache issues uncovered along the way.
- **`4a504b1` feat:** end-to-end iOS offline downloads with full airplane-mode UX. Modelled on Swiftfin / Streamyfin — AVPlayer drives streaming and AVKit-friendly offline files; libVLC handles MKV / AVI / WebM.

## Offline downloads

- **`DownloadManager`** (`@MainActor @Observable`) owning a background `URLSession` (id `com.cinemax.downloads`) with 2-concurrent throttle, persisted resume-data, and orphan-file reconciliation on launch.
- **`JellyfinAPIClient.buildDownloadRequest`** negotiates via PlaybackInfo with a download-only `DeviceProfile` (HTTP MP4, `context = .static`) so the server fast-remuxes / transcodes for AVKit-incompatible sources instead of handing us an unplayable MKV.
- **Container detection** from `Content-Disposition`; **file size** read off disk post-move so chunked responses no longer show "Zéro ko".
- **Artwork prefetch** — poster + backdrop JPEGs saved next to the media file so airplane-mode surfaces show real thumbnails (Nuke caches per-URL, so unvisited sizes would otherwise be cold).
- **`VLCOfflinePresenter`** (libVLC, iOS-only) for non-AVKit containers — scrubber, tap-to-toggle chrome, autohide, `:file-caching=3000` for snappy scrubbing through multi-GB files.
- **`NetworkMonitor`** (`NWPathMonitor`) + fast-fail URLSession timeouts (8s request / 20s resource). `AppState.restoreSession` now runs server probes in a detached `Task` so airplane-mode launches don't block.
- **Offline UI surfaces** — Home / Movies / Series / Search swap to `OfflineLibraryView` when offline; `MediaDetailScreen` short-circuits to `OfflineMediaDetailView` built entirely from cached `DownloadItem` metadata.
- **Settings → Downloads** (new iOS-only category) — grouped list of movies + per-series episodes, storage banner with "Remove all downloads", per-row pause / resume / retry / remove, and tap-to-play `PlayLink` on completed entries.
- **Download surfaces** — `DownloadButton` on movie / episode detail, on per-episode cards (iOS), and as a menu on series detail (download current season / download whole series via async per-season fan-out).

## Dependency

`VLCKitSPM` v3.6.0 ([tylerjonesio/vlckit-spm](https://github.com/tylerjonesio/vlckit-spm)) — SPM-friendly XCFramework that re-exports `MobileVLCKit` / `TVVLCKit`. Same package Swiftfin ships.

## Refactor / fixes (squashed into the earlier commit)

- `MediaDetailScreen` → per-section files (`MediaDetail{Cast,Similar}Section`, `MediaDetailEpisode{Card,Row,MetadataLine,OverviewSheet}`, `MediaDetailButtonStyles`).
- `PrivacySecurityScreen` → split out `PrivacySecurityConnectedDevicesList`.
- `SettingsScreen+tvOS` → carved out `SettingsTV{AccentPicker,LanguagePicker,ProfileSection,ActionRow}` + moved Settings family under `Shared/Screens/Settings/`.
- `RemoteCommandController` factored out of `NativeVideoPresenter` (prev/next `MPRemoteCommandCenter` bindings).
- Image cache: bumped Nuke's in-memory `ImageCache.costLimit` to 256 MB and pinned 500 MB disk cache via `AppNavigation.configurePipeline` so 4K backdrops don't evict mid-render.

## CLAUDE.md

Expanded with a new "Offline Downloads (iOS / iPadOS only)" section covering URL negotiation, manager internals, on-disk layout, the AVPlayer ⇄ VLC dual path, and every offline UI surface. Dependencies, project structure, and the `APIClientProtocol` line updated alongside.

## Test plan

- [ ] iOS build clean (`xcodebuild build -scheme Cinemax -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`).
- [ ] tvOS build clean (`xcodebuild build -scheme CinemaxTV -destination 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation)'`).
- [ ] All 40 unit tests pass (`xcodebuild test -scheme Cinemax …`).
- [ ] FR / EN `Localizable.strings` key parity (no diff on the comm pair).
- [ ] Download an MP4 source → plays via AVPlayer with full chrome (skip intro, AirPlay, PiP).
- [ ] Download an MKV source → plays via VLC modal (Done / scrubber / play-pause / time labels).
- [ ] Pause / resume across an app force-quit — task picks up from URLSession resume data.
- [ ] Series detail "Download whole series" enqueues every season's episodes.
- [ ] Airplane mode: Home / Movies / Series / Search render `OfflineLibraryView` with real artwork; tapping a poster opens `OfflineMediaDetailView`; Play works.
- [ ] Settings → Downloads → storage banner "Remove all downloads" frees the full subtree (media + resume + art).
- [ ] Airplane-mode launch: app reaches the home tab in <2s (no 60s SDK timeout stall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)