### PR TITLE
fix(player): transcode AVI/XviD instead of streaming it raw (fixes freeze + stale progress)

### DIFF
--- a/Cinemax.xcodeproj/project.pbxproj
+++ b/Cinemax.xcodeproj/project.pbxproj
@@ -1790,6 +1790,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				OTHER_LDFLAGS = "-e _NSExtensionMain";
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cinemax.tvos.topshelf;
 				PRODUCT_NAME = CinemaxTopShelf;
 				SDKROOT = appletvos;
@@ -1803,13 +1804,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Widgets/CinemaxWidget.entitlements;
-				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = Widgets/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cinemax.ios.widget;
 				PRODUCT_NAME = CinemaxWidget;
 				SDKROOT = iphoneos;
@@ -1825,12 +1826,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = iOS/Cinemax.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cinemax.ios;
 				PRODUCT_NAME = Cinemax;
 				SDKROOT = iphoneos;
@@ -1879,13 +1880,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Widgets/CinemaxWidget.entitlements;
-				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = Widgets/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cinemax.ios.widget;
 				PRODUCT_NAME = CinemaxWidget;
 				SDKROOT = iphoneos;
@@ -1907,6 +1908,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cinemax.tvos;
 				PRODUCT_NAME = CinemaxTV;
 				SDKROOT = appletvos;
@@ -1927,6 +1929,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				OTHER_LDFLAGS = "-e _NSExtensionMain";
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cinemax.tvos.topshelf;
 				PRODUCT_NAME = CinemaxTopShelf;
 				SDKROOT = appletvos;
@@ -1942,12 +1945,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = iOS/Cinemax.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cinemax.ios;
 				PRODUCT_NAME = Cinemax;
 				SDKROOT = iphoneos;
@@ -2029,6 +2032,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cinemax.tvos;
 				PRODUCT_NAME = CinemaxTV;
 				SDKROOT = appletvos;

--- a/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient+Playback.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient+Playback.swift
@@ -18,7 +18,7 @@ extension JellyfinAPIClient {
         }
     }
 
-    private func _getPlaybackInfo(itemId: String, userId: String, maxBitrate: Int, audioStreamIndex: Int?, subtitleStreamIndex: Int?, engine: VideoPlaybackEngine) async throws -> PlaybackInfo {
+    private func _getPlaybackInfo(itemId: String, userId: String, maxBitrate: Int, audioStreamIndex: Int?, subtitleStreamIndex: Int?, engine: VideoPlaybackEngine, forceTranscode: Bool = false) async throws -> PlaybackInfo {
         guard let client = getClient(),
               let serverURL = getServerURL() else {
             throw JellyfinError.notConnected
@@ -56,7 +56,8 @@ extension JellyfinAPIClient {
 
         // Step 2: POST PlaybackInfo (matching Swiftfin exactly)
         let deviceProfile: DeviceProfile = (engine == .vlc)
-            ? Self.buildVLCDeviceProfile(maxBitrate: maxBitrate)
+            ? (forceTranscode ? Self.buildVLCTranscodeProfile(maxBitrate: maxBitrate)
+                              : Self.buildVLCDeviceProfile(maxBitrate: maxBitrate))
             : Self.buildAppleDeviceProfile(maxBitrate: maxBitrate)
         var body = PlaybackInfoDto(deviceProfile: deviceProfile)
         body.isAutoOpenLiveStream = true
@@ -126,6 +127,33 @@ extension JellyfinAPIClient {
         debugLog("  directPlay=\(mediaSource.isSupportsDirectPlay ?? false), directStream=\(mediaSource.isSupportsDirectStream ?? false)")
         debugLog("  transcodingURL=\(redactedURL(mediaSource.transcodingURL))")
         #endif
+
+        // Seek-heavy containers (AVI/XviD &c.) keep their index at EOF, so libVLC
+        // seeks constantly over HTTP — un-streamable raw from a reverse-proxied
+        // origin: direct trips the proxy (HTTP/2 range storm) and our loopback
+        // proxy can't serve the random-access pattern (the index seek wedges the
+        // one-shot connection → freeze). So re-resolve once with an empty-DirectPlay
+        // profile, forcing the server to hand us a linear HLS transcode instead.
+        // (A true remux/copy would be lighter, but this server transcodes XviD
+        // regardless: it reports SupportsDirectStream=false / ContainerNotSupported
+        // for mpeg4.) Falls through to the raw path only if the server can't
+        // transcode at all.
+        if engine == .vlc, !forceTranscode,
+           Self.isSeekHeavyContainer(mediaSource.container) {
+            #if DEBUG
+            debugLog("  seek-heavy container '\(mediaSource.container ?? "?")' → forcing HLS transcode")
+            #endif
+            if let transcoded = try? await _getPlaybackInfo(
+                itemId: effectiveItemId, userId: userId, maxBitrate: maxBitrate,
+                audioStreamIndex: audioStreamIndex, subtitleStreamIndex: subtitleStreamIndex,
+                engine: engine, forceTranscode: true
+            ), transcoded.playMethod == .transcode {
+                return transcoded
+            }
+            #if DEBUG
+            debugLog("  forced transcode unavailable — falling back to raw stream")
+            #endif
+        }
 
         // Step 4: Build stream URL (same logic as Swiftfin's streamURL)
 
@@ -584,7 +612,13 @@ extension JellyfinAPIClient {
     // remux) we keep an HLS path so playback isn't impossible.
     nonisolated(unsafe) fileprivate static let _vlcTranscodingProfiles: [TranscodingProfile] = [
         TranscodingProfile(
-            audioCodec: "aac,ac3,alac,dts,eac3,flac,mp1,mp2,mp3,opus,vorbis",
+            // NO mp1/mp2/mp3 here on purpose. When the video is transcoded but a
+            // source MPEG-audio track is COPIED into fMP4 HLS segments, MP3's
+            // encoder delay/priming isn't re-timed against the new video → a
+            // constant audio offset (the "son décalé" on transcoded AVI/XviD).
+            // Leaving these out forces the server to re-encode audio to AAC, which
+            // muxes cleanly into fMP4 and stays locked to the transcoded video.
+            audioCodec: "aac,ac3,alac,dts,eac3,flac,opus,vorbis",
             isBreakOnNonKeyFrames: true,
             container: "mp4",
             context: .streaming,
@@ -618,5 +652,30 @@ extension JellyfinAPIClient {
             subtitleProfiles: _vlcSubtitleProfiles,
             transcodingProfiles: _vlcTranscodingProfiles
         )
+    }
+
+    /// Transcode-forcing VLC profile: empty `directPlayProfiles` means nothing
+    /// matches for DirectPlay/DirectStream, so the server hands back a linear HLS
+    /// transcode. Used only for seek-heavy containers (`isSeekHeavyContainer`)
+    /// that can't be streamed raw over HTTP from a reverse-proxied origin.
+    fileprivate static func buildVLCTranscodeProfile(maxBitrate: Int = 40_000_000) -> DeviceProfile {
+        DeviceProfile(
+            directPlayProfiles: [],
+            maxStreamingBitrate: maxBitrate,
+            subtitleProfiles: _vlcSubtitleProfiles,
+            transcodingProfiles: _vlcTranscodingProfiles
+        )
+    }
+
+    /// Containers whose index lives at EOF, so libVLC seeks constantly over HTTP
+    /// (the AVI/XviD range storm). These must be transcoded server-side, not
+    /// streamed raw. Matched against the (possibly comma/space-joined) container.
+    private static let seekHeavyContainers: Set<String> = [
+        "avi", "divx", "wmv", "asf", "flv", "vob", "mpg", "mpeg", "mpe", "m2v"
+    ]
+    static func isSeekHeavyContainer(_ container: String?) -> Bool {
+        guard let raw = container?.lowercased() else { return false }
+        return raw.split(whereSeparator: { $0 == "," || $0 == " " })
+            .contains { seekHeavyContainers.contains(String($0)) }
     }
 }


### PR DESCRIPTION
## Problem

Streaming an **AVI/XviD** episode on tvOS froze every few seconds with the progress bar stuck at 0:00 (reproduced on a physical Apple TV against a reverse-proxied Jellyfin server). A 4K HEVC **MKV** on the same server played flawlessly.

**Root cause:** AVI keeps its index (`idx1`) at EOF, so libVLC seek-storms it over HTTP. Neither raw path works on a reverse-proxied origin:
- **Direct** → the HTTP/2 range-request storm trips the reverse proxy (`peer stream error: Protocol error`) → freeze (the issue commit `27fb19b` originally routed around).
- **Loopback proxy** (`CinemaxStreamProxy`) → a one-shot proxy connection can't serve libVLC's random-access pattern; the index seek wedges it (`send wedged`, `cannot seek`, `ES_OUT_SET_PCR called 11000+ ms late`).

MKV reads near-linearly (index up front), which is why it's unaffected.

## Fix

In `JellyfinAPIClient._getPlaybackInfo`: when a **seek-heavy container** (`avi/divx/wmv/asf/flv/vob/mpg/mpeg/mpe/m2v`) resolves for the VLC engine, **re-resolve once with an empty-DirectPlay profile**, forcing the server to return a **linear HLS transcode** — no seek storm, hardware-decoded, no proxy. Falls through to the raw path only if the server can't transcode at all.

Also dropped `mp1/mp2/mp3` from the VLC transcoding profile's audio codecs so audio **re-encodes to AAC**: copying the source MP3 into fMP4 HLS segments caused a constant audio offset ("son décalé"); AAC muxes cleanly and stays locked to the re-encoded video.

- **MKV / MP4 / etc. are untouched** — still DirectPlay (4K/HEVC/DV preserved). The re-resolve fires only for seek-heavy containers.
- True remux (video *copy*) isn't possible for XviD on this server (`SupportsDirectStream=false` / `ContainerNotSupported` — MPEG-4 Part 2 isn't HLS/MP4-streamable there), so transcode is the only working path. A DirectStream-remux attempt was explored and removed as dead code.

## Trade-off

A transcoded AVI starts a few seconds slower than a DirectPlayed MKV (server ffmpeg spin-up + first HLS segments) — inherent to transcoding, not a regression. Quality impact on a 360p XviD is nil.

## Verification

Built and deployed to a physical Apple TV (`CinemaxTV`, device build). Result: **no freeze, video + audio + correct A/V sync, live progress bar.** MKV DirectPlay unaffected.

## Notes

- Independent of #37/#38; branches off `main`.
- Second commit restores `DEVELOPMENT_TEAM` for the tvOS targets (it was committed only for the iOS targets, so device builds of `CinemaxTV`/`CinemaxTopShelf` failed signing). Kept separate so the fix commit is clean.
- No proxy changes — earlier proxy-tuning attempts were reverted; the proxy is back to its `main` state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)