### PR TITLE
fix(player/tvOS): full-screen video + Siri Remote play/pause off-HUD

### DIFF
--- a/Shared/Screens/NativeVideoPresenter.swift
+++ b/Shared/Screens/NativeVideoPresenter.swift
@@ -144,8 +144,23 @@ final class NativeVideoPresenter {
             onDone: { [weak self] in self?.playerVC?.dismiss(animated: true) }
         )
         self.remoteCommands = RemoteCommandController(
-            onNavigate: { [weak self] ref in self?.navigateToEpisode(ref) }
+            onNavigate: { [weak self] ref in self?.navigateToEpisode(ref) },
+            onTogglePlayPause: { [weak self] in self?.toggleAVPlayerPlayback() }
         )
+    }
+
+    /// Called by `RemoteCommandController` when the system play/pause command
+    /// fires (Siri Remote dedicated button, Lock Screen, CarPlay).
+    /// `AVPlayerViewController` already handles the on-screen transport-bar
+    /// play/pause press itself; this covers the case where the system delivers
+    /// the press out-of-band (no focused control or HUD hidden).
+    private func toggleAVPlayerPlayback() {
+        guard let player = playerVC?.player else { return }
+        if player.timeControlStatus == .playing {
+            player.pause()
+        } else {
+            player.play()
+        }
     }
 
     func present(info: PlaybackInfo) {

--- a/Shared/Screens/VideoPlayer/PlayerEngineSurface.swift
+++ b/Shared/Screens/VideoPlayer/PlayerEngineSurface.swift
@@ -15,13 +15,22 @@ struct PlayerEngineSurface: View {
     #endif
 
     var body: some View {
+        // `.ignoresSafeArea()` is required: SwiftUI's safe area on tvOS is the
+        // TV's overscan margin (~5% inset per edge); on iOS it's the status
+        // bar / notch area. Without it the hosted `UIViewRepresentable`
+        // shrinks inside the inset and libVLC's drawable sits in a centered
+        // rectangle smaller than the screen — "video in a smaller window with
+        // black bars on all 4 sides." `AVPlayerViewController` is unaffected
+        // because it's pure UIKit and never traverses SwiftUI layout.
         #if os(iOS)
         PiPVideoView(player, controller: Binding(
             get: { controller },
             set: { controller = $0; onController($0) }
         ))
+        .ignoresSafeArea()
         #else
         VideoView(player)
+            .ignoresSafeArea()
         #endif
     }
 }

--- a/Shared/Screens/VideoPlayer/RemoteCommandController.swift
+++ b/Shared/Screens/VideoPlayer/RemoteCommandController.swift
@@ -1,28 +1,39 @@
 import MediaPlayer
 
-/// Drives the system's prev/next track buttons in the native HUD (Lock Screen,
-/// Control Center, Siri Remote on tvOS). Mirrors the sub-controller pattern
-/// already used by `PlaybackReporter` / `SkipSegmentController` /
-/// `SleepTimerController`: presenter retains a single instance per session,
-/// `attach` on play / episode-nav, `detach` on cleanup.
+/// Drives the system's prev/next track and play/pause buttons in the native
+/// HUD (Lock Screen, Control Center, Siri Remote on tvOS). Mirrors the
+/// sub-controller pattern already used by `PlaybackReporter` /
+/// `SkipSegmentController` / `SleepTimerController`: presenter retains a
+/// single instance per session, `attach` on play / episode-nav,
+/// `detach` on cleanup.
 ///
-/// Both target handlers capture the destination `EpisodeRef` directly — no
-/// per-tick state on this controller; the system fires the closure when the
-/// user taps prev/next in the HUD.
+/// Prev/next targets capture the destination `EpisodeRef` directly. Play/pause
+/// fires a presenter-supplied closure that toggles the engine *and* reveals
+/// the HUD — critical on tvOS, where pressing the Siri Remote play/pause
+/// while the HUD is hidden has no focused responder, so the press is delivered
+/// to `MPRemoteCommandCenter` instead of bubbling to `pressesBegan`.
 @MainActor
 final class RemoteCommandController {
     private let onNavigate: @MainActor (EpisodeRef) -> Void
+    private let onTogglePlayPause: @MainActor () -> Void
     private var prevCommandTarget: Any?
     private var nextCommandTarget: Any?
+    private var playPauseTarget: Any?
+    private var playTarget: Any?
+    private var pauseTarget: Any?
 
-    init(onNavigate: @escaping @MainActor (EpisodeRef) -> Void) {
+    init(onNavigate: @escaping @MainActor (EpisodeRef) -> Void,
+         onTogglePlayPause: @escaping @MainActor () -> Void) {
         self.onNavigate = onNavigate
+        self.onTogglePlayPause = onTogglePlayPause
     }
 
-    /// Wires the system prev/next commands. Pass `hasNavigator == false` to
-    /// suppress both buttons (e.g. movie playback where there is no episode
-    /// graph). Re-callable: previously registered targets are replaced each
-    /// time, matching how the presenter calls this on every episode nav.
+    /// Wires the system prev/next + play/pause commands. Pass `hasNavigator ==
+    /// false` to suppress both episode buttons (e.g. movie playback where there
+    /// is no episode graph). Play/pause is always wired — it's the dedicated
+    /// Siri Remote button and must work regardless of HUD state.
+    /// Re-callable: previously registered targets are replaced each time,
+    /// matching how the presenter calls this on every episode nav.
     func attach(previous: EpisodeRef?, next: EpisodeRef?, hasNavigator: Bool) {
         detach()
         let center = MPRemoteCommandCenter.shared()
@@ -46,9 +57,30 @@ final class RemoteCommandController {
         } else {
             center.nextTrackCommand.isEnabled = false
         }
+
+        // tvOS dedicated play/pause button reaches us here when the HUD is
+        // hidden (no focused responder). The presenter's closure both flips
+        // the engine and reveals the HUD so the user gets visual feedback.
+        center.togglePlayPauseCommand.isEnabled = true
+        playPauseTarget = center.togglePlayPauseCommand.addTarget { [weak self] _ in
+            Task { @MainActor [weak self] in self?.onTogglePlayPause() }
+            return .success
+        }
+        // Some surfaces (CarPlay, headphones with discrete play/pause) only
+        // wire the split commands — duplicate the binding so all three resolve.
+        center.playCommand.isEnabled = true
+        playTarget = center.playCommand.addTarget { [weak self] _ in
+            Task { @MainActor [weak self] in self?.onTogglePlayPause() }
+            return .success
+        }
+        center.pauseCommand.isEnabled = true
+        pauseTarget = center.pauseCommand.addTarget { [weak self] _ in
+            Task { @MainActor [weak self] in self?.onTogglePlayPause() }
+            return .success
+        }
     }
 
-    /// Removes the prev/next targets and disables the commands. Idempotent.
+    /// Removes every registered target and disables the commands. Idempotent.
     func detach() {
         let center = MPRemoteCommandCenter.shared()
         if let target = prevCommandTarget {
@@ -59,7 +91,22 @@ final class RemoteCommandController {
             center.nextTrackCommand.removeTarget(target)
             nextCommandTarget = nil
         }
+        if let target = playPauseTarget {
+            center.togglePlayPauseCommand.removeTarget(target)
+            playPauseTarget = nil
+        }
+        if let target = playTarget {
+            center.playCommand.removeTarget(target)
+            playTarget = nil
+        }
+        if let target = pauseTarget {
+            center.pauseCommand.removeTarget(target)
+            pauseTarget = nil
+        }
         center.previousTrackCommand.isEnabled = false
         center.nextTrackCommand.isEnabled = false
+        center.togglePlayPauseCommand.isEnabled = false
+        center.playCommand.isEnabled = false
+        center.pauseCommand.isEnabled = false
     }
 }

--- a/Shared/Screens/VideoPlayer/VLCStreamPresenter.swift
+++ b/Shared/Screens/VideoPlayer/VLCStreamPresenter.swift
@@ -347,9 +347,14 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
         self.loc = loc
         self.onDismiss = onDismiss
         var navTarget: ((EpisodeRef) -> Void)?
-        self.remoteCommands = RemoteCommandController(onNavigate: { ref in navTarget?(ref) })
+        var playPauseTarget: (() -> Void)?
+        self.remoteCommands = RemoteCommandController(
+            onNavigate: { ref in navTarget?(ref) },
+            onTogglePlayPause: { playPauseTarget?() }
+        )
         super.init(nibName: nil, bundle: nil)
         navTarget = { [weak self] ref in self?.navigateToEpisode(ref) }
+        playPauseTarget = { [weak self] in self?.handleRemotePlayPause() }
     }
 
     /// Offline init — same HUD scaffolding, no Jellyfin context. Network-only
@@ -373,8 +378,13 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
         self.imageBuilder = nil
         self.loc = loc
         self.onDismiss = onDismiss
-        self.remoteCommands = RemoteCommandController(onNavigate: { _ in })
+        var playPauseTarget: (() -> Void)?
+        self.remoteCommands = RemoteCommandController(
+            onNavigate: { _ in },
+            onTogglePlayPause: { playPauseTarget?() }
+        )
         super.init(nibName: nil, bundle: nil)
+        playPauseTarget = { [weak self] in self?.handleRemotePlayPause() }
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) not used") }
@@ -495,8 +505,17 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
     // MARK: - Reporter
 
     private func setupReporter() {
-        // Offline: no PlaybackReporter (nothing to phone home to) and no
-        // remote-command prev/next (episode graph isn't cached locally).
+        // System-button targets (play/pause + prev/next on tvOS Siri Remote,
+        // Lock Screen / CarPlay on iOS) attach for *every* session — play/pause
+        // is the dedicated remote button and must work even offline, where the
+        // episode-nav graph is absent (prev/next are then suppressed by the
+        // nil EpisodeRefs + hasNavigator).
+        remoteCommands.attach(
+            previous: previousEpisode,
+            next: nextEpisode,
+            hasNavigator: episodeNavigator != nil
+        )
+        // Offline: no PlaybackReporter (nothing to phone home to).
         guard let apiClient, let userId, let info else { return }
         reporter = PlaybackReporter(
             apiClient: apiClient,
@@ -510,7 +529,6 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
                 return (Double(self.currentMs) / 1000.0, !self.enginePlaying)
             }
         )
-        remoteCommands.attach(previous: previousEpisode, next: nextEpisode, hasNavigator: episodeNavigator != nil)
     }
 
     private func startProgressTimer() {
@@ -1478,6 +1496,17 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
         fetchSegments()
         startSleepTimerIfNeeded()
         fetchChapters()
+    }
+
+    /// Called by `RemoteCommandController` when the Siri Remote / Lock Screen /
+    /// CarPlay play-pause command fires. Reveals the HUD on tvOS so the user
+    /// gets visual feedback (HUD often hidden when the press lands here —
+    /// that's exactly when `pressesBegan` doesn't reach the controller).
+    private func handleRemotePlayPause() {
+        playPauseTapped()
+        #if os(tvOS)
+        revealControls()
+        #endif
     }
 
     @objc private func playPauseTapped() {


### PR DESCRIPTION
## Summary

Two tvOS player regressions reported on the VLC engine (default since the SwiftVLC migration).

### 1. Video rendered with black bars on all 4 sides

`PlayerEngineSurface` now applies `.ignoresSafeArea()` on the hosted libVLC video view. SwiftUI's safe area on tvOS is the TV's overscan margin (~5% per edge), and every SwiftUI view — including a hosted `UIViewRepresentable` — shrinks inside it by default. libVLC's drawable was therefore rendering into a centered rectangle smaller than the screen, with the visible black band being the overscan band. `AVPlayerViewController` never had this issue because it's pure UIKit and never traverses SwiftUI layout.

### 2. Siri Remote play/pause silent when HUD hidden

When the HUD is visible, the focused `TVScrubBar` bubbles the press up to the presenter's `pressesBegan`. When the HUD is hidden, nothing is focused and tvOS routes the dedicated play/pause button to `MPRemoteCommandCenter`. `RemoteCommandController` only had targets on `previousTrackCommand` / `nextTrackCommand`, so the press was a silent no-op. Added targets for `togglePlayPauseCommand` / `playCommand` / `pauseCommand`, dispatching to a HUD-aware handler that toggles the engine and reveals the controls.

Also moved `remoteCommands.attach()` out of the `apiClient/userId/info` guard in `setupReporter` so play/pause works in offline mode too.

## Test plan

- [ ] Apple TV device: launch any 16:9 stream → video fills the entire screen, no bands.
- [ ] Apple TV device: Arrow → same behavior, image fills the screen (any baked-in letterbox is part of the source).
- [ ] Apple TV device: during playback, wait for the HUD to fade (~4 s), then press Siri Remote play/pause → toggles play/pause, HUD re-appears, center glyph flashes.
- [ ] Apple TV device: HUD visible + paused → press play/pause → resumes (regression check).
- [ ] iPhone: AirPlay an offline-downloaded MKV → play/pause from Lock Screen / Control Center still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)