### PR TITLE
UX/perf batch: search history, trailers, skeletons, prefetching, iPad hardening, 4K badge fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Native Jellyfin client for iOS 26+ and tvOS 26+. "Cinema Glass" design system (d
 
 - **`UIButton`**: use `UIButton.Configuration`; never `UIButton(type:)` + `setTitle/titleLabel?.font/backgroundColor/contentEdgeInsets`. Pattern in `NativeVideoPresenter`. Frosted bg via `config.background.customView = UIVisualEffectView(...)`.
 - Free SwiftUI helpers returning `some View` that touch `PrimitiveButtonStyle.plain`/`Font`/etc. must be `@MainActor`.
-- **iPad**: `UIRequiresFullScreen` removed (deprecated); split view / Stage Manager allowed but hero/backdrop layouts not yet hardened for resize.
+- **iPad**: `UIRequiresFullScreen` removed (deprecated); split view / Stage Manager supported. Hero/backdrop heights are clamped to a viewport fraction via `containerRelativeFrame(.vertical) { min(fixedHeight, length * 0.55…0.62) }` (iOS only — tvOS keeps fixed heights) in `HomeScreen.heroSection` / `LibraryHeroSection` / `MediaDetailScreen.backdropSection` so short windows keep content below the hero reachable. New full-bleed heroes must follow the same pattern.
 - **Toolbar + Liquid Glass**: iOS 26 auto-renders `ToolbarItem` buttons with Liquid Glass. **Never** add `.buttonStyle(.glass)`/`.glassProminent` on toolbar items (nests double capsules). Active state via `.tint(themeManager.accent)` + `.fill` icon variant.
 
 ### Dependencies
@@ -215,6 +215,9 @@ Three-level navigation. Landing — tvOS: split (left brand, right nav pills, pe
 | `home.showWatchingNow` | `true` | Watching Now row |
 | `home.showFavorites` | `true` | Favorites row (hearted movies/series) |
 | `detail.showQualityBadges` | `true` | Quality pill row on `MediaDetailScreen` |
+| `detail.showTrailerButton` | `true` | iOS-only "Bande-annonce" button on `MediaDetailScreen` (opens first http(s) `remoteTrailers` URL in Safari; no tvOS browser ⇒ no button/toggle there) |
+| `search.saveHistory` | `true` | Recent-search capture + chips on the empty Search screen. Toggle lives in Privacy & Security; turning OFF wipes `search.recentQueries` |
+| `search.recentQueries` | — | JSON `[String]` — most-recent-first history (cap 8). Not a setting; written only via `SearchViewModel.recordRecentSearch`/`clearRecentSearches` |
 | `library.tvBrowseLayout` | `"browse"` | tvOS-only. `browse` = hero + genre rows; `grid` = flat grid. Filters force grid regardless |
 | `privacy.maxContentAge` | `0` | Rating ceiling (0=unrestricted; 10/12/14/16/18) via `apiClient.applyContentRatingLimit` |
 | `menu.mode` | `"default"` | `"default"` ⇒ canonical 5 tabs; `"custom"` ⇒ user-driven (see `MenuConfigStore`) |
@@ -308,6 +311,7 @@ Jellyfin's `searchTerm` is contiguous + punctuation-sensitive — "Mission Impos
 - `ImageURLBuilder` → `/Items/{id}/Images/{type}`. **Backdrop sizing**: use `ImageURLBuilder.screenPixelWidth` — never hardcode `1920`.
 - **RULE — always pass the `tag:` cache-buster to `imageURL(...)`/`imageURLRaw(...)`**: without it the image URL is byte-identical across server-side poster/backdrop edits, so Nuke (keyed by URL) serves the stale image forever — a metadata/poster change is invisible until reinstall, and `clearCache()`/"Refresh Catalogue" don't help (they clear the JSON cache, not Nuke's). Pass `tag: item.primaryImageTagValue` for `.primary`, `tag: item.backdropImageTagValue` for `.backdrop` (helpers in `BaseItemDto+Metadata.swift`; backdrop helper mirrors `backdropItemID`'s parent-first resolution), `person.primaryImageTag` for cast. Every new live image call site must thread the tag. Deliberately omitted on download-prefetch/offline paths (image is fetched once to disk; some point at the `seriesID` poster whose tag wouldn't match) and `NowPlayingInfoController` (separate `URLSession` cache, re-fetched per playback).
 - **Image cache**: `AppNavigation.init()` configures `ImagePipeline.shared` with 500 MB disk + explicit `ImageCache` `costLimit = 256 MB` (Nuke's ~100 MB default evicts mid-render on tvOS — 4K backdrops decode to 4–8 MB each).
+- **Prefetch (`PosterPrefetcher`, Shared/ViewModels)**: Home + Library warm card images via Nuke `ImagePrefetcher` after each data load. **RULE — prefetched URLs must be byte-identical to the consuming card's request** (same `maxWidth` AND `tag`) — Nuke keys on the URL, a near-miss warms nothing. Posters = primary/300, continue-watching = backdrop/600. Call `reset()` before a full catalogue refresh so refreshed tags re-prefetch.
 - **Backdrop fallback**: `item.backdropItemID` (→ `parentBackdropItemID ?? seriesID ?? id`). **No-backdrop placeholder**: gate on `item.hasBackdropImage` (NOT `backdropItemID` — always non-nil) → `BackdropFallbackView` (centered `film` symbol over `surfaceContainerLow` + accent radial, under `CinemaGradient.heroOverlay`). Wired in `MediaDetailScreen.backdropSection`/`HomeScreen.heroSection`/`LibraryHeroSection`.
 - **Always `CinemaLazyImage`** — never `LazyImage` directly. Card containers: `Color.clear` + `.aspectRatio()` + `.frame(maxWidth: .infinity)` + `.overlay { CinemaLazyImage }` + `.clipped()`. **Backdrop (full-bleed ZStack)**: `CinemaLazyImage` must have `.frame(maxWidth:.infinity, maxHeight:.infinity)` — else ZStack sizes from natural 1920px pushing title off-screen. Outer container `LazyVStack(alignment: .leading)`.
 - **PosterCard title alignment**: hidden `Text("M\nM").hidden()` placeholder + actual title overlaid top-aligned → uniform row height.

--- a/Cinemax.xcodeproj/project.pbxproj
+++ b/Cinemax.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		1EF97616FD7266817F2A97D0 /* AdminNetworkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952BA3312C0EC62F0CF9ACBE /* AdminNetworkViewModel.swift */; };
 		1F8DDF74B6AA98658B045CF5 /* MovieLibraryScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A30840A8AEBE5AA59B722F /* MovieLibraryScreen.swift */; };
 		2071AE386D844DA8B6283716 /* SettingsTVActionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96FE07986012B06BD4B2E9DD /* SettingsTVActionRow.swift */; };
+		23F08C5E6904A507BF0E2C93 /* PosterPrefetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD74C7044AE82EE6BA3DDAB0 /* PosterPrefetcher.swift */; };
 		26FE32C915B9FA41BD2760A3 /* AdminCatalogScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B4D9D3C1CDC4B248270077 /* AdminCatalogScreen.swift */; };
 		276021C21CB270437185ACF2 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1B61BF8E4B4D7BFFEEDF40 /* MainTabView.swift */; };
 		2795FD90A8FA67405535C2B7 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 653AA083295D61DCACCEC0A1 /* PrivacyInfo.xcprivacy */; };
@@ -108,6 +109,7 @@
 		48FF615615634DB49D4F7284 /* MediaDetailSimilarSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5BE8C3505764A69391252DD /* MediaDetailSimilarSection.swift */; };
 		4979E3EF3554A8E4DF2E07EF /* ServerHelpSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23376A2C6A25FD3A7A74DBE /* ServerHelpSheet.swift */; };
 		49EC4B1F2B8BB56DCB239830 /* PlaybackReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97FFFD02B7FDCCDF546C872 /* PlaybackReporterTests.swift */; };
+		4B129DCA9BC57149F2DC1B82 /* SkeletonViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92DA34832DA62A5B0A010C5 /* SkeletonViews.swift */; };
 		4B66D96B583EDB78690FD695 /* ServerHelpSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23376A2C6A25FD3A7A74DBE /* ServerHelpSheet.swift */; };
 		4B7E73007A559CA15B9D34CE /* MetadataCastTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEAE9BB3E538E792AD643F8 /* MetadataCastTab.swift */; };
 		4BE51C7C783DC5665E32AB27 /* MediaDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD57D8126029102A7AE191CF /* MediaDetailViewModel.swift */; };
@@ -207,6 +209,7 @@
 		8CE621C8D3CAD1DE98B6CA11 /* AppNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78377E8E832D65F7226A2A06 /* AppNavigation.swift */; };
 		8CEDBFDF0D342D653C8FA840 /* CinemaToggleIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38AC0B18ACCE5C2EBA766E08 /* CinemaToggleIndicator.swift */; };
 		8D24463B5C884F60485FD40C /* LoginScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE7C8046FBDB91EFDDC0805 /* LoginScreen.swift */; };
+		8E5CEC5B238BCD6A80E82AD0 /* SkeletonViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92DA34832DA62A5B0A010C5 /* SkeletonViews.swift */; };
 		8E85DE19A0AC363A1A138788 /* GlassModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A353B49C5117D5F686F07B /* GlassModifiers.swift */; };
 		8EA6683BCA87AA552B36C4CA /* LicensesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21750E7690B40CFD3168FACA /* LicensesView.swift */; };
 		9034FB9DFF2164E0FF803803 /* SkipSegmentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D0C0F047D7CB697E80F4CA5 /* SkipSegmentController.swift */; };
@@ -311,6 +314,7 @@
 		E47F32A6D835E3546B9E083C /* PrivacySecurityScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B000BF38B945DD465445ED /* PrivacySecurityScreen.swift */; };
 		E4AF1097C891473701C8C2C9 /* LoadingStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A863021FF6B842EE2A0E27CA /* LoadingStateView.swift */; };
 		E61CB24A8F271963C9893633 /* IdentifyResultsGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74AE99230CEB07F7CC4FCCFA /* IdentifyResultsGridView.swift */; };
+		E6A483EBAE295BA9DF0BD577 /* PosterPrefetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD74C7044AE82EE6BA3DDAB0 /* PosterPrefetcher.swift */; };
 		E6B2BB0C27B3C1FCDB145884 /* SettingsScreen+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66D79E78292DF655B3F508E /* SettingsScreen+iOS.swift */; };
 		E6C2C97AB4AD05D3A7D95087 /* AdminScheduledTasksScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2101C4E32EEC83662C75D00 /* AdminScheduledTasksScreen.swift */; };
 		E71BC25CBB98F5DF97065B98 /* BaseItemDto+Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BDB8AB3BF62513D67C2E16 /* BaseItemDto+Metadata.swift */; };
@@ -580,6 +584,7 @@
 		E5BE8C3505764A69391252DD /* MediaDetailSimilarSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDetailSimilarSection.swift; sourceTree = "<group>"; };
 		E61944A0EB692FE3706F500B /* ThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
 		E81F4A35762E8619A3D24747 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
+		E92DA34832DA62A5B0A010C5 /* SkeletonViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonViews.swift; sourceTree = "<group>"; };
 		E9A353B49C5117D5F686F07B /* GlassModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassModifiers.swift; sourceTree = "<group>"; };
 		EAEC7B9C5388FF38DAC9FE9A /* boot.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = boot.c; sourceTree = "<group>"; };
 		EFF999321A455C6A950736CB /* AdminApiKeysScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminApiKeysScreen.swift; sourceTree = "<group>"; };
@@ -591,6 +596,7 @@
 		F9D01599D90904C2EF5B69CE /* MenuSettingsScreen+tvOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MenuSettingsScreen+tvOS.swift"; sourceTree = "<group>"; };
 		FC5F40A4DB82730AD3871CB7 /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		FCB36F2BA2BA2F32157D2B57 /* LibraryLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryLogicTests.swift; sourceTree = "<group>"; };
+		FD74C7044AE82EE6BA3DDAB0 /* PosterPrefetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PosterPrefetcher.swift; sourceTree = "<group>"; };
 		FF0A552AFA2A46BB879FE87B /* ServerSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSetupViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -907,6 +913,7 @@
 				DD57D8126029102A7AE191CF /* MediaDetailViewModel.swift */,
 				DE7B27B99DB58FF2CAC5D765 /* MediaLibraryViewModel.swift */,
 				E5BC952DF89C9791E8414656 /* NetworkMonitor.swift */,
+				FD74C7044AE82EE6BA3DDAB0 /* PosterPrefetcher.swift */,
 				611E44F72064D91AE6DBCC6C /* SearchViewModel.swift */,
 				FF0A552AFA2A46BB879FE87B /* ServerSetupViewModel.swift */,
 				B14D3FE509DDFB9EA6569161 /* VideoPlayerCoordinator.swift */,
@@ -1090,6 +1097,7 @@
 				D3DF8C441837A8A10C480077 /* ProgressBarView.swift */,
 				A862B86E04553CE19E85DEA1 /* RainbowAccentSwatch.swift */,
 				19C632FC97E86299EBCAA2CA /* RatingBadge.swift */,
+				E92DA34832DA62A5B0A010C5 /* SkeletonViews.swift */,
 				0E5C1E6AA06EF0B35E4B4CD2 /* ToastOverlay.swift */,
 				8FFCCAA7179A62CDE9CECD2E /* UserAvatar.swift */,
 				BA0B2775D4776FF99A90FB12 /* WideCard.swift */,
@@ -1443,6 +1451,7 @@
 				F0EB8A2EC337D3B4E6E8371D /* PlayerTimeFormat.swift in Sources */,
 				C29097B0D079DD881E7EC4E3 /* PlayerTransportViews.swift in Sources */,
 				850FA2A4714148E59074CC92 /* PosterCard.swift in Sources */,
+				E6A483EBAE295BA9DF0BD577 /* PosterPrefetcher.swift in Sources */,
 				C023EB1EF502941C1528CC62 /* PrivacySecurityConnectedDevicesList.swift in Sources */,
 				477719DD3B599CC529C72C89 /* PrivacySecurityScreen.swift in Sources */,
 				74CBBF39B6E72933460424C5 /* ProgressBarView.swift in Sources */,
@@ -1467,6 +1476,7 @@
 				2071AE386D844DA8B6283716 /* SettingsTVActionRow.swift in Sources */,
 				31515E2177896D6C0B3EC858 /* SettingsTVLanguagePicker.swift in Sources */,
 				3A1B0A7811DD9CF81234A706 /* SettingsTVProfileSection.swift in Sources */,
+				8E5CEC5B238BCD6A80E82AD0 /* SkeletonViews.swift in Sources */,
 				7155A56A5485AAF1DC82145D /* SkipSegmentController.swift in Sources */,
 				6FD9760CC8B8978452CF4288 /* SleepTimerController.swift in Sources */,
 				7D2D1CAAA138FF339ED93EFF /* SleepTimerOption.swift in Sources */,
@@ -1611,6 +1621,7 @@
 				3938ED16A1F48ED88B8B716C /* PlayerTimeFormat.swift in Sources */,
 				DD527ADA33EDBEC22FBE5EB1 /* PlayerTransportViews.swift in Sources */,
 				172A4AE31E117BAB19C89CA6 /* PosterCard.swift in Sources */,
+				23F08C5E6904A507BF0E2C93 /* PosterPrefetcher.swift in Sources */,
 				CB8A5B33DC46E1D442D55956 /* PrivacySecurityConnectedDevicesList.swift in Sources */,
 				E47F32A6D835E3546B9E083C /* PrivacySecurityScreen.swift in Sources */,
 				18D85464EB601F8113743C4D /* ProgressBarView.swift in Sources */,
@@ -1635,6 +1646,7 @@
 				CCD551977D38C74BA8A43DDF /* SettingsTVActionRow.swift in Sources */,
 				D795322803A88D523D9D8351 /* SettingsTVLanguagePicker.swift in Sources */,
 				C0E93495C815097BC0DC1ECC /* SettingsTVProfileSection.swift in Sources */,
+				4B129DCA9BC57149F2DC1B82 /* SkeletonViews.swift in Sources */,
 				9034FB9DFF2164E0FF803803 /* SkipSegmentController.swift in Sources */,
 				89E70B6249FE96008E832974 /* SleepTimerController.swift in Sources */,
 				575A596CB9AB11EAB858E4F5 /* SleepTimerOption.swift in Sources */,

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -667,6 +667,7 @@
 "settings.homePage.favorites" = "Favorites";
 "settings.detailPage" = "Detail Page";
 "settings.detailPage.qualityBadges" = "Quality badges";
+"settings.detailPage.trailerButton" = "Trailer button";
 "settings.libraryLayout" = "Library landing";
 "settings.libraryLayout.browse" = "Browse";
 "settings.libraryLayout.grid" = "Grid";
@@ -853,6 +854,7 @@
 "home.favorites" = "Favorites";
 "detail.partOf" = "Part of: %@";
 "detail.favorite.add" = "Add to favorites";
+"detail.trailer" = "Trailer";
 "detail.favorite.remove" = "Remove from favorites";
 "person.movies" = "Movies";
 "person.series" = "TV Shows";

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -143,6 +143,8 @@
 "search.surpriseMePrompt" = "Not sure what to watch?";
 "search.surprise.movie" = "Surprise movie";
 "search.surprise.series" = "Surprise series";
+"search.recent" = "Recent searches";
+"search.recent.clear" = "Clear";
 
 // MARK: - Settings
 
@@ -201,6 +203,9 @@
 "privacy.sessions.signOutConfirm" = "This device will be signed out of the server.";
 "privacy.sessions.empty" = "No other connected devices";
 "privacy.maintenance" = "Maintenance";
+"privacy.search" = "Search";
+"privacy.saveSearchHistory" = "Save recent searches";
+"privacy.saveSearchHistory.subtitle" = "Shown as suggestions on the Search screen. Turning this off clears the history.";
 "privacy.clearContinueWatching" = "Clear Continue Watching";
 "privacy.clearContinueWatching.subtitle" = "Remove resume progress shown in Continue Watching.";
 "privacy.clearContinueWatching.confirm" = "Resume progress will be cleared on the server.";
@@ -774,6 +779,8 @@
 
 "accessibility.clearSearch" = "Clear search";
 "accessibility.voiceSearch" = "Voice search";
+"accessibility.clearRecentSearches" = "Clear recent searches";
+"accessibility.searchAgainFor" = "Search again for %@";
 "accessibility.stopVoiceSearch" = "Stop voice search";
 "accessibility.previousEpisode" = "Previous episode";
 "accessibility.nextEpisode" = "Next episode";

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -143,6 +143,8 @@
 "search.surpriseMePrompt" = "Pas d'idée de ce que regarder ?";
 "search.surprise.movie" = "Film surprise";
 "search.surprise.series" = "Série surprise";
+"search.recent" = "Recherches récentes";
+"search.recent.clear" = "Effacer";
 
 // MARK: - Settings
 
@@ -201,6 +203,9 @@
 "privacy.sessions.signOutConfirm" = "Cet appareil sera déconnecté du serveur.";
 "privacy.sessions.empty" = "Aucun autre appareil connecté";
 "privacy.maintenance" = "Maintenance";
+"privacy.search" = "Recherche";
+"privacy.saveSearchHistory" = "Enregistrer les recherches récentes";
+"privacy.saveSearchHistory.subtitle" = "Affichées en suggestions sur l'écran Recherche. Désactiver efface l'historique.";
 "privacy.clearContinueWatching" = "Effacer « Reprendre »";
 "privacy.clearContinueWatching.subtitle" = "Supprimer la progression affichée dans Reprendre.";
 "privacy.clearContinueWatching.confirm" = "Les progressions de lecture seront effacées côté serveur.";
@@ -376,6 +381,8 @@
 
 "accessibility.clearSearch" = "Effacer la recherche";
 "accessibility.voiceSearch" = "Recherche vocale";
+"accessibility.clearRecentSearches" = "Effacer les recherches récentes";
+"accessibility.searchAgainFor" = "Rechercher à nouveau %@";
 "accessibility.stopVoiceSearch" = "Arrêter la recherche vocale";
 "accessibility.previousEpisode" = "Épisode précédent";
 "accessibility.nextEpisode" = "Épisode suivant";

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -269,6 +269,7 @@
 "settings.homePage.favorites" = "Favoris";
 "settings.detailPage" = "Page de détail";
 "settings.detailPage.qualityBadges" = "Badges de qualité";
+"settings.detailPage.trailerButton" = "Bouton Bande-annonce";
 "settings.libraryLayout" = "Page d'accueil bibliothèque";
 "settings.libraryLayout.browse" = "Parcourir";
 "settings.libraryLayout.grid" = "Grille";
@@ -854,6 +855,7 @@
 "home.favorites" = "Favoris";
 "detail.partOf" = "Fait partie de : %@";
 "detail.favorite.add" = "Ajouter aux favoris";
+"detail.trailer" = "Bande-annonce";
 "detail.favorite.remove" = "Retirer des favoris";
 "person.movies" = "Films";
 "person.series" = "Séries";

--- a/Shared/DesignSystem/Components/MediaQualityBadges.swift
+++ b/Shared/DesignSystem/Components/MediaQualityBadges.swift
@@ -67,14 +67,19 @@ struct MediaQualityBadges: View {
 
     // MARK: - Resolution
 
+    /// Classifies on width OR height (same approach as Jellyfin's web client).
+    /// Height alone is wrong for anything wider than 16:9 — Jellyfin stores
+    /// the encoded frame's dimensions with letterbox bars cropped out, so a
+    /// 2.39:1 4K movie is 3840×1600 (and a scope 1080p is 1920×800). The
+    /// thresholds sit at ~95% of nominal to absorb slightly-cropped encodes.
     private static func resolutionLabel(for stream: MediaStream) -> String? {
-        guard let h = stream.height else { return nil }
-        switch h {
-        case let x where x >= 2160: return "4K"
-        case let x where x >= 1080: return "1080p"
-        case let x where x >= 720:  return "720p"
-        default:                    return "SD"
-        }
+        let w = stream.width ?? 0
+        let h = stream.height ?? 0
+        guard w > 0 || h > 0 else { return nil }
+        if w >= 3800 || h >= 2100 { return "4K" }
+        if w >= 1800 || h >= 1000 { return "1080p" }
+        if w >= 1200 || h >= 700  { return "720p" }
+        return "SD"
     }
 
     // MARK: - HDR

--- a/Shared/DesignSystem/Components/SkeletonViews.swift
+++ b/Shared/DesignSystem/Components/SkeletonViews.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+
+// MARK: - Skeleton building blocks
+
+/// Shimmering placeholder block used to sketch a screen's layout while its
+/// data loads (replaces the centered spinner on Home / Library, which gave no
+/// hint of what was coming and made load latency feel longer).
+///
+/// The sweep is a translating linear-gradient highlight; when Motion Effects
+/// is off the block renders as a static tinted shape (no animation at all,
+/// matching the app-wide motion gate).
+struct SkeletonBlock: View {
+    var cornerRadius: CGFloat = CinemaRadius.large
+
+    @Environment(\.motionEffectsEnabled) private var motionEffects
+    @State private var phase: CGFloat = -1
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: cornerRadius)
+            .fill(CinemaColor.surfaceContainerHigh)
+            .overlay {
+                if motionEffects {
+                    GeometryReader { geo in
+                        LinearGradient(
+                            colors: [
+                                .clear,
+                                CinemaColor.surfaceContainerHighest.opacity(0.9),
+                                .clear
+                            ],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                        .frame(width: geo.size.width * 0.6)
+                        // phase -1…1 maps the highlight from fully off-screen
+                        // left to fully off-screen right.
+                        .offset(x: phase * geo.size.width * 1.6)
+                    }
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .onAppear {
+                guard motionEffects else { return }
+                withAnimation(.linear(duration: 1.4).repeatForever(autoreverses: false)) {
+                    phase = 1
+                }
+            }
+            .accessibilityHidden(true)
+    }
+}
+
+// MARK: - Page skeleton (Home / Library browse)
+
+/// Full-page placeholder mirroring the hero + content-rows layout shared by
+/// `HomeScreen` and `MediaLibraryScreen`'s browse view. Sizing is injected by
+/// the caller so the skeleton matches the screen's own adaptive metrics
+/// (tvOS vs iPhone vs iPad) without duplicating them here.
+struct MediaPageSkeleton: View {
+    enum RowKind {
+        /// 16:9 wide cards (continue watching).
+        case wide
+        /// 2:3 poster cards (recently added, genre rows).
+        case poster
+    }
+
+    let heroHeight: CGFloat
+    let rows: [RowKind]
+    let posterCardWidth: CGFloat
+    let wideCardWidth: CGFloat
+    let horizontalPadding: CGFloat
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: CinemaSpacing.spacing6) {
+            SkeletonBlock(cornerRadius: 0)
+                .frame(maxWidth: .infinity)
+                .frame(height: heroHeight)
+
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, kind in
+                rowSkeleton(kind)
+            }
+
+            Spacer(minLength: 0)
+        }
+        // Static sketch — never scrollable, never interactive.
+        .allowsHitTesting(false)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .clipped()
+    }
+
+    @ViewBuilder
+    private func rowSkeleton(_ kind: RowKind) -> some View {
+        VStack(alignment: .leading, spacing: CinemaSpacing.spacing3) {
+            // Row title placeholder.
+            SkeletonBlock(cornerRadius: CinemaRadius.small)
+                .frame(width: 160, height: CinemaScale.pt(18))
+                .padding(.horizontal, horizontalPadding)
+
+            HStack(alignment: .top, spacing: CinemaSpacing.spacing3) {
+                switch kind {
+                case .wide:
+                    ForEach(0..<6, id: \.self) { _ in
+                        SkeletonBlock()
+                            .frame(width: wideCardWidth, height: wideCardWidth * 9 / 16)
+                    }
+                case .poster:
+                    ForEach(0..<10, id: \.self) { _ in
+                        VStack(alignment: .leading, spacing: CinemaSpacing.spacing2) {
+                            SkeletonBlock()
+                                .frame(width: posterCardWidth, height: posterCardWidth * 3 / 2)
+                            SkeletonBlock(cornerRadius: CinemaRadius.small)
+                                .frame(width: posterCardWidth * 0.7, height: CinemaScale.pt(12))
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, horizontalPadding)
+        }
+    }
+}
+
+#if DEBUG
+#Preview("MediaPageSkeleton") {
+    MediaPageSkeleton(
+        heroHeight: 360,
+        rows: [.wide, .poster],
+        posterCardWidth: 140,
+        wideCardWidth: 280,
+        horizontalPadding: CinemaSpacing.spacing3
+    )
+    .background(CinemaColor.surface)
+}
+#endif

--- a/Shared/DesignSystem/Components/SkeletonViews.swift
+++ b/Shared/DesignSystem/Components/SkeletonViews.swift
@@ -13,37 +13,45 @@ struct SkeletonBlock: View {
     var cornerRadius: CGFloat = CinemaRadius.large
 
     @Environment(\.motionEffectsEnabled) private var motionEffects
-    @State private var phase: CGFloat = -1
+
+    /// Sweep period in seconds.
+    private static let period: Double = 1.4
 
     var body: some View {
         RoundedRectangle(cornerRadius: cornerRadius)
             .fill(CinemaColor.surfaceContainerHigh)
             .overlay {
                 if motionEffects {
-                    GeometryReader { geo in
-                        LinearGradient(
-                            colors: [
-                                .clear,
-                                CinemaColor.surfaceContainerHighest.opacity(0.9),
-                                .clear
-                            ],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                        .frame(width: geo.size.width * 0.6)
-                        // phase -1…1 maps the highlight from fully off-screen
-                        // left to fully off-screen right.
-                        .offset(x: phase * geo.size.width * 1.6)
+                    // Clock-driven sweep via TimelineView rather than a
+                    // `withAnimation(.repeatForever)` started in `onAppear` —
+                    // that pattern silently fails to animate when the block is
+                    // part of the screen's initial render (the state change
+                    // lands inside an already-committed transaction and the
+                    // shimmer freezes). Deriving the phase from the timeline
+                    // date can't be dropped, and all blocks sweep in sync.
+                    TimelineView(.animation) { context in
+                        let t = context.date.timeIntervalSinceReferenceDate
+                        // 0…1 over each period, remapped to -1…1 so the
+                        // highlight travels from fully off-screen left to
+                        // fully off-screen right, then restarts.
+                        let phase = (t.truncatingRemainder(dividingBy: Self.period)) / Self.period * 2 - 1
+                        GeometryReader { geo in
+                            LinearGradient(
+                                colors: [
+                                    .clear,
+                                    CinemaColor.surfaceContainerHighest.opacity(0.9),
+                                    .clear
+                                ],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                            .frame(width: geo.size.width * 0.6)
+                            .offset(x: phase * geo.size.width * 1.6)
+                        }
                     }
                 }
             }
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
-            .onAppear {
-                guard motionEffects else { return }
-                withAnimation(.linear(duration: 1.4).repeatForever(autoreverses: false)) {
-                    phase = 1
-                }
-            }
             .accessibilityHidden(true)
     }
 }

--- a/Shared/DesignSystem/SettingsKeys.swift
+++ b/Shared/DesignSystem/SettingsKeys.swift
@@ -36,6 +36,16 @@ enum SettingsKey {
     // Detail page
     static let detailShowQualityBadges = "detail.showQualityBadges"
 
+    // Search
+    /// When `true` (default), successful search queries are persisted to
+    /// `searchRecentQueries` and surfaced as tappable chips on the empty
+    /// search screen. Toggle lives in Privacy & Security (it's a privacy
+    /// concern, not an interface one).
+    static let searchSaveHistory = "search.saveHistory"
+    /// JSON `[String]` — most-recent-first list of past queries. Not a user
+    /// setting; written only through `SearchViewModel`'s mutators.
+    static let searchRecentQueries = "search.recentQueries"
+
     // Library landing (tvOS only)
     /// `"browse"` (default) shows hero + genre rows; `"grid"` shows a flat poster grid using the default sort.
     static let libraryTVBrowseLayout = "library.tvBrowseLayout"
@@ -79,6 +89,8 @@ enum SettingsKey {
         static let homeShowWatchingNow = true
 
         static let detailShowQualityBadges = true
+
+        static let searchSaveHistory = true
 
         static let libraryTVBrowseLayout = LibraryTVBrowseLayout.browse.rawValue
 

--- a/Shared/DesignSystem/SettingsKeys.swift
+++ b/Shared/DesignSystem/SettingsKeys.swift
@@ -35,6 +35,10 @@ enum SettingsKey {
 
     // Detail page
     static let detailShowQualityBadges = "detail.showQualityBadges"
+    /// iOS only — shows the "Bande-annonce" button on `MediaDetailScreen` when
+    /// the item carries `remoteTrailers`. tvOS has no browser to open the URL,
+    /// so the button (and its settings row) don't exist there.
+    static let detailShowTrailerButton = "detail.showTrailerButton"
 
     // Search
     /// When `true` (default), successful search queries are persisted to
@@ -89,6 +93,7 @@ enum SettingsKey {
         static let homeShowWatchingNow = true
 
         static let detailShowQualityBadges = true
+        static let detailShowTrailerButton = true
 
         static let searchSaveHistory = true
 

--- a/Shared/Screens/HomeScreen.swift
+++ b/Shared/Screens/HomeScreen.swift
@@ -310,7 +310,17 @@ struct HomeScreen: View {
         // action buttons off-screen.
         Color.clear
             .frame(maxWidth: .infinity)
+            #if os(tvOS)
             .frame(height: heroHeight)
+            #else
+            // iPad hardening: in a short window (Stage Manager, Split View
+            // landscape) a fixed 500pt hero can swallow the whole viewport.
+            // Clamp to ~60% of the scroll viewport's height; full-screen
+            // iPhone/iPad resolve to the regular `heroHeight` (the min wins).
+            .containerRelativeFrame(.vertical) { length, _ in
+                min(heroHeight, length * 0.62)
+            }
+            #endif
             .overlay {
                 if item.hasBackdropImage, let backdropId = item.backdropItemID {
                     CinemaLazyImage(

--- a/Shared/Screens/HomeScreen.swift
+++ b/Shared/Screens/HomeScreen.swift
@@ -11,6 +11,7 @@ struct HomeScreen: View {
     @Environment(\.horizontalSizeClass) private var sizeClass
     #endif
     @State private var viewModel = HomeViewModel()
+    @State private var prefetcher = PosterPrefetcher()
 
     @AppStorage(SettingsKey.homeShowContinueWatching) private var showContinueWatching: Bool = SettingsKey.Default.homeShowContinueWatching
     @AppStorage(SettingsKey.homeShowRecentlyAdded) private var showRecentlyAdded: Bool = SettingsKey.Default.homeShowRecentlyAdded
@@ -27,7 +28,7 @@ struct HomeScreen: View {
             if !network.isOnline {
                 OfflineLibraryView(scope: .all)
             } else if viewModel.isLoading {
-                LoadingStateView()
+                loadingSkeleton
             } else if isHomeEmpty {
                 homeEmptyState
             } else {
@@ -35,7 +36,7 @@ struct HomeScreen: View {
             }
             #else
             if viewModel.isLoading {
-                LoadingStateView()
+                loadingSkeleton
             } else if isHomeEmpty {
                 homeEmptyState
             } else {
@@ -49,9 +50,14 @@ struct HomeScreen: View {
         #endif
         .task {
             await viewModel.loadInitial(using: appState)
+            prefetchCardImages()
         }
         .onReceive(NotificationCenter.default.publisher(for: .cinemaxShouldRefreshCatalogue)) { _ in
-            Task { await viewModel.reload(using: appState) }
+            Task {
+                prefetcher.reset()
+                await viewModel.reload(using: appState)
+                prefetchCardImages()
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .cinemaxFavoritesChanged)) { _ in
             Task { await viewModel.refreshFavorites(using: appState) }
@@ -83,6 +89,29 @@ struct HomeScreen: View {
         let id: String
     }
 
+    /// Warms Nuke's cache for every card the loaded rows will render. URLs
+    /// mirror the cards' own requests exactly (same `maxWidth` + `tag`) —
+    /// a parameter mismatch would warm a different cache entry (see
+    /// `PosterPrefetcher`). Cheap to call repeatedly: already-seen URLs are
+    /// deduped inside the prefetcher.
+    private func prefetchCardImages() {
+        let builder = appState.imageBuilder
+
+        // 2:3 posters — recently added, favorites, genre rows (cards request maxWidth 300).
+        var posterItems = viewModel.latestItems + viewModel.favoriteItems
+        for row in viewModel.genreRows {
+            if case .items(let items) = row.state { posterItems += items }
+        }
+        prefetcher.prefetch(posterItems.map { item in
+            item.id.map { builder.imageURL(itemId: $0, imageType: .primary, maxWidth: 300, tag: item.primaryImageTagValue) }
+        })
+
+        // 16:9 backdrops — continue watching (cards request maxWidth 600).
+        prefetcher.prefetch(viewModel.resumeItems.map { item in
+            item.backdropItemID.map { builder.imageURL(itemId: $0, imageType: .backdrop, maxWidth: 600, tag: item.backdropImageTagValue) }
+        })
+    }
+
     /// True when there's no hero, no resume items, no recently added items, and no genre rows.
     /// Happens on a fresh Jellyfin install or a server with no media.
     private var isHomeEmpty: Bool {
@@ -90,6 +119,26 @@ struct HomeScreen: View {
             && viewModel.resumeItems.isEmpty
             && viewModel.latestItems.isEmpty
             && viewModel.genreRows.isEmpty
+    }
+
+    /// Layout-shaped placeholder shown during the initial load — sketches the
+    /// hero + continue-watching + poster rows the real content will occupy.
+    private var loadingSkeleton: some View {
+        MediaPageSkeleton(
+            heroHeight: heroHeight,
+            rows: [.wide, .poster],
+            posterCardWidth: posterCardWidth,
+            wideCardWidth: wideCardWidth,
+            horizontalPadding: skeletonPadding
+        )
+    }
+
+    private var skeletonPadding: CGFloat {
+        #if os(tvOS)
+        CinemaSpacing.spacing20
+        #else
+        CinemaSpacing.spacing6
+        #endif
     }
 
     private var homeEmptyState: some View {

--- a/Shared/Screens/LibraryHeroSection.swift
+++ b/Shared/Screens/LibraryHeroSection.swift
@@ -26,7 +26,16 @@ struct LibraryHeroSection: View {
         // outside the visible hero bounds.
         Color.clear
             .frame(maxWidth: .infinity)
+            #if os(tvOS)
             .frame(height: heroHeight)
+            #else
+            // iPad hardening: clamp to ~60% of the scroll viewport so short
+            // Stage Manager / Split View windows keep content below the hero
+            // reachable. Full-screen devices resolve to `heroHeight`.
+            .containerRelativeFrame(.vertical) { length, _ in
+                min(heroHeight, length * 0.62)
+            }
+            #endif
             .overlay {
                 if item.hasBackdropImage, let id = item.id {
                     CinemaLazyImage(

--- a/Shared/Screens/MediaDetailScreen.swift
+++ b/Shared/Screens/MediaDetailScreen.swift
@@ -24,6 +24,10 @@ struct MediaDetailScreen: View {
     @State private var adminPushIntent: AdminMenuPushIntent?
     #endif
     @AppStorage(SettingsKey.detailShowQualityBadges) private var showQualityBadges: Bool = SettingsKey.Default.detailShowQualityBadges
+    #if os(iOS)
+    @AppStorage(SettingsKey.detailShowTrailerButton) private var showTrailerButton: Bool = SettingsKey.Default.detailShowTrailerButton
+    @Environment(\.openURL) private var openURL
+    #endif
 
     init(itemId: String, itemType: BaseItemKind = .movie) {
         _viewModel = State(initialValue: MediaDetailViewModel(itemId: itemId, itemType: itemType))
@@ -400,6 +404,7 @@ struct MediaDetailScreen: View {
             .equatable()
             favoriteButton
             #if os(iOS)
+            trailerButton(for: item)
             downloadAffordance(for: item, resolvedNextEpisode: nextEp)
             #endif
             Spacer(minLength: 0)
@@ -431,6 +436,45 @@ struct MediaDetailScreen: View {
         #endif
         .accessibilityLabel(loc.localized(viewModel.isFavorite ? "detail.favorite.remove" : "detail.favorite.add"))
     }
+
+    // MARK: - Trailer (iOS)
+
+    #if os(iOS)
+    /// Opens the first remote trailer (YouTube/Vimeo URL provided by the
+    /// server's metadata) in the system browser. iOS-only: tvOS has no
+    /// browser to hand the URL to, so the affordance doesn't exist there.
+    /// Hidden when the item carries no trailer or the user disabled the
+    /// button in Settings → Interface → Detail page.
+    @ViewBuilder
+    private func trailerButton(for item: BaseItemDto) -> some View {
+        if showTrailerButton, let trailerURL = Self.firstTrailerURL(of: item) {
+            Button {
+                openURL(trailerURL)
+            } label: {
+                Image(systemName: "movieclapper")
+                    .font(.system(size: buttonFontSize, weight: .bold))
+                    .foregroundStyle(CinemaColor.onSurface)
+                    .padding(.vertical, buttonVerticalPadding)
+                    .padding(.horizontal, CinemaSpacing.spacing4)
+                    .background(.ultraThinMaterial)
+                    .clipShape(RoundedRectangle(cornerRadius: CinemaRadius.large))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(loc.localized("detail.trailer"))
+        }
+    }
+
+    /// First http(s) trailer URL of the item. Defensive on scheme — Jellyfin
+    /// metadata can carry plugin-specific URIs the system can't open.
+    private static func firstTrailerURL(of item: BaseItemDto) -> URL? {
+        for trailer in item.remoteTrailers ?? [] {
+            guard let raw = trailer.url, let url = URL(string: raw),
+                  url.scheme == "https" || url.scheme == "http" else { continue }
+            return url
+        }
+        return nil
+    }
+    #endif
 
     // MARK: - Download affordance (iOS)
 

--- a/Shared/Screens/MediaDetailScreen.swift
+++ b/Shared/Screens/MediaDetailScreen.swift
@@ -235,7 +235,16 @@ struct MediaDetailScreen: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .frame(maxWidth: .infinity)
+        #if os(tvOS)
         .frame(height: backdropHeight)
+        #else
+        // iPad hardening: clamp the backdrop to ~55% of the scroll viewport
+        // so action buttons / overview stay reachable in short Stage Manager
+        // or Split View windows. Full-screen sizes resolve to `backdropHeight`.
+        .containerRelativeFrame(.vertical) { length, _ in
+            min(backdropHeight, length * 0.55)
+        }
+        #endif
         .clipped()
     }
 

--- a/Shared/Screens/MovieLibraryScreen.swift
+++ b/Shared/Screens/MovieLibraryScreen.swift
@@ -13,6 +13,7 @@ struct MediaLibraryScreen: View {
     @Environment(\.horizontalSizeClass) private var sizeClass
     #endif
     @State private var viewModel: MediaLibraryViewModel
+    @State private var prefetcher = PosterPrefetcher()
     @State private var showSortFilter = false
     #if os(iOS)
     /// Lifted from `AdminItemMenu` so `navigationDestination(item:)` can
@@ -120,10 +121,35 @@ struct MediaLibraryScreen: View {
         #endif
         .task {
             await viewModel.loadInitial(using: appState, loc: loc)
+            prefetchBrowsePosters()
+        }
+        // Each filtered page that lands gets its posters warmed; the count is
+        // a cheap Equatable proxy for "a page was appended".
+        .onChange(of: viewModel.filteredLoader.items.count) {
+            prefetchPosters(for: viewModel.filteredLoader.items)
         }
         .onReceive(NotificationCenter.default.publisher(for: .cinemaxShouldRefreshCatalogue)) { _ in
-            Task { await viewModel.reload(using: appState, loc: loc) }
+            Task {
+                prefetcher.reset()
+                await viewModel.reload(using: appState, loc: loc)
+                prefetchBrowsePosters()
+            }
         }
+    }
+
+    // MARK: - Image prefetch
+
+    /// Warms every genre row's posters once the browse data is in. URLs match
+    /// `LibraryPosterCard`'s request exactly (primary, maxWidth 300, tag).
+    private func prefetchBrowsePosters() {
+        prefetchPosters(for: viewModel.itemsByGenre.values.flatMap { $0 })
+    }
+
+    private func prefetchPosters(for items: [BaseItemDto]) {
+        let builder = appState.imageBuilder
+        prefetcher.prefetch(items.map { item in
+            item.id.map { builder.imageURL(itemId: $0, imageType: .primary, maxWidth: 300, tag: item.primaryImageTagValue) }
+        })
     }
 
     // MARK: Main Content Switch
@@ -557,7 +583,33 @@ struct MediaLibraryScreen: View {
 
     // MARK: - Loading & Error
 
-    private var loadingView: some View { LoadingStateView() }
+    /// Layout-shaped placeholder for the initial load — mirrors the browse
+    /// view's hero + poster rows instead of a context-free spinner.
+    private var loadingView: some View {
+        MediaPageSkeleton(
+            heroHeight: skeletonHeroHeight,
+            rows: [.poster, .poster],
+            posterCardWidth: skeletonPosterWidth,
+            wideCardWidth: skeletonPosterWidth * 2,
+            horizontalPadding: browseGenresPadding
+        )
+    }
+
+    private var skeletonHeroHeight: CGFloat {
+        #if os(tvOS)
+        820
+        #else
+        AdaptiveLayout.heroHeight(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass))
+        #endif
+    }
+
+    private var skeletonPosterWidth: CGFloat {
+        #if os(tvOS)
+        200
+        #else
+        AdaptiveLayout.posterCardWidth(for: AdaptiveLayout.form(horizontalSizeClass: sizeClass))
+        #endif
+    }
 
     private func errorView(_ message: String) -> some View {
         ErrorStateView(message: message, retryTitle: loc.localized("action.retry")) {

--- a/Shared/Screens/PrivacySecurityScreen.swift
+++ b/Shared/Screens/PrivacySecurityScreen.swift
@@ -25,6 +25,8 @@ struct PrivacySecurityScreen: View {
     @Environment(\.dismiss) private var dismiss
 
     @AppStorage(SettingsKey.privacyMaxContentAge) private var maxContentAge: Int = SettingsKey.Default.privacyMaxContentAge
+    @AppStorage(SettingsKey.searchSaveHistory) private var saveSearchHistory: Bool = SettingsKey.Default.searchSaveHistory
+    @Environment(\.motionEffectsEnabled) private var motionEffects
 
     @State private var showClearContinueWatchingAlert = false
     @State private var showClearImageCacheAlert = false
@@ -35,6 +37,7 @@ struct PrivacySecurityScreen: View {
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: CinemaSpacing.spacing5) {
                     parentalControlsSection
+                    searchHistorySection
                     connectedDevicesLink
                     maintenanceSection
                 }
@@ -120,6 +123,49 @@ struct PrivacySecurityScreen: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+    }
+
+    // MARK: - Search history
+
+    /// Privacy toggle for recent-search capture on the Search screen. Turning
+    /// it OFF also wipes whatever was already stored — keeping stale queries
+    /// around after the user opted out would defeat the point of the toggle.
+    private var searchHistorySection: some View {
+        VStack(alignment: .leading, spacing: CinemaSpacing.spacing2) {
+            sectionHeader(loc.localized("privacy.search"))
+
+            HStack(spacing: CinemaSpacing.spacing3) {
+                rowIcon(systemName: "clock.arrow.circlepath", color: themeManager.accent)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(loc.localized("privacy.saveSearchHistory"))
+                        .font(CinemaFont.label(.large))
+                        .foregroundStyle(CinemaColor.onSurface)
+                    Text(loc.localized("privacy.saveSearchHistory.subtitle"))
+                        .font(CinemaFont.label(.medium))
+                        .foregroundStyle(CinemaColor.onSurfaceVariant)
+                        .multilineTextAlignment(.leading)
+                }
+
+                Spacer()
+
+                Button {
+                    saveSearchHistory.toggle()
+                    if !saveSearchHistory {
+                        UserDefaults.standard.removeObject(forKey: SettingsKey.searchRecentQueries)
+                    }
+                } label: {
+                    CinemaToggleIndicator(isOn: saveSearchHistory, accent: themeManager.accent, animated: motionEffects)
+                }
+                .buttonStyle(.plain)
+                #if os(iOS)
+                .sensoryFeedback(.selection, trigger: saveSearchHistory)
+                #endif
+            }
+            .padding(.horizontal, CinemaSpacing.spacing4)
+            .padding(.vertical, CinemaSpacing.spacing3)
+            .glassPanel(cornerRadius: CinemaRadius.extraLarge)
+        }
     }
 
     // MARK: - Connected Devices entry

--- a/Shared/Screens/SearchScreen.swift
+++ b/Shared/Screens/SearchScreen.swift
@@ -16,6 +16,7 @@ struct SearchScreen: View {
     @FocusState private var searchFieldFocused: Bool
     #endif
     @State private var viewModel = SearchViewModel()
+    @AppStorage(SettingsKey.searchSaveHistory) private var saveSearchHistory: Bool = SettingsKey.Default.searchSaveHistory
 
     // Surprise Me state — two buttons (movie + series) in the empty state.
     @State private var surpriseDestination: SurpriseDestination?
@@ -241,6 +242,11 @@ struct SearchScreen: View {
                     .font(CinemaFont.headline(.small))
                     .foregroundStyle(CinemaColor.onSurfaceVariant)
 
+                // Past queries as one-tap chips (gated on the Privacy toggle).
+                if saveSearchHistory, !viewModel.recentSearches.isEmpty {
+                    recentSearchesSection
+                }
+
                 // "Not sure what to watch?" → two pills for a random movie or series.
                 surpriseMePills
             }
@@ -255,6 +261,87 @@ struct SearchScreen: View {
                 headerTitle: loc.localized("search.topMatches")
             )
         }
+    }
+
+    // MARK: - Recent Searches
+
+    /// Wrapping chip cloud of past queries + a trailing "clear" chip. A chip
+    /// tap re-runs the query by writing `searchText` (the existing `.onChange`
+    /// debounce path picks it up — no separate search trigger needed).
+    private var recentSearchesSection: some View {
+        VStack(spacing: CinemaSpacing.spacing2) {
+            Text(loc.localized("search.recent"))
+                .font(CinemaFont.dynamicLabel(.medium))
+                .foregroundStyle(CinemaColor.onSurfaceVariant)
+
+            FlowLayout(spacing: CinemaSpacing.spacing2) {
+                ForEach(viewModel.recentSearches, id: \.self) { term in
+                    recentSearchChip(term)
+                }
+
+                Button {
+                    viewModel.clearRecentSearches()
+                } label: {
+                    HStack(spacing: CinemaSpacing.spacing1) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: CinemaScale.pt(11), weight: .semibold))
+                        Text(loc.localized("search.recent.clear"))
+                            .font(CinemaFont.label(.medium))
+                    }
+                    .foregroundStyle(CinemaColor.onSurfaceVariant)
+                    .padding(.horizontal, CinemaSpacing.spacing3)
+                    .padding(.vertical, CinemaSpacing.spacing2)
+                    .background(CinemaColor.surfaceContainer)
+                    .clipShape(Capsule())
+                }
+                #if os(tvOS)
+                .buttonStyle(TVFilterChipButtonStyle(accent: themeManager.accent))
+                .focusEffectDisabled()
+                .hoverEffectDisabled()
+                #else
+                .buttonStyle(.plain)
+                #endif
+                .accessibilityLabel(loc.localized("accessibility.clearRecentSearches"))
+            }
+            .frame(maxWidth: recentSearchesMaxWidth)
+        }
+        .padding(.horizontal, gridPadding)
+    }
+
+    private func recentSearchChip(_ term: String) -> some View {
+        Button {
+            viewModel.searchText = term
+        } label: {
+            HStack(spacing: CinemaSpacing.spacing1) {
+                Image(systemName: "clock.arrow.circlepath")
+                    .font(.system(size: CinemaScale.pt(12)))
+                    .foregroundStyle(CinemaColor.onSurfaceVariant)
+                Text(term)
+                    .font(CinemaFont.label(.medium))
+                    .foregroundStyle(CinemaColor.onSurface)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, CinemaSpacing.spacing3)
+            .padding(.vertical, CinemaSpacing.spacing2)
+            .background(CinemaColor.surfaceContainerHigh)
+            .clipShape(Capsule())
+        }
+        #if os(tvOS)
+        .buttonStyle(TVFilterChipButtonStyle(accent: themeManager.accent))
+        .focusEffectDisabled()
+        .hoverEffectDisabled()
+        #else
+        .buttonStyle(.plain)
+        #endif
+        .accessibilityLabel(String(format: loc.localized("accessibility.searchAgainFor"), term))
+    }
+
+    private var recentSearchesMaxWidth: CGFloat {
+        #if os(tvOS)
+        800
+        #else
+        420
+        #endif
     }
 
     // MARK: - Surprise Me

--- a/Shared/Screens/Settings/SettingsScreen.swift
+++ b/Shared/Screens/Settings/SettingsScreen.swift
@@ -185,6 +185,7 @@ struct SettingsScreen: View {
     @AppStorage(SettingsKey.homeShowGenreRows) var showGenreRows: Bool = SettingsKey.Default.homeShowGenreRows
     @AppStorage(SettingsKey.homeShowWatchingNow) var showWatchingNow: Bool = SettingsKey.Default.homeShowWatchingNow
     @AppStorage(SettingsKey.detailShowQualityBadges) var showQualityBadges: Bool = SettingsKey.Default.detailShowQualityBadges
+    @AppStorage(SettingsKey.detailShowTrailerButton) var showTrailerButton: Bool = SettingsKey.Default.detailShowTrailerButton
     @AppStorage(SettingsKey.libraryTVBrowseLayout) var libraryTVBrowseLayout: String = SettingsKey.Default.libraryTVBrowseLayout
     @AppStorage(SettingsKey.sleepTimerDefaultMinutes) var sleepTimerMinutes: Int = SettingsKey.Default.sleepTimerDefaultMinutes
     @AppStorage(SettingsKey.debugFastSleepTimer) var debugFastSleepTimer: Bool = SettingsKey.Default.debugFastSleepTimer
@@ -280,9 +281,15 @@ struct SettingsScreen: View {
     }
 
     var detailPageToggleRows: [SettingsToggleRow] {
-        [
+        var rows: [SettingsToggleRow] = [
             .init(id: "detailQualityBadges", icon: "info.square", label: loc.localized("settings.detailPage.qualityBadges"), value: $showQualityBadges)
         ]
+        // The trailer button opens the URL in Safari — tvOS has no browser,
+        // so neither the button nor its toggle exist there.
+        #if os(iOS)
+        rows.append(.init(id: "detailTrailerButton", icon: "movieclapper", label: loc.localized("settings.detailPage.trailerButton"), value: $showTrailerButton))
+        #endif
+        return rows
     }
 
     /// iOS marks debug icons orange to signal developer territory. tvOS

--- a/Shared/ViewModels/PosterPrefetcher.swift
+++ b/Shared/ViewModels/PosterPrefetcher.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Nuke
+
+/// Warms Nuke's cache for card images the user is about to scroll to, so
+/// posters render instantly instead of popping in (most visible on tvOS,
+/// where remote-driven scrolling outruns lazy loading).
+///
+/// IMPORTANT: prefetched URLs must be byte-identical to what the consuming
+/// card requests (same `maxWidth`, same `tag`) — Nuke keys its caches on the
+/// URL, so a near-miss warms nothing. Build them with the same
+/// `ImageURLBuilder` call the card uses.
+///
+/// `prefetched` dedupes across calls so re-renders / pagination don't requeue
+/// work Nuke has already been asked for; `ImagePrefetcher` itself runs at low
+/// priority and yields to on-screen requests.
+@MainActor
+final class PosterPrefetcher {
+    private let prefetcher = ImagePrefetcher(pipeline: ImagePipeline.shared)
+    private var prefetched: Set<URL> = []
+
+    /// Queues any not-yet-seen URLs for background prefetch. Nil entries are
+    /// dropped so call sites can pass optional-URL maps straight through.
+    func prefetch(_ urls: [URL?]) {
+        let fresh = urls.compactMap { $0 }.filter { !prefetched.contains($0) }
+        guard !fresh.isEmpty else { return }
+        prefetched.formUnion(fresh)
+        prefetcher.startPrefetching(with: fresh)
+    }
+
+    /// Drops the in-flight queue and the dedupe set — call when the data set
+    /// is replaced wholesale (catalogue refresh), so stale URLs don't keep
+    /// downloading and refreshed tags re-prefetch.
+    func reset() {
+        prefetcher.stopPrefetching()
+        prefetched.removeAll()
+    }
+}

--- a/Shared/ViewModels/SearchViewModel.swift
+++ b/Shared/ViewModels/SearchViewModel.swift
@@ -221,6 +221,18 @@ final class SearchViewModel {
     var isSearching = false
     var hasSearched = false
 
+    /// Most-recent-first queries shown as chips on the empty search screen.
+    /// Persisted as JSON under `SettingsKey.searchRecentQueries`; mutate only
+    /// through `recordRecentSearch` / `clearRecentSearches` (explicit-mutator
+    /// pattern — see the `@Observable`+`didSet` RULE). Loaded in `init` —
+    /// the `@Observable` macro rejects `Self.`-qualified calls in stored
+    /// property initializers ("covariant 'Self'" diagnostic).
+    private(set) var recentSearches: [String] = []
+
+    init() {
+        recentSearches = Self.loadRecentSearches()
+    }
+
     // Voice search state (iOS only)
     var isListening = false
     var showPermissionAlert = false
@@ -334,6 +346,53 @@ final class SearchViewModel {
             guard !Task.isCancelled else { return }
             self?.results = ranked
             self?.hasSearched = true
+            // Only remember queries that produced something — a typo midway
+            // through "missio" shouldn't pollute the history, and the debounce
+            // already collapses keystroke noise into the final query.
+            if !ranked.isEmpty {
+                self?.recordRecentSearch(query)
+            }
+        }
+    }
+
+    // MARK: Recent searches
+
+    private static let maxRecentSearches = 8
+
+    /// Whether history capture is enabled (Privacy & Security toggle).
+    /// Read straight from UserDefaults because `@AppStorage` can't live on an
+    /// `@Observable` class; `object(forKey:)` keeps the default-true semantics
+    /// (`bool(forKey:)` would default to false for fresh installs).
+    private static var isHistoryEnabled: Bool {
+        UserDefaults.standard.object(forKey: SettingsKey.searchSaveHistory) as? Bool
+            ?? SettingsKey.Default.searchSaveHistory
+    }
+
+    private static func loadRecentSearches() -> [String] {
+        guard let data = UserDefaults.standard.data(forKey: SettingsKey.searchRecentQueries),
+              let list = try? JSONDecoder().decode([String].self, from: data) else { return [] }
+        return list
+    }
+
+    private func recordRecentSearch(_ query: String) {
+        guard Self.isHistoryEnabled else { return }
+        var list = recentSearches.filter { $0.caseInsensitiveCompare(query) != .orderedSame }
+        list.insert(query, at: 0)
+        if list.count > Self.maxRecentSearches {
+            list = Array(list.prefix(Self.maxRecentSearches))
+        }
+        recentSearches = list
+        persistRecentSearches()
+    }
+
+    func clearRecentSearches() {
+        recentSearches = []
+        UserDefaults.standard.removeObject(forKey: SettingsKey.searchRecentQueries)
+    }
+
+    private func persistRecentSearches() {
+        if let data = try? JSONEncoder().encode(recentSearches) {
+            UserDefaults.standard.set(data, forKey: SettingsKey.searchRecentQueries)
         }
     }
 


### PR DESCRIPTION
## Summary

Six per-feature commits:

- **feat(search)** — recent-search history (8 max, deduped) shown as chips on the empty Search screen (iOS + tvOS), gated by a new "Save recent searches" toggle in Privacy & Security; turning it off wipes the stored history.
- **feat(detail)** — iOS trailer button (clapboard) on the detail action row, opens the first http(s) `remoteTrailers` URL in Safari; toggleable in Interface → Detail page. No tvOS counterpart (no browser).
- **feat(loading)** — skeleton shimmer placeholders (static when Motion Effects is off) replace the centered spinner on Home/Library initial loads; `PosterPrefetcher` (Nuke `ImagePrefetcher` + dedup) warms card images after each data load with byte-identical URLs (same maxWidth + tag).
- **feat(ipad)** — hero/backdrop heights clamped to ~55–62% of the scroll viewport via `containerRelativeFrame(.vertical)` so short Stage Manager / Split View windows keep content reachable; full-screen and tvOS unchanged.
- **fix(detail)** — resolution badge now classifies on width OR height (Jellyfin web client approach): 2.39:1 4K (3840×1600) was showing "1080p", scope 1080p (1920×800) was showing "720p".
- **docs(claude)** — new settings keys, prefetch URL-identity rule, iPad clamp pattern.

## Test plan

- [x] iOS + tvOS builds (`BUILD SUCCEEDED`)
- [x] FR/EN key parity + hardcoded-string sweep (localize-check)
- [x] Design-system grep sweep (no new violations)
- [ ] Manual: search chips tap/clear on both platforms, trailer button on an item with remote trailers, skeleton on cold launch, 4K badge on a scope movie, Stage Manager resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)