### PR TITLE
Harden video playback edge cases + audit fixes

### DIFF
--- a/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient+Playback.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient+Playback.swift
@@ -101,6 +101,15 @@ extension JellyfinAPIClient {
         }()
 
         guard let mediaSource else {
+            // The POST succeeded but matched no source. If `getItem` ALSO had no
+            // media source, the item has no playable file (missing / unmounted on
+            // the server) — surface a clear error rather than falling through to a
+            // direct-stream URL that resolves to a 404/empty mux and leaves the
+            // user on a frozen black screen. When getItem *did* have a source, the
+            // mismatch is benign and the direct-stream fallback can still work.
+            guard initialMediaSource != nil else {
+                throw JellyfinError.playbackFailed("No playable media source")
+            }
             #if DEBUG
             debugLog("No media source in PlaybackInfo response — using direct stream fallback")
             #endif

--- a/Shared/Screens/Admin/Activity/AdminActivityScreen.swift
+++ b/Shared/Screens/Admin/Activity/AdminActivityScreen.swift
@@ -145,10 +145,18 @@ struct AdminActivityScreen: View {
             .frame(width: 8, height: 8)
     }
 
+    // Hoisted out of the per-row helper — `RelativeDateTimeFormatter()` init is
+    // non-trivial and was previously allocated on every list row render. Only
+    // ever touched during main-actor view rendering, so `nonisolated(unsafe)`
+    // is safe.
+    nonisolated(unsafe) private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .full
+        return f
+    }()
+
     private func relativeTimeLabel(for date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .full
-        return formatter.localizedString(for: date, relativeTo: Date())
+        Self.relativeFormatter.localizedString(for: date, relativeTo: Date())
     }
 }
 #endif

--- a/Shared/Screens/Admin/Devices/AdminDevicesScreen.swift
+++ b/Shared/Screens/Admin/Devices/AdminDevicesScreen.swift
@@ -151,11 +151,17 @@ struct AdminDevicesScreen: View {
             }
         }
         if let date = device.dateLastActivity {
-            let formatter = RelativeDateTimeFormatter()
-            formatter.unitsStyle = .full
-            parts.append(formatter.localizedString(for: date, relativeTo: Date()))
+            parts.append(Self.relativeFormatter.localizedString(for: date, relativeTo: Date()))
         }
         return parts.joined(separator: " • ")
     }
+
+    // Hoisted to avoid allocating a `RelativeDateTimeFormatter` on every row
+    // render. Main-actor render only, so `nonisolated(unsafe)` is safe.
+    nonisolated(unsafe) private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .full
+        return f
+    }()
 }
 #endif

--- a/Shared/Screens/Admin/Identify/IdentifyFlowModel.swift
+++ b/Shared/Screens/Admin/Identify/IdentifyFlowModel.swift
@@ -109,8 +109,10 @@ final class IdentifyFlowModel {
                 let query = SeriesInfoRemoteSearchQuery(itemID: itemId, searchInfo: info)
                 results = try await apiClient.searchRemoteSeries(query: query)
             default:
+                // Defensive only — the UI gates search behind `isSupportedKind`,
+                // so this branch isn't reachable in practice. Avoid surfacing a
+                // hardcoded (unlocalized) string; just clear results.
                 results = []
-                errorMessage = "Identify isn't supported for this item kind"
             }
         } catch {
             errorMessage = error.localizedDescription

--- a/Shared/Screens/Admin/Logs/AdminLogsScreen.swift
+++ b/Shared/Screens/Admin/Logs/AdminLogsScreen.swift
@@ -17,6 +17,10 @@ struct AdminLogsScreen: View {
 
     @State private var viewModel = AdminLogsViewModel()
 
+    // Hoisted to avoid allocating a `RelativeDateTimeFormatter` per log-file
+    // row render. Main-actor render only, so `nonisolated(unsafe)` is safe.
+    nonisolated(unsafe) private static let relativeFormatter = RelativeDateTimeFormatter()
+
     var body: some View {
         AdminLoadStateContainer(
             isLoading: viewModel.isLoading && viewModel.files.isEmpty,
@@ -79,8 +83,7 @@ struct AdminLogsScreen: View {
                             Text("•")
                                 .font(CinemaFont.label(.small))
                                 .foregroundStyle(CinemaColor.onSurfaceVariant)
-                            let formatter = RelativeDateTimeFormatter()
-                            Text(formatter.localizedString(for: date, relativeTo: Date()))
+                            Text(Self.relativeFormatter.localizedString(for: date, relativeTo: Date()))
                                 .font(CinemaFont.label(.small))
                                 .foregroundStyle(CinemaColor.onSurfaceVariant)
                         }

--- a/Shared/Screens/Admin/Tasks/AdminScheduledTasksScreen.swift
+++ b/Shared/Screens/Admin/Tasks/AdminScheduledTasksScreen.swift
@@ -136,10 +136,16 @@ struct AdminScheduledTasksScreen: View {
         }
     }
 
+    // Hoisted to avoid per-render allocation (this screen live-polls every 2s
+    // while a task runs). Main-actor render only, so `nonisolated(unsafe)` is safe.
+    nonisolated(unsafe) private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .short
+        return f
+    }()
+
     private func relativeShort(_ date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .short
-        return formatter.localizedString(for: date, relativeTo: Date())
+        Self.relativeFormatter.localizedString(for: date, relativeTo: Date())
     }
 
     private func labelBadge(_ text: String, color: Color) -> some View {

--- a/Shared/Screens/Admin/Users/AdminUsersScreen.swift
+++ b/Shared/Screens/Admin/Users/AdminUsersScreen.swift
@@ -120,13 +120,20 @@ struct AdminUsersScreen: View {
             .background(Capsule().fill(themeManager.accent))
     }
 
+    // Hoisted out of the per-row helper to avoid allocating a
+    // `RelativeDateTimeFormatter` on every list row render. Only touched during
+    // main-actor view rendering, so `nonisolated(unsafe)` is safe.
+    nonisolated(unsafe) private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .full
+        return f
+    }()
+
     private func lastActivityText(for user: UserDto) -> String {
         guard let date = user.lastActivityDate ?? user.lastLoginDate else {
             return loc.localized("admin.users.neverActive")
         }
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .full
-        return formatter.localizedString(for: date, relativeTo: Date())
+        return Self.relativeFormatter.localizedString(for: date, relativeTo: Date())
     }
 
     // MARK: - Create user sheet

--- a/Shared/Screens/Downloads/DownloadsScreen.swift
+++ b/Shared/Screens/Downloads/DownloadsScreen.swift
@@ -290,11 +290,17 @@ struct DownloadsScreen: View {
     }
 
     private func formatBytes(_ bytes: Int64) -> String {
-        let formatter = ByteCountFormatter()
-        formatter.allowedUnits = [.useMB, .useGB]
-        formatter.countStyle = .file
-        return formatter.string(fromByteCount: bytes)
+        return Self.byteFormatter.string(fromByteCount: bytes)
     }
+
+    // Hoisted to avoid allocating a `ByteCountFormatter` on every row render.
+    // Main-actor render only, so `nonisolated(unsafe)` is safe.
+    nonisolated(unsafe) private static let byteFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.allowedUnits = [.useMB, .useGB]
+        f.countStyle = .file
+        return f
+    }()
 
     // MARK: - Grouping
 

--- a/Shared/Screens/NativeVideoPresenter.swift
+++ b/Shared/Screens/NativeVideoPresenter.swift
@@ -273,8 +273,8 @@ final class NativeVideoPresenter {
                 Task { @MainActor in
                     switch item.status {
                     case .readyToPlay:
-                        if let st, st > 0 {
-                            avPlayer?.seek(to: CMTime(seconds: st, preferredTimescale: 600),
+                        if let st, let target = Self.safeResumeSeconds(st, duration: item.duration.seconds) {
+                            avPlayer?.seek(to: CMTime(seconds: target, preferredTimescale: 600),
                                           toleranceBefore: .zero, toleranceAfter: .zero)
                         }
                     case .failed:
@@ -336,8 +336,8 @@ final class NativeVideoPresenter {
             Task { @MainActor in
                 switch item.status {
                 case .readyToPlay:
-                    if let st = startTime, st > 0 {
-                        player.seek(to: CMTime(seconds: st, preferredTimescale: 600),
+                    if let st = startTime, let target = Self.safeResumeSeconds(st, duration: item.duration.seconds) {
+                        player.seek(to: CMTime(seconds: target, preferredTimescale: 600),
                                     toleranceBefore: .zero, toleranceAfter: .zero)
                     }
                 case .failed:
@@ -554,6 +554,19 @@ final class NativeVideoPresenter {
         meta.identifier = .commonIdentifierTitle
         meta.value = title as NSString
         item.externalMetadata = [meta]
+    }
+
+    /// Validates a resume position before seeking. Guards against a non-finite
+    /// position (corrupt `playbackPositionTicks` → NaN/∞ would make an invalid
+    /// `CMTime` and stall AVPlayer on a black screen) and clamps a stale tick
+    /// that points past the end of a re-transcoded/shorter item back to just
+    /// before the end. Returns `nil` when there's nothing meaningful to seek to.
+    nonisolated static func safeResumeSeconds(_ position: Double, duration: Double) -> Double? {
+        guard position.isFinite, position > 0 else { return nil }
+        if duration.isFinite, duration > 1 {
+            return min(position, duration - 1)
+        }
+        return position
     }
 
     // MARK: - Shared Time Observer

--- a/Shared/Screens/VideoPlayer/VLCStreamPresenter.swift
+++ b/Shared/Screens/VideoPlayer/VLCStreamPresenter.swift
@@ -323,6 +323,15 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
     private var isTearingDown = false
     private var lastPlayStart = Date.distantPast
 
+    // "Media never opened" watchdog. libVLC 4.0 can fail to open a stream
+    // (server 404/416 on the static URL, codec the demuxer rejects) by going
+    // straight to `.stopped` with `lengthMs == 0` and emitting no
+    // `.encounteredError` — none of the end/error guards match, so the user
+    // is stranded on a frozen black screen. This fires if no valid time AND no
+    // length has arrived within the timeout, routing to the normal error path.
+    private var openWatchdog: Timer?
+    private static let openTimeout: TimeInterval = 30
+
     // Polish: a track/chapter picker is up — freeze the HUD behind it.
     private var pickerPresented = false
 
@@ -426,6 +435,7 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
 
     private func teardown() {
         isTearingDown = true
+        cancelOpenWatchdog()
         progressTimer?.invalidate()
         progressTimer = nil
         remoteCommands.detach()
@@ -496,6 +506,7 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
                     let c = d.components
                     self.mediaLengthMs = Int32(clamping: Int(c.seconds) * 1000
                         + Int(c.attoseconds / 1_000_000_000_000_000))
+                    if self.mediaLengthMs > 0 { self.cancelOpenWatchdog() }
                 case .timeChanged:
                     self.onEngineTimeChanged()
                 case .stateChanged(let state):
@@ -1506,11 +1517,32 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
         startEventLoop()
         lastPlayStart = Date()
         try? player.play(media)
+        scheduleOpenWatchdog()
         reporter?.reportStart(startTime: startTime)
         startProgressTimer()
         fetchSegments()
         startSleepTimerIfNeeded()
         fetchChapters()
+    }
+
+    /// Arms (or re-arms) the open watchdog. Cancelled the moment playback
+    /// produces a length or a valid time, or on teardown / error / end.
+    private func scheduleOpenWatchdog() {
+        openWatchdog?.invalidate()
+        let t = Timer(timeInterval: Self.openTimeout, repeats: false) { [weak self] _ in
+            Task { @MainActor in
+                guard let self, !self.isTearingDown, !self.hasValidTime, self.lengthMs <= 0 else { return }
+                logger.error("VLC open watchdog: media never became ready — surfacing error")
+                self.handlePlaybackError()
+            }
+        }
+        RunLoop.main.add(t, forMode: .common)
+        openWatchdog = t
+    }
+
+    private func cancelOpenWatchdog() {
+        openWatchdog?.invalidate()
+        openWatchdog = nil
     }
 
     /// Called by `RemoteCommandController` when the Siri Remote / Lock Screen /
@@ -1568,6 +1600,7 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
             guard let media = self.makeMedia(url) else { self.handlePlaybackError(); return }
             self.lastPlayStart = Date()
             try? self.player.play(media)
+            self.scheduleOpenWatchdog()
             self.refreshTimeUISoon()
             self.reporter?.resetTicking()
             self.reporter?.reportStart(startTime: nil)
@@ -1762,6 +1795,7 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
     private func handlePlaybackEnded() {
         guard !didReportEnd else { return }
         didReportEnd = true
+        cancelOpenWatchdog()
         if autoPlayNext, let next = nextEpisode, episodeNavigator != nil {
             didReportEnd = false
             navigateToEpisode(next)
@@ -1796,6 +1830,7 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
     }
 
     private func handlePlaybackError() {
+        cancelOpenWatchdog()
         if !didRetry {
             didRetry = true
             let target = isOffline ? "offline:\(offlineLocalURL?.lastPathComponent ?? "?")" : itemId
@@ -1814,6 +1849,7 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
                 media.addOption(isOffline ? ":file-caching=3000" : ":network-caching=5000")
                 lastPlayStart = Date()
                 try? player.play(media)
+                scheduleOpenWatchdog()
             }
             return
         }
@@ -1832,10 +1868,14 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
 
     private func onEngineTimeChanged() {
         refreshTimeUI()
-        if currentMs > 0 { hasValidTime = true }
-        if !didSeekToStart, let start = startTime, start > 0, lengthMs > 0 {
+        if currentMs > 0 { hasValidTime = true; cancelOpenWatchdog() }
+        if !didSeekToStart, let start = startTime, start.isFinite, start > 0, lengthMs > 0 {
             didSeekToStart = true
-            engineSeek(ms: Int32(start * 1000))
+            // `Int32(start * 1000)` traps on overflow if a corrupt resume tick
+            // yields a huge position — clamp the conversion, then cap to just
+            // before the end so a stale tick past EOF doesn't seek into nothing.
+            let targetMs = min(Int32(clamping: Int(start * 1000)), max(0, lengthMs - 5000))
+            if targetMs > 0 { engineSeek(ms: targetMs) }
         }
     }
 

--- a/Shared/ViewModels/VideoPlayerCoordinator.swift
+++ b/Shared/ViewModels/VideoPlayerCoordinator.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import AVKit
 import OSLog
+import UIKit
 import CinemaxKit
 
 private let logger = Logger(subsystem: "com.cinemax", category: "Playback")
@@ -106,9 +107,38 @@ final class VideoPlayerCoordinator {
                 self.presenter = p
                 p.present(info: info)
             } catch {
+                // Surface the failure to the user. Without this, a thrown
+                // getPlaybackInfo (no playable media, server 500, network drop,
+                // or a Series/Season that never resolves to an Episode) left the
+                // Play button looking dead — the #1 "some videos can't be
+                // launched" report on tvOS. tvOS never mounts VideoPlayerView, so
+                // there's no SwiftUI error surface here; present a native alert.
                 logger.error("tvOS playback error: \(error.localizedDescription)")
+                guard self.currentGeneration == generation else { return }
+                self.presentPlaybackError(loc.userFacingMessage(for: error))
             }
         }
+    }
+
+    /// Presents a native error alert from the top-most view controller. Used by
+    /// the play `Task`'s catch — the only user-facing failure surface on tvOS,
+    /// where playback is driven by this coordinator rather than `VideoPlayerView`.
+    private func presentPlaybackError(_ message: String) {
+        guard let loc = localizationManager else { return }
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        guard let scene = scenes.first(where: { $0.activationState == .foregroundActive }) ?? scenes.first,
+              let root = scene.windows.first(where: { $0.isKeyWindow })?.rootViewController else {
+            return
+        }
+        var top: UIViewController = root
+        while let presented = top.presentedViewController { top = presented }
+        let alert = UIAlertController(
+            title: loc.localized("playback.error.title"),
+            message: message,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: loc.localized("playback.error.close"), style: .default))
+        top.present(alert, animated: true)
     }
 }
 #endif

--- a/Tests/CinemaxKitTests/VideoResumeSeekTests.swift
+++ b/Tests/CinemaxKitTests/VideoResumeSeekTests.swift
@@ -1,0 +1,38 @@
+import Testing
+import Foundation
+@testable import Cinemax
+
+/// Regression coverage for `NativeVideoPresenter.safeResumeSeconds`, the guard
+/// added so a corrupt/stale resume position can't crash AVPlayer (non-finite
+/// `CMTime`) or seek past the end of a re-transcoded, shorter item.
+@Suite("Resume seek clamping")
+struct VideoResumeSeekTests {
+
+    @Test("normal position within duration is unchanged")
+    func normalPosition() {
+        #expect(NativeVideoPresenter.safeResumeSeconds(100, duration: 1000) == 100)
+    }
+
+    @Test("position past the end clamps to just before the end")
+    func pastEndClamps() {
+        #expect(NativeVideoPresenter.safeResumeSeconds(1500, duration: 1000) == 999)
+    }
+
+    @Test("zero and negative positions return nil (nothing to resume)")
+    func nonPositiveReturnsNil() {
+        #expect(NativeVideoPresenter.safeResumeSeconds(0, duration: 1000) == nil)
+        #expect(NativeVideoPresenter.safeResumeSeconds(-5, duration: 1000) == nil)
+    }
+
+    @Test("non-finite positions return nil (would make an invalid CMTime)")
+    func nonFiniteReturnsNil() {
+        #expect(NativeVideoPresenter.safeResumeSeconds(.nan, duration: 1000) == nil)
+        #expect(NativeVideoPresenter.safeResumeSeconds(.infinity, duration: 1000) == nil)
+    }
+
+    @Test("unknown/non-finite duration falls back to the raw position")
+    func unknownDurationKeepsPosition() {
+        #expect(NativeVideoPresenter.safeResumeSeconds(120, duration: .nan) == 120)
+        #expect(NativeVideoPresenter.safeResumeSeconds(120, duration: 0) == 120)
+    }
+}


### PR DESCRIPTION
## Summary

Addresses reports of **videos that won't launch / crash / black-screen** on iOS + tvOS, plus a fresh security/quality/performance audit pass. (App Store Guideline 5.2.2 was handled separately — it's an App Store Connect screenshots/demo-server content issue, no code change.)

## Playback hardening

| Severity | Problem | Fix |
|---|---|---|
| **High** | **tvOS errors were silently swallowed** — `VideoPlayerCoordinator.play()` only logged a thrown `getPlaybackInfo`, so no-playable-media items, server 500s, network drops, or an unresolved Series/Season made the Play button look dead. Likely the #1 "video won't launch" cause on Apple TV. | Coordinator now presents a native alert via `userFacingMessage(for:)`. |
| **High** | An item with no media source from **both** `getItem` and the PlaybackInfo response (missing/unmounted file) fell through to a direct-stream URL that 404s into a frozen black screen. | `getPlaybackInfo` now throws a clear `playbackFailed` error (legitimate partial-match fallback preserved). |
| **High (crash)** | Resume seeks weren't validated: a corrupt `playbackPositionTicks` (NaN/∞) makes an invalid `CMTime` (AVPlayer stalls), and on VLC `Int32(start * 1000)` **traps on overflow**; stale ticks past EOF seek into nothing. | New `safeResumeSeconds()` rejects non-finite + clamps past-EOF; VLC uses overflow-safe `Int32(clamping:)` capped before the end. |
| **Medium** | VLC streams that silently fail to open (server 404/416 with no error event, demuxer-rejected codec) emitted only `.stopped` with `lengthMs == 0`, matching no guard → frozen HUD that feels like a crash. | Added a 30s "open watchdog" that routes a never-ready stream to the normal error/retry path. Cancelled on length/time arrival, teardown, error/end; re-armed on retry + episode-nav. |

**Left intentionally:** the periodic-observer `MainActor.assumeIsolated` (passes `queue: .main` → already on the MainActor executor; matches the documented-safe pattern).

## Audit fixes

- **Localization rule violation** — removed a hardcoded English string in `IdentifyFlowModel` (the branch is UI-gated/unreachable).
- **Per-row formatter allocations** — hoisted `RelativeDateTimeFormatter` (Admin Activity/Users/Devices/Logs/Tasks) and `ByteCountFormatter` (Downloads) to shared statics. The Tasks screen live-polls every 2s, so it was re-allocating each tick.

**Documented as follow-up (not in this PR):** S1 — ~15 admin view models surface raw SDK error strings instead of `userFacingMessage(for:)`. Admin-only / privilege-gated; a correct fix threads `LocalizationManager` through every VM and is best done as its own change.

## Tests

- `Tests/CinemaxKitTests/VideoResumeSeekTests.swift` — regression coverage for the resume-seek clamping logic.

> Note: built/verified by static analysis only (no Swift toolchain in the authoring environment). The new test will compile and run under CI (`xcodegen generate` → `xcodebuild test`). Recommend a local Xcode build of both schemes before merge.

https://claude.ai/code/session_017cKnxvdeGFVR58TC61uZ5x

---
_Generated by [Claude Code](https://claude.ai/code/session_017cKnxvdeGFVR58TC61uZ5x)_