### PR TITLE
Brand login/setup screens as Cinemax, not Jellyfin

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -669,7 +669,7 @@
 
 // MARK: - Login
 
-"login.header" = "JELLYFIN";
+"login.header" = "CINEMAX";
 "login.title" = "SIGN IN";
 "login.subtitle" = "Enter your credentials to access your library";
 "login.mobileTitle" = "Sign In";
@@ -689,7 +689,7 @@
 
 // MARK: - Server Setup
 
-"server.header" = "JELLYFIN";
+"server.header" = "CINEMAX";
 "server.title" = "Connect to Server";
 "server.subtitle" = "Enter the address of your Jellyfin media server to start streaming your collection.";
 "server.mobileTitle" = "Setup Server";

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -270,7 +270,7 @@
 
 // MARK: - Login
 
-"login.header" = "JELLYFIN";
+"login.header" = "CINEMAX";
 "login.title" = "CONNEXION";
 "login.subtitle" = "Entrez vos identifiants pour accéder à votre bibliothèque";
 "login.mobileTitle" = "Connexion";
@@ -290,7 +290,7 @@
 
 // MARK: - Server Setup
 
-"server.header" = "JELLYFIN";
+"server.header" = "CINEMAX";
 "server.title" = "Connexion au serveur";
 "server.subtitle" = "Entrez l'adresse de votre serveur Jellyfin pour commencer à diffuser votre collection.";
 "server.mobileTitle" = "Configuration du serveur";


### PR DESCRIPTION
The Login and Server Setup screens displayed 'JELLYFIN' as a large wordmark header (login.header / server.header), branding the app itself as Jellyfin. This reads as impersonation of the official Jellyfin app (App Store Guidelines 4.1c Copycats / 1.1.6). Rebrand the headers to 'CINEMAX'; the nominative 'votre serveur Jellyfin' descriptive subtitles are unchanged.