### PR TITLE
feat(detail): mark items watched / unwatched

### DIFF
--- a/Packages/CinemaxKit/Sources/CinemaxKit/Networking/APIClientProtocol.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Networking/APIClientProtocol.swift
@@ -111,6 +111,11 @@ public protocol LibraryAPI: Sendable {
     /// without leaking what was being watched.
     func markItemUnplayed(itemId: String, userId: String) async throws
 
+    /// Marks the item as fully played (watched). For a series or season the
+    /// server cascades the state to every child episode. Counterpart to
+    /// `markItemUnplayed`.
+    func markItemPlayed(itemId: String, userId: String) async throws
+
     /// Marks/unmarks the item as a user favorite (heart).
     func setFavorite(itemId: String, userId: String, favorite: Bool) async throws
 

--- a/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient+Library.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient+Library.swift
@@ -217,6 +217,19 @@ extension JellyfinAPIClient {
         cache.invalidate(prefix: "resume-")
     }
 
+    public func markItemPlayed(itemId: String, userId: String) async throws {
+        do {
+            guard let client = getClient() else { throw JellyfinError.notConnected }
+            _ = try await client.send(Paths.markPlayedItem(itemID: itemId, userID: userId))
+            // Marking watched pulls the item out of Continue Watching — drop the
+            // resume list so the row catches up. Other caches stay intact.
+            cache.invalidate(prefix: "resume-")
+        } catch {
+            notifyIfUnauthorized(error)
+            throw error
+        }
+    }
+
     public func setFavorite(itemId: String, userId: String, favorite: Bool) async throws {
         do {
             guard let client = getClient() else { throw JellyfinError.notConnected }

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -856,6 +856,8 @@
 "detail.favorite.add" = "Add to favorites";
 "detail.trailer" = "Trailer";
 "detail.favorite.remove" = "Remove from favorites";
+"detail.watched.add" = "Mark as watched";
+"detail.watched.remove" = "Mark as unwatched";
 "person.movies" = "Movies";
 "person.series" = "TV Shows";
 "person.born" = "Born %@";

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -857,6 +857,8 @@
 "detail.favorite.add" = "Ajouter aux favoris";
 "detail.trailer" = "Bande-annonce";
 "detail.favorite.remove" = "Retirer des favoris";
+"detail.watched.add" = "Marquer comme vu";
+"detail.watched.remove" = "Marquer comme non vu";
 "person.movies" = "Films";
 "person.series" = "Séries";
 "person.born" = "Né(e) le %@";

--- a/Shared/Screens/MediaDetailEpisodeCard.swift
+++ b/Shared/Screens/MediaDetailEpisodeCard.swift
@@ -17,6 +17,7 @@ struct MediaDetailEpisodeCard: View, Equatable {
     let epNavigator: EpisodeNavigator?
     let episodeTitleFontSize: CGFloat
     let onSelectOverview: (EpisodeOverviewItem) -> Void
+    let onToggleWatched: (BaseItemDto) -> Void
 
     @Environment(AppState.self) private var appState
     @Environment(ThemeManager.self) private var themeManager
@@ -100,6 +101,16 @@ struct MediaDetailEpisodeCard: View, Equatable {
                                 .foregroundStyle(CinemaColor.onSurfaceVariant)
                         }
                         Spacer(minLength: 0)
+                        Button {
+                            onToggleWatched(episode)
+                        } label: {
+                            Image(systemName: isPlayed ? "checkmark.circle.fill" : "checkmark.circle")
+                                .font(.system(size: CinemaScale.pt(18), weight: .semibold))
+                                .foregroundStyle(isPlayed ? themeManager.accent : CinemaColor.onSurfaceVariant)
+                        }
+                        .buttonStyle(.plain)
+                        .sensoryFeedback(.selection, trigger: isPlayed)
+                        .accessibilityLabel(loc.localized(isPlayed ? "detail.watched.remove" : "detail.watched.add"))
                         DownloadButton(item: episode)
                     }
                     Text(episode.name ?? "")

--- a/Shared/Screens/MediaDetailScreen.swift
+++ b/Shared/Screens/MediaDetailScreen.swift
@@ -412,6 +412,7 @@ struct MediaDetailScreen: View {
             )
             .equatable()
             favoriteButton
+            watchedButton
             #if os(iOS)
             trailerButton(for: item)
             downloadAffordance(for: item, resolvedNextEpisode: nextEp)
@@ -444,6 +445,31 @@ struct MediaDetailScreen: View {
         .sensoryFeedback(.selection, trigger: viewModel.isFavorite)
         #endif
         .accessibilityLabel(loc.localized(viewModel.isFavorite ? "detail.favorite.remove" : "detail.favorite.add"))
+    }
+
+    /// Watched toggle next to the heart. Marks the movie / whole series played;
+    /// optimistic flip on the view model, accent fill when watched.
+    private var watchedButton: some View {
+        Button {
+            Task { await viewModel.togglePlayed(using: appState) }
+        } label: {
+            Image(systemName: viewModel.isPlayed ? "checkmark.circle.fill" : "checkmark.circle")
+                .font(.system(size: buttonFontSize, weight: .bold))
+                .foregroundStyle(viewModel.isPlayed ? themeManager.accent : CinemaColor.onSurface)
+                .padding(.vertical, buttonVerticalPadding)
+                .padding(.horizontal, CinemaSpacing.spacing4)
+                #if os(iOS)
+                .background(.ultraThinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: CinemaRadius.large))
+                #endif
+        }
+        #if os(tvOS)
+        .buttonStyle(CinemaTVButtonStyle(cinemaStyle: .ghost))
+        #else
+        .buttonStyle(.plain)
+        .sensoryFeedback(.selection, trigger: viewModel.isPlayed)
+        #endif
+        .accessibilityLabel(loc.localized(viewModel.isPlayed ? "detail.watched.remove" : "detail.watched.add"))
     }
 
     // MARK: - Trailer (iOS)
@@ -656,7 +682,10 @@ struct MediaDetailScreen: View {
                             epNext: nav.next,
                             epNavigator: nav.navigator,
                             episodeTitleFontSize: episodeTitleFontSize,
-                            onSelectOverview: { episodeOverview = $0 }
+                            onSelectOverview: { episodeOverview = $0 },
+                            onToggleWatched: { ep in
+                                Task { await viewModel.toggleEpisodeWatched(ep, using: appState) }
+                            }
                         )
                         .equatable()
                         .containerRelativeFrame(.horizontal) { w, _ in w - contentPadding * 2 - 32 }

--- a/Shared/ViewModels/MediaDetailViewModel.swift
+++ b/Shared/ViewModels/MediaDetailViewModel.swift
@@ -33,6 +33,11 @@ final class MediaDetailViewModel {
     /// flipped optimistically by `toggleFavorite`.
     var isFavorite = false
 
+    /// User watched state (checkmark). Mirrors `item.userData.isPlayed`,
+    /// flipped optimistically by `togglePlayed`. For a series this is true
+    /// only when every episode has been played.
+    var isPlayed = false
+
     /// BoxSet collection containing this movie ("Part of: …") and its other
     /// members. Empty when the item belongs to no collection (or the server
     /// can't resolve one — see `LibraryAPI.getCollections`).
@@ -83,6 +88,7 @@ final class MediaDetailViewModel {
         }
 
         isFavorite = item?.userData?.isFavorite ?? false
+        isPlayed = item?.userData?.isPlayed ?? false
         // Collections are a movie-only garnish — resolved after the main load
         // so a slow boxset lookup never delays the detail render.
         if resolvedType == .movie, item != nil {
@@ -106,6 +112,80 @@ final class MediaDetailViewModel {
         } catch {
             logger.error("Favorite toggle failed: \(error.localizedDescription, privacy: .public)")
             isFavorite = !target
+        }
+    }
+
+    /// Optimistic watched toggle for the resolved item (a movie, or a whole
+    /// series). Marking a series played cascades to its episodes server-side,
+    /// so the visible season is re-fetched to catch up the per-episode marks.
+    func togglePlayed(using appState: AppState) async {
+        guard let userId = appState.currentUserId, let id = item?.id else { return }
+        let target = !isPlayed
+        isPlayed = target
+        do {
+            if target {
+                try await appState.apiClient.markItemPlayed(itemId: id, userId: userId)
+            } else {
+                try await appState.apiClient.markItemUnplayed(itemId: id, userId: userId)
+            }
+            NotificationCenter.default.post(name: .cinemaxShouldRefreshCatalogue, object: nil)
+            if resolvedType == .series {
+                await refreshVisibleEpisodes(seriesId: id, using: appState)
+            }
+        } catch {
+            logger.error("Played toggle failed: \(error.localizedDescription, privacy: .public)")
+            isPlayed = !target
+        }
+    }
+
+    /// Optimistic per-episode watched toggle. Flips the local episode payload
+    /// so the `Equatable` episode card re-renders immediately; reverts on a
+    /// server failure.
+    func toggleEpisodeWatched(_ episode: BaseItemDto, using appState: AppState) async {
+        guard let userId = appState.currentUserId, let id = episode.id else { return }
+        let target = !(episode.userData?.isPlayed ?? false)
+        setEpisodePlayed(id: id, played: target)
+        do {
+            if target {
+                try await appState.apiClient.markItemPlayed(itemId: id, userId: userId)
+            } else {
+                try await appState.apiClient.markItemUnplayed(itemId: id, userId: userId)
+            }
+            NotificationCenter.default.post(name: .cinemaxShouldRefreshCatalogue, object: nil)
+        } catch {
+            logger.error("Episode watched toggle failed: \(error.localizedDescription, privacy: .public)")
+            setEpisodePlayed(id: id, played: !target)
+        }
+    }
+
+    /// Reflects a played-state change in the local episode arrays so the
+    /// `Equatable` episode cards re-render. Marking played also clears the
+    /// resume position so the in-progress bar disappears. Only mutates the
+    /// existing `userData` (episodes always carry it — fetched with
+    /// `enableUserData: true`).
+    private func setEpisodePlayed(id: String, played: Bool) {
+        func apply(to ep: inout BaseItemDto) {
+            guard var userData = ep.userData else { return }
+            userData.isPlayed = played
+            if played { userData.playbackPositionTicks = 0 }
+            ep.userData = userData
+        }
+        if let idx = episodes.firstIndex(where: { $0.id == id }) { apply(to: &episodes[idx]) }
+        if let idx = nextUpEpisodes.firstIndex(where: { $0.id == id }) { apply(to: &nextUpEpisodes[idx]) }
+        if nextUpEpisode?.id == id, var ep = nextUpEpisode {
+            apply(to: &ep)
+            nextUpEpisode = ep
+        }
+    }
+
+    /// Re-fetches the currently selected season's episodes after a series-level
+    /// played toggle cascades server-side. Silent on failure — the optimistic
+    /// `isPlayed` flip already gave the user feedback.
+    private func refreshVisibleEpisodes(seriesId: String, using appState: AppState) async {
+        guard let userId = appState.currentUserId, let seasonId = selectedSeasonId else { return }
+        if let refreshed = try? await appState.apiClient.getEpisodes(seriesId: seriesId, seasonId: seasonId, userId: userId) {
+            episodes = refreshed
+            rebuildNavigationMaps(apiClient: appState.apiClient, userId: userId)
         }
     }
 

--- a/Tests/CinemaxKitTests/MediaDetailViewModelTests.swift
+++ b/Tests/CinemaxKitTests/MediaDetailViewModelTests.swift
@@ -14,6 +14,26 @@ private func makeEpisode(id: String, name: String) -> BaseItemDto {
     return ep
 }
 
+/// Episode carrying a `userData` payload so played-state mutations have
+/// something to flip (episodes are fetched with `enableUserData: true`).
+private func makeWatchableEpisode(id: String, name: String, played: Bool) -> BaseItemDto {
+    var ep = makeEpisode(id: id, name: name)
+    var userData = UserItemDataDto()
+    userData.isPlayed = played
+    ep.userData = userData
+    return ep
+}
+
+private func makeMovie(id: String, played: Bool) -> BaseItemDto {
+    var item = BaseItemDto()
+    item.id = id
+    item.type = .movie
+    var userData = UserItemDataDto()
+    userData.isPlayed = played
+    item.userData = userData
+    return item
+}
+
 @MainActor
 @Suite("MediaDetailViewModel")
 struct MediaDetailViewModelTests {
@@ -71,6 +91,38 @@ struct MediaDetailViewModelTests {
 
         #expect(vm.selectedSeasonId == "season-A")
         #expect(vm.episodes.map(\.id) == ["ep-1"])
+    }
+
+    @Test("togglePlayed flips state and marks the movie played, then unplayed")
+    func togglePlayedRoundTrip() async {
+        let api = MockAPIClient()
+        let appState = makeAppState(api: api)
+        let vm = MediaDetailViewModel(itemId: "movie-1", itemType: .movie)
+        vm.item = makeMovie(id: "movie-1", played: false)
+        vm.isPlayed = false
+
+        await vm.togglePlayed(using: appState)
+        #expect(vm.isPlayed == true)
+        #expect(api.markPlayedCalls == ["movie-1"])
+
+        await vm.togglePlayed(using: appState)
+        #expect(vm.isPlayed == false)
+        #expect(api.markUnplayedCalls == ["movie-1"])
+    }
+
+    @Test("toggleEpisodeWatched flips the local episode payload and clears resume")
+    func toggleEpisodeWatchedUpdatesLocalState() async {
+        let api = MockAPIClient()
+        let appState = makeAppState(api: api)
+        let vm = MediaDetailViewModel(itemId: "series-1", itemType: .series)
+        var episode = makeWatchableEpisode(id: "ep-1", name: "Pilot", played: false)
+        episode.userData?.playbackPositionTicks = 500
+        vm.episodes = [episode]
+
+        await vm.toggleEpisodeWatched(episode, using: appState)
+        #expect(vm.episodes.first?.userData?.isPlayed == true)
+        #expect(vm.episodes.first?.userData?.playbackPositionTicks == 0)
+        #expect(api.markPlayedCalls == ["ep-1"])
     }
 
     @Test("selectSeason without userId short-circuits")

--- a/Tests/CinemaxKitTests/MockAPIClient.swift
+++ b/Tests/CinemaxKitTests/MockAPIClient.swift
@@ -298,7 +298,10 @@ final class MockAPIClient: APIClientProtocol, @unchecked Sendable {
         return []
     }
     func getNextUp(seriesId: String, userId: String) async throws -> BaseItemDto? { nil }
-    func markItemUnplayed(itemId: String, userId: String) async throws {}
+    private(set) var markPlayedCalls: [String] = []
+    private(set) var markUnplayedCalls: [String] = []
+    func markItemUnplayed(itemId: String, userId: String) async throws { markUnplayedCalls.append(itemId) }
+    func markItemPlayed(itemId: String, userId: String) async throws { markPlayedCalls.append(itemId) }
     func setFavorite(itemId: String, userId: String, favorite: Bool) async throws {}
     func getPersonItems(personId: String, userId: String, limit: Int) async throws -> [BaseItemDto] { [] }
     func getCollections(containingItemId: String, tmdbCollectionId: String?, userId: String) async throws -> [BaseItemDto] { [] }


### PR DESCRIPTION
Adds the most-expected Jellyfin gesture that was missing: an explicit
"watched" toggle alongside the favorite heart.

- API: new `LibraryAPI.markItemPlayed` (counterpart to `markItemUnplayed`,
  posts /UserPlayedItems; cascades to episodes for series/seasons server-side;
  invalidates the resume cache so Continue Watching catches up).
- MediaDetailViewModel: `isPlayed` mirror + optimistic `togglePlayed`
  (movie / whole series) and per-episode `toggleEpisodeWatched`, reverting on
  failure. Series toggle re-fetches the visible season; marking watched clears
  the episode's resume position.
- UI: checkmark `watchedButton` in the play-action row (iOS + tvOS, mirrors
  favoriteButton) and an inline per-episode toggle in the iOS episode card.
- Posts .cinemaxShouldRefreshCatalogue so Home/Library refresh.
- FR/EN strings + view-model tests + mock call spies.

https://claude.ai/code/session_01XTEt8udteKjVyLYSUakMCB