### PR TITLE
feat(player): Now Playing widget metadata for Apple TV Remote

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Native Jellyfin client for iOS 26+ and tvOS 26+. "Cinema Glass" design system (d
 
 ### API protocol split (`Packages/CinemaxKit/.../APIClientProtocol.swift`)
 
-`APIClientProtocol = ServerAPI & AuthAPI & LibraryAPI & PlaybackAPI & AdminAPI & DownloadAPI`. View models needing multiple domains take `APIClientProtocol`; leaf controllers narrow to a slice (`PlaybackReporter`/`SkipSegmentController` → `any PlaybackAPI`; `DownloadManager` → `any DownloadAPI`). `AdminAPI` is a privilege boundary — gated on `AppState.isAdministrator`; server enforces authoritatively.
+`APIClientProtocol = ServerAPI & AuthAPI & LibraryAPI & PlaybackAPI & AdminAPI & DownloadAPI`. View models needing multiple domains take `APIClientProtocol`; leaf controllers narrow to a slice (`PlaybackReporter`/`SkipSegmentController` → `any PlaybackAPI`; `NowPlayingInfoController` → `any LibraryAPI`; `DownloadManager` → `any DownloadAPI`). `AdminAPI` is a privilege boundary — gated on `AppState.isAdministrator`; server enforces authoritatively.
 
 ### Swift 6 `nonisolated` escape hatches (safe when body only reads parameters)
 
@@ -45,7 +45,7 @@ Shared/
   DesignSystem/Components/   CinemaButton, CinemaLazyImage, PosterCard, WideCard, CastCircle, ContentRow, ProgressBarView, RatingBadge, GlassTextField, FlowLayout, ToastOverlay, EmptyStateView, ErrorStateView, LoadingStateView, AlphabeticalJumpBar, CinemaToggleIndicator, RainbowAccentSwatch, MediaQualityBadges, UserAvatar
   Navigation/               AppNavigation (auth routing), MainTabView
   Screens/                  Home/Login/ServerSetup/Search/MovieLibrary/TVSeries/PrivacySecurity, MediaDetailScreen + MediaDetail* siblings, VideoPlayerView, NativeVideoPresenter, HLSManifestLoader, PlayLink
-    VideoPlayer/            PlaybackReporter, SkipSegmentController, SleepTimerController, ChapterController, EndOfSeriesOverlayController, RemoteCommandController, VLCStreamPresenter (covers online iOS+tvOS via stream init AND offline iOS via second init — same HUD class for both); shared extractions: PlayerTimeFormat (HH:MM:SS), PlayerEngineSurface (SwiftVLC host), PlayerTransportViews (TVScrubBar/ChapterChip/PassthroughView)
+    VideoPlayer/            PlaybackReporter, SkipSegmentController, SleepTimerController, ChapterController, EndOfSeriesOverlayController, RemoteCommandController, NowPlayingInfoController, VLCStreamPresenter (covers online iOS+tvOS via stream init AND offline iOS via second init — same HUD class for both); shared extractions: PlayerTimeFormat (HH:MM:SS), PlayerEngineSurface (SwiftVLC host), PlayerTransportViews (TVScrubBar/ChapterChip/PassthroughView)
     Settings/               SettingsScreen + iOS/tvOS extensions, SettingsAppearanceView+iOS, SettingsRowHelpers, SettingsTV{AccentPicker,LanguagePicker,ProfileSection,ActionRow}
     Downloads/              (iOS-only) DownloadButton, DownloadsScreen, OfflineLibraryView, OfflineMediaDetailView, DownloadItem+BaseItemDto
     Admin/                  (iOS-only) Dashboard/Users/Devices/Activity/Tasks/Plugins/Catalog/Playback/Network/Logs/ApiKeys/Metadata/Identify
@@ -124,7 +124,7 @@ Online playback defaults to VLC on iOS + tvOS. Settings → Interface **"Use Nat
 
 ### Native Player (`NativeVideoPresenter.swift`)
 
-Both platforms `AVPlayerViewController` presented via UIKit modal. `@MainActor` sub-controllers in `Shared/Screens/VideoPlayer/`: `PlaybackReporter`, `SkipSegmentController`, `SleepTimerController`, `ChapterController`, `EndOfSeriesOverlayController`, `RemoteCommandController`. Presenter keeps **one** `addPeriodicTimeObserver` (1s) fanning ticks to sub-controllers — sub-controllers never add their own.
+Both platforms `AVPlayerViewController` presented via UIKit modal. `@MainActor` sub-controllers in `Shared/Screens/VideoPlayer/`: `PlaybackReporter`, `SkipSegmentController`, `SleepTimerController`, `ChapterController`, `EndOfSeriesOverlayController`, `RemoteCommandController`, `NowPlayingInfoController`. Presenter keeps **one** `addPeriodicTimeObserver` (1s) fanning ticks to sub-controllers — sub-controllers never add their own.
 
 - **RULE — MUST present via UIKit modal** — SwiftUI presentation corrupts `TabView`/`NavigationSplitView` focus on dismiss.
 - **RULE — Dismiss detection**: iOS `PlayerHostingVC.viewWillDisappear(isBeingDismissed:)`; tvOS `TVDismissDelegate.playerViewControllerDidEndDismissalTransition`. **Do NOT embed `AVPlayerViewController` as a child VC on tvOS** — internal constraint conflicts + `-12881`.
@@ -139,6 +139,9 @@ Both platforms `AVPlayerViewController` presented via UIKit modal. `@MainActor` 
 - **RULE — AirPlay (iOS)**: `UIBackgroundModes = [audio]` in `project.yml` (playback continues when iPhone locks during cast). **Do not add `airplay`** as a background mode — invalid key, App Store validator rejects upload (`Invalid value: 'airplay'`); `audio` covers AirPlay. `present` activates `.playback`/`.moviePlayback` + external playback; `cleanup()` deactivates `.notifyOthersOnDeactivation`. **Don't start voice search during active playback** (`SearchViewModel` flips category to `.record`).
 - **Error recovery**: `showPlaybackErrorAlert` — `-12881/-12886/-16170` → transcode guidance; `-12938/-1001/-1004/-1005/-1009` → network; else generic. iOS alert only after `retryWithDirectURL` fails. `isShowingErrorAlert` prevents stacking.
 - **Debug tooling** (Settings → Interface → Debug, always visible): `debug.fastSleepTimer` (→15s); `debug.showSkipToEnd` (seeks to `duration−15s`).
+- **Apple TV Remote widget metadata (`NowPlayingInfoController`)**: shared by Native and VLC paths. Owns `MPNowPlayingInfoCenter.default().nowPlayingInfo` (title / artwork / elapsed / duration / rate / `MPMediaItemPropertyAlbumTitle = seriesName` / `MPMediaItemPropertyArtist = "S{parentIndexNumber}E{indexNumber}"`). `attach` publishes a title-only placeholder immediately so the iPhone Lock Screen widget fills in <1s, then fans out `getItem` (enrich series + S×E×) and an authenticated `URLSession.shared.data(for:)` against `imageBuilder.imageURL(itemId:imageType:.primary, maxWidth:600)` for poster bytes. `update(elapsed:duration:rate:)` runs from each presenter's existing 1s tick (no second timer); both engines also call it from their play/pause state-change paths for sub-second widget sync. `RemoteCommandController` is the buttons; `NowPlayingInfoController` is the metadata — never merge them.
+- **RULE — `MPMediaItemArtwork` request handler MUST be `@Sendable`**: MediaPlayer invokes it on a background queue. Without explicit annotation the trailing closure inherits the enclosing `@MainActor` Task's isolation and tvOS 26 traps it with `dispatch_assert_queue` ("Block was expected to execute on queue …"). Always write `MPMediaItemArtwork(boundsSize: image.size) { @Sendable [image] _ in image }`.
+- **RULE — Episode-nav race guard on metadata fetch**: `NowPlayingInfoController` bumps an internal `generation: Int` at every `attach`/`detach` and re-checks it before writing back from the `getItem` enrich task and the artwork fetch task. A slow poster arriving after a next-track press must not overwrite the new episode's metadata — without the guard, the user sees the wrong artwork on the iPhone widget for several seconds.
 
 ## Settings Screen
 

--- a/Cinemax.xcodeproj/project.pbxproj
+++ b/Cinemax.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		03D32DF529FA75DDA8FFC3E6 /* APICacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FE585AF0EC0507240E8772 /* APICacheTests.swift */; };
 		05134BFB07C3D63FBE6B60AE /* MediaDetailEpisodeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BC56A0134905744D8E1BFD2 /* MediaDetailEpisodeCard.swift */; };
 		06BDE914978422D2AF610106 /* SettingsKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9025B941E4912A05542646B1 /* SettingsKeys.swift */; };
+		09D69F7BEC8C65724E087626 /* NowPlayingInfoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EB1E7DC341889FBAB7BE87 /* NowPlayingInfoController.swift */; };
 		0A06186102AA10D92923583B /* AlphabeticalJumpBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9B086604524FCFB71F0E15 /* AlphabeticalJumpBar.swift */; };
 		0A93FBC398B8FD4F94C93E8D /* PlaybackReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017C266BB19FE6F0097A03A7 /* PlaybackReporter.swift */; };
 		0AE3E986461061F2BAB359EC /* SettingsScreen+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3EBB34DE4C848E6DDFF63A /* SettingsScreen+tvOS.swift */; };
@@ -41,6 +42,7 @@
 		1BE6E3C085D620D4F697285D /* MediaDetailButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554633B7F0AE3A72EE4B56BB /* MediaDetailButtonStyles.swift */; };
 		1CE784553056487755282A82 /* AdminUserDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB9A108C0F29A3010E8E65A /* AdminUserDetailScreen.swift */; };
 		1E03D8BA6CCE8D44B3FA35DE /* MetadataIdentifyTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70046F639E1635F36221E545 /* MetadataIdentifyTab.swift */; };
+		1E9CE08297D5E64B61E18257 /* NowPlayingInfoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EB1E7DC341889FBAB7BE87 /* NowPlayingInfoController.swift */; };
 		1ED2FC93756895B5F884DDA2 /* AdminUserDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C9346642E51488EB9DDC40 /* AdminUserDetailViewModel.swift */; };
 		1EF97616FD7266817F2A97D0 /* AdminNetworkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952BA3312C0EC62F0CF9ACBE /* AdminNetworkViewModel.swift */; };
 		1F8DDF74B6AA98658B045CF5 /* MovieLibraryScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A30840A8AEBE5AA59B722F /* MovieLibraryScreen.swift */; };
@@ -325,6 +327,7 @@
 
 /* Begin PBXFileReference section */
 		017C266BB19FE6F0097A03A7 /* PlaybackReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackReporter.swift; sourceTree = "<group>"; };
+		01EB1E7DC341889FBAB7BE87 /* NowPlayingInfoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingInfoController.swift; sourceTree = "<group>"; };
 		0798A7868A025E73D1891D8B /* AdminSectionGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminSectionGroup.swift; sourceTree = "<group>"; };
 		07FE737816B4F86FC1A9D144 /* NativeVideoPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeVideoPresenter.swift; sourceTree = "<group>"; };
 		09B000BF38B945DD465445ED /* PrivacySecurityScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySecurityScreen.swift; sourceTree = "<group>"; };
@@ -397,7 +400,7 @@
 		78377E8E832D65F7226A2A06 /* AppNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNavigation.swift; sourceTree = "<group>"; };
 		7D53C46CC9C173E104ABA41C /* MediaQualityBadges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaQualityBadges.swift; sourceTree = "<group>"; };
 		7D70C7B71261C61B6B142FD1 /* MediaDetailEpisodeMetadataLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDetailEpisodeMetadataLine.swift; sourceTree = "<group>"; };
-		7D88DF3FEF51CF7E5E1C948A /* Cinemax.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Cinemax.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7D88DF3FEF51CF7E5E1C948A /* Cinemax.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Cinemax.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7EB193219DC7306139A95B60 /* LibraryPosterCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryPosterCard.swift; sourceTree = "<group>"; };
 		7ECE57A7C26153CDFAB148F7 /* SettingsRowHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRowHelpers.swift; sourceTree = "<group>"; };
 		7F1A9840C693FD9D46644B69 /* AdminDashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminDashboardViewModel.swift; sourceTree = "<group>"; };
@@ -444,7 +447,7 @@
 		B7221CEFB5232DC40DB2FEA9 /* OfflineMediaDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineMediaDetailView.swift; sourceTree = "<group>"; };
 		BA0B2775D4776FF99A90FB12 /* WideCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WideCard.swift; sourceTree = "<group>"; };
 		BAF45837A14E93AA0A9739F5 /* SettingsTVAccentPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTVAccentPicker.swift; sourceTree = "<group>"; };
-		BCC43AE61EC4C83ED88C63C1 /* CinemaxTV.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = CinemaxTV.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		BCC43AE61EC4C83ED88C63C1 /* CinemaxTV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CinemaxTV.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEE8ECEE461A97A3A4667563 /* PlayerTimeFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerTimeFormat.swift; sourceTree = "<group>"; };
 		BF3A6F8801C8046B8B055A99 /* PrivacySecurityConnectedDevicesList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySecurityConnectedDevicesList.swift; sourceTree = "<group>"; };
 		BFF8782ADA4FEA223DAFF8AA /* DownloadButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadButton.swift; sourceTree = "<group>"; };
@@ -837,6 +840,7 @@
 			children = (
 				AA375893B142E24F3FA77C9E /* ChapterController.swift */,
 				1A17484ECAEA652B7D37B7EB /* EndOfSeriesOverlayController.swift */,
+				01EB1E7DC341889FBAB7BE87 /* NowPlayingInfoController.swift */,
 				017C266BB19FE6F0097A03A7 /* PlaybackReporter.swift */,
 				15453ED6A1F2D12B3E0F09DE /* PlayerEngineSurface.swift */,
 				BEE8ECEE461A97A3A4667563 /* PlayerTimeFormat.swift */,
@@ -1194,6 +1198,7 @@
 				1F8DDF74B6AA98658B045CF5 /* MovieLibraryScreen.swift in Sources */,
 				FB6FC7ADD24BFD093F9D6098 /* NativeVideoPresenter.swift in Sources */,
 				B51B03597E31E0C20548439F /* NetworkMonitor.swift in Sources */,
+				09D69F7BEC8C65724E087626 /* NowPlayingInfoController.swift in Sources */,
 				B9C9C67DF817636EF69645E8 /* OfflineLibraryView.swift in Sources */,
 				6019A67C869CBAAB7B737A31 /* OfflineMediaDetailView.swift in Sources */,
 				D64C3AD31EC5F1CC8C2197F7 /* PlayLink.swift in Sources */,
@@ -1343,6 +1348,7 @@
 				FF21EDCBFAE6F61736975202 /* MovieLibraryScreen.swift in Sources */,
 				6F9AEB4561324499DA1F1F4E /* NativeVideoPresenter.swift in Sources */,
 				52F51831022AFCDC5833B695 /* NetworkMonitor.swift in Sources */,
+				1E9CE08297D5E64B61E18257 /* NowPlayingInfoController.swift in Sources */,
 				701DFA07F1097668B91466C4 /* OfflineLibraryView.swift in Sources */,
 				A65575CB5ED23B6F9C3C8CE2 /* OfflineMediaDetailView.swift in Sources */,
 				38D0284F287A35C7FC3D4858 /* PlayLink.swift in Sources */,
@@ -1485,7 +1491,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1541,6 +1546,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "";
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = tvOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1560,7 +1566,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1641,6 +1646,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "";
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = tvOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Shared/Screens/NativeVideoPresenter.swift
+++ b/Shared/Screens/NativeVideoPresenter.swift
@@ -50,6 +50,7 @@ final class NativeVideoPresenter {
     private var chapters: ChapterController!
     private var endOfSeries: EndOfSeriesOverlayController!
     private var remoteCommands: RemoteCommandController!
+    private var nowPlaying: NowPlayingInfoController!
 
     // Track state
     private var audioTracks: [MediaTrackInfo] = []
@@ -147,6 +148,10 @@ final class NativeVideoPresenter {
             onNavigate: { [weak self] ref in self?.navigateToEpisode(ref) },
             onTogglePlayPause: { [weak self] in self?.toggleAVPlayerPlayback() }
         )
+        self.nowPlaying = NowPlayingInfoController(
+            apiClient: apiClient, userId: userId,
+            imageBuilder: imageBuilder, authToken: nil
+        )
     }
 
     /// Called by `RemoteCommandController` when the system play/pause command
@@ -161,6 +166,20 @@ final class NativeVideoPresenter {
         } else {
             player.play()
         }
+        nowPlaying.update(
+            elapsed: player.currentTime().seconds,
+            duration: currentItemDurationSeconds(),
+            rate: player.rate > 0 ? 1.0 : 0.0
+        )
+    }
+
+    /// Finite duration of the current `AVPlayerItem` in seconds, or nil for
+    /// live / not-yet-loaded items. Helper shared by the now-playing update
+    /// callers so we don't repeat the `isFinite` guard at every site.
+    private func currentItemDurationSeconds() -> Double? {
+        guard let d = playerVC?.player?.currentItem?.duration.seconds,
+              d.isFinite, d > 0 else { return nil }
+        return d
     }
 
     func present(info: PlaybackInfo) {
@@ -210,6 +229,8 @@ final class NativeVideoPresenter {
         #endif
         self.playerVC = vc
         remoteCommands.attach(previous: previousEpisode, next: nextEpisode, hasNavigator: episodeNavigator != nil)
+        nowPlaying.setAuthToken(playbackInfo?.authToken)
+        nowPlaying.attach(itemId: itemId, title: title, durationSeconds: nil)
         setupTrackMenus()
         setupBackgroundObserver()
 
@@ -496,6 +517,8 @@ final class NativeVideoPresenter {
             avPlayer.automaticallyWaitsToMinimizeStalling = true
             vc.player = avPlayer
             remoteCommands.attach(previous: previousEpisode, next: nextEpisode, hasNavigator: episodeNavigator != nil)
+            nowPlaying.setAuthToken(playbackInfo?.authToken)
+            nowPlaying.attach(itemId: ep.id, title: ep.title, durationSeconds: nil)
             setupTrackMenus()              // refreshes native "..." menu for new episode
 
             playerObservation?.invalidate()
@@ -551,6 +574,12 @@ final class NativeVideoPresenter {
                 guard let self else { return }
                 self.skipSegments.onTick(currentTime: time.seconds)
                 self.playbackReporter.onTick()
+                let rate = (self.playerVC?.player?.rate ?? 0) > 0 ? 1.0 : 0.0
+                self.nowPlaying.update(
+                    elapsed: time.seconds,
+                    duration: self.currentItemDurationSeconds(),
+                    rate: rate
+                )
             }
         }
     }
@@ -807,6 +836,7 @@ final class NativeVideoPresenter {
 
     private func cleanup() {
         remoteCommands.detach()
+        nowPlaying.detach()
         if let vc = playerVC { applyTransportBarItems([], to: vc) }
         #if os(tvOS)
         dismissDelegate = nil

--- a/Shared/Screens/VideoPlayer/NowPlayingInfoController.swift
+++ b/Shared/Screens/VideoPlayer/NowPlayingInfoController.swift
@@ -1,0 +1,152 @@
+import UIKit
+import MediaPlayer
+import CinemaxKit
+
+/// Publishes the current playback metadata to `MPNowPlayingInfoCenter` so the
+/// iOS Apple TV Remote widget (Lock Screen / Control Center) — which polls the
+/// tvOS device's Now Playing info center — shows the title, season/episode,
+/// duration, elapsed time, playback rate, and poster artwork. Sibling of
+/// `RemoteCommandController`: that one wires the buttons, this one supplies
+/// the metadata the buttons sit on top of.
+///
+/// Same sub-controller pattern as `PlaybackReporter` / `SleepTimerController`:
+/// presenter retains one instance per session, calls `attach` on play /
+/// episode-nav, `update` from the existing 1 s tick + on play/pause
+/// transitions, `detach` on cleanup.
+///
+/// Optional dependencies (`apiClient`, `userId`, `imageBuilder`, `authToken`)
+/// let the VLC offline init construct one and still publish title + elapsed —
+/// when nil, item enrichment and artwork fetch are skipped, no crash.
+@MainActor
+final class NowPlayingInfoController {
+    private let apiClient: (any LibraryAPI)?
+    private let userId: String?
+    private let imageBuilder: ImageURLBuilder?
+    private var authToken: String?
+
+    /// Race guard. Bumped in `attach` and `detach` *before* spawning enrichment /
+    /// artwork tasks; each task re-reads `generation` at the moment of writeback
+    /// so a slow artwork that arrives after an episode-swap is ignored.
+    private var generation: Int = 0
+    private var enrichTask: Task<Void, Never>?
+    private var artworkTask: Task<Void, Never>?
+
+    init(apiClient: (any LibraryAPI)?, userId: String?, imageBuilder: ImageURLBuilder?, authToken: String?) {
+        self.apiClient = apiClient
+        self.userId = userId
+        self.imageBuilder = imageBuilder
+        self.authToken = authToken
+    }
+
+    /// Native player path: token isn't known at presenter `init` time (lives on
+    /// `PlaybackInfo`, fetched later). Set immediately before `attach`.
+    func setAuthToken(_ token: String?) {
+        self.authToken = token
+    }
+
+    /// Publish the placeholder metadata (title + duration if known + elapsed=0 +
+    /// rate=1.0) so the widget gets something to display within ~1 s, then kick
+    /// off the item-detail fetch (series name + S×E×) and the artwork fetch.
+    func attach(itemId: String, title: String, durationSeconds: Double?) {
+        detach()
+        generation += 1
+        let gen = generation
+
+        var info: [String: Any] = [
+            MPMediaItemPropertyTitle: title,
+            MPNowPlayingInfoPropertyMediaType: MPNowPlayingInfoMediaType.video.rawValue,
+            MPNowPlayingInfoPropertyElapsedPlaybackTime: 0.0,
+            MPNowPlayingInfoPropertyPlaybackRate: 1.0
+        ]
+        if let durationSeconds, durationSeconds.isFinite, durationSeconds > 0 {
+            info[MPMediaItemPropertyPlaybackDuration] = durationSeconds
+        }
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+
+        startEnrichment(itemId: itemId, fallbackTitle: title, generation: gen)
+        startArtworkFetch(itemId: itemId, generation: gen)
+    }
+
+    /// Cheap per-tick update: mutates elapsed, duration (if it has just become
+    /// known), and rate on the existing dict. Called every second by the
+    /// presenter's existing time observer + on every play/pause state change.
+    /// No-ops when no session is attached, so a leftover tick firing between
+    /// `detach` and the next `attach` can't publish a zombie dict with no
+    /// title / artwork.
+    func update(elapsed: Double, duration: Double?, rate: Double) {
+        guard var info = MPNowPlayingInfoCenter.default().nowPlayingInfo else { return }
+        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = max(0, elapsed)
+        info[MPNowPlayingInfoPropertyPlaybackRate] = rate
+        if let duration, duration.isFinite, duration > 0,
+           info[MPMediaItemPropertyPlaybackDuration] as? Double != duration {
+            info[MPMediaItemPropertyPlaybackDuration] = duration
+        }
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+    }
+
+    /// Clears the now-playing dict and cancels any in-flight enrichment /
+    /// artwork tasks. Idempotent.
+    func detach() {
+        generation += 1
+        enrichTask?.cancel()
+        enrichTask = nil
+        artworkTask?.cancel()
+        artworkTask = nil
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+    }
+
+    // MARK: - Private
+
+    private func startEnrichment(itemId: String, fallbackTitle: String, generation gen: Int) {
+        guard let apiClient, let userId else { return }
+        enrichTask = Task { @MainActor [weak self] in
+            guard let fullItem = try? await apiClient.getItem(userId: userId, itemId: itemId) else { return }
+            guard let self, self.generation == gen, !Task.isCancelled else { return }
+            var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+            if let name = fullItem.name, !name.isEmpty {
+                info[MPMediaItemPropertyTitle] = name
+            } else {
+                info[MPMediaItemPropertyTitle] = fallbackTitle
+            }
+            if let seriesName = fullItem.seriesName, !seriesName.isEmpty {
+                info[MPMediaItemPropertyAlbumTitle] = seriesName
+            }
+            if let season = fullItem.parentIndexNumber, let episode = fullItem.indexNumber {
+                info[MPMediaItemPropertyArtist] = "S\(season)E\(episode)"
+            }
+            if let ticks = fullItem.runTimeTicks {
+                let dur = Double(ticks) / 10_000_000
+                if dur > 0 {
+                    info[MPMediaItemPropertyPlaybackDuration] = dur
+                }
+            }
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        }
+    }
+
+    private func startArtworkFetch(itemId: String, generation gen: Int) {
+        guard let imageBuilder else { return }
+        let url = imageBuilder.imageURL(itemId: itemId, imageType: .primary, maxWidth: 600)
+        let token = authToken
+        artworkTask = Task { @MainActor [weak self] in
+            var req = URLRequest(url: url)
+            if let token, !token.isEmpty {
+                req.addValue("MediaBrowser Token=\(token)", forHTTPHeaderField: "Authorization")
+            }
+            guard let (data, response) = try? await URLSession.shared.data(for: req),
+                  let http = response as? HTTPURLResponse, http.statusCode == 200,
+                  let image = UIImage(data: data) else { return }
+            guard let self, self.generation == gen, !Task.isCancelled else { return }
+            // **Sendable closure**: MediaPlayer invokes the request handler on a
+            // background queue. Without explicit `@Sendable` the trailing closure
+            // inherits the enclosing `@MainActor` Task's isolation and traps on
+            // tvOS 26 with `dispatch_assert_queue` ("Block was expected to
+            // execute on queue …"). Capture the image by value to keep the
+            // closure self-contained.
+            let artwork = MPMediaItemArtwork(boundsSize: image.size) { @Sendable [image] _ in image }
+            var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+            info[MPMediaItemPropertyArtwork] = artwork
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        }
+    }
+}

--- a/Shared/Screens/VideoPlayer/VLCStreamPresenter.swift
+++ b/Shared/Screens/VideoPlayer/VLCStreamPresenter.swift
@@ -284,6 +284,7 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
 
     private var reporter: PlaybackReporter?
     private let remoteCommands: RemoteCommandController
+    private let nowPlaying: NowPlayingInfoController
     private var progressTimer: Timer?
     private var hideControlsWorkItem: DispatchWorkItem?
     private var didSeekToStart = false
@@ -352,6 +353,10 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
             onNavigate: { ref in navTarget?(ref) },
             onTogglePlayPause: { playPauseTarget?() }
         )
+        self.nowPlaying = NowPlayingInfoController(
+            apiClient: apiClient, userId: userId,
+            imageBuilder: imageBuilder, authToken: info.authToken
+        )
         super.init(nibName: nil, bundle: nil)
         navTarget = { [weak self] ref in self?.navigateToEpisode(ref) }
         playPauseTarget = { [weak self] in self?.handleRemotePlayPause() }
@@ -382,6 +387,9 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
         self.remoteCommands = RemoteCommandController(
             onNavigate: { _ in },
             onTogglePlayPause: { playPauseTarget?() }
+        )
+        self.nowPlaying = NowPlayingInfoController(
+            apiClient: nil, userId: nil, imageBuilder: nil, authToken: nil
         )
         super.init(nibName: nil, bundle: nil)
         playPauseTarget = { [weak self] in self?.handleRemotePlayPause() }
@@ -421,6 +429,7 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
         progressTimer?.invalidate()
         progressTimer = nil
         remoteCommands.detach()
+        nowPlaying.detach()
         hideControlsWorkItem?.cancel()
         pendingTapWork?.cancel()
         segmentFetchTask?.cancel()
@@ -515,6 +524,10 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
             next: nextEpisode,
             hasNavigator: episodeNavigator != nil
         )
+        // Title / artwork / S×E× on the Lock Screen widget. Offline mode passes
+        // nil apiClient + nil imageBuilder so artwork + enrichment are skipped
+        // (title + elapsed still publish — see NowPlayingInfoController).
+        nowPlaying.attach(itemId: itemId, title: titleText, durationSeconds: nil)
         // Offline: no PlaybackReporter (nothing to phone home to).
         guard let apiClient, let userId, let info else { return }
         reporter = PlaybackReporter(
@@ -544,6 +557,8 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
     private func onSecondTick() {
         reporter?.onTick()
         let now = Double(currentMs) / 1000.0
+        let dur: Double? = lengthMs > 0 ? Double(lengthMs) / 1000 : nil
+        nowPlaying.update(elapsed: now, duration: dur, rate: enginePlaying ? 1.0 : 0.0)
         updateSkipButton(currentTime: now)
         if sleepActive {
             sleepRemaining -= 1
@@ -1564,6 +1579,7 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
                 previous: self.previousEpisode, next: self.nextEpisode,
                 hasNavigator: true
             )
+            self.nowPlaying.attach(itemId: ref.id, title: ref.title, durationSeconds: nil)
             self.showControls()
             self.scheduleHideControls()
         }
@@ -1722,12 +1738,25 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
             #if os(iOS)
             setPlayPauseIcon(playing: true)
             #endif
+            refreshNowPlayingRate(playing: true)
         case .paused:
             #if os(iOS)
             setPlayPauseIcon(playing: false)
             #endif
+            refreshNowPlayingRate(playing: false)
         default: break
         }
+    }
+
+    /// Sub-second sync of the Lock Screen widget's play/pause indicator on
+    /// engine state transitions — the 1 s tick alone would lag visibly here.
+    private func refreshNowPlayingRate(playing: Bool) {
+        let dur: Double? = lengthMs > 0 ? Double(lengthMs) / 1000 : nil
+        nowPlaying.update(
+            elapsed: Double(currentMs) / 1000,
+            duration: dur,
+            rate: playing ? 1.0 : 0.0
+        )
     }
 
     private func handlePlaybackEnded() {


### PR DESCRIPTION
## Summary
- Wires `MPNowPlayingInfoCenter` on both the Native (`AVPlayer`) and SwiftVLC (default) paths so the iPhone Apple TV Remote widget shows title, series + S×E×, poster, duration, elapsed time, and live play/pause state instead of the empty placeholder it currently displays when a video is streaming on the Apple TV.
- New `NowPlayingInfoController` sub-controller (same shape as `PlaybackReporter` / `SleepTimerController`): publishes a title-only placeholder so the widget fills in <1s, then fans out an authenticated `getItem` to enrich with series + S×E× and an authenticated `URLSession` fetch for the primary image. Generation counter guards against episode-nav races.
- Updates piggyback on each presenter's existing 1s tick (no second timer) and on engine state transitions for sub-second pause/play parity on the widget.

## Notes
- `MPMediaItemArtwork`'s request handler is explicitly `@Sendable [image] _ in image` — MediaPlayer invokes it on a background queue and without the annotation Swift 6 makes the closure inherit the enclosing `@MainActor` Task's isolation, which traps on tvOS 26 with `dispatch_assert_queue` ("Block was expected to execute on queue …"). Encoded as a RULE in `CLAUDE.md` to prevent regression.
- `RemoteCommandController` (system buttons) and `NowPlayingInfoController` (metadata) stay as two separate concerns.
- Offline VLC init (no `apiClient` / no `imageBuilder`) constructs the controller with `nil` dependencies and still publishes title + elapsed — artwork + enrichment auto-skip.

## Test plan
- [x] iOS build (`xcodebuild ... -scheme Cinemax`) ✅
- [x] tvOS build (`xcodebuild ... -scheme CinemaxTV`) ✅
- [x] Play a series episode on Apple TV via VLC engine → on locked iPhone, Apple TV Remote widget shows episode title + series name + S×E× + poster + elapsed time + play/pause synced.
- [ ] Repeat with `forceNativeAVPlayer` enabled (Native AVPlayer path).
- [ ] iOS offline downloaded file → title + elapsed only, no artwork, no crash.
- [ ] Press Siri Remote next-track on a series → widget metadata refreshes to the new episode (poster, title, S×E×) without stale data from the previous one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)