### PR TITLE
refactor(player): extract testable SeekCoalescer from VLCStreamViewController

### DIFF
--- a/Cinemax.xcodeproj/project.pbxproj
+++ b/Cinemax.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		70AA7510474C61BC215F7181 /* MediaQualityBadges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D53C46CC9C173E104ABA41C /* MediaQualityBadges.swift */; };
 		7155A56A5485AAF1DC82145D /* SkipSegmentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D0C0F047D7CB697E80F4CA5 /* SkipSegmentController.swift */; };
 		7165F9BAF328AF12A60701DE /* MetadataEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F3F5E9E871E48C07DB53691 /* MetadataEditorViewModel.swift */; };
+		71B23336490FEFD9143B5D99 /* SeekCoalescerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E3E989946C44C0AAA0640F /* SeekCoalescerTests.swift */; };
 		72281CF32299F9545AA48ED7 /* SearchScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C144D0A57021E0A0A783977B /* SearchScreen.swift */; };
 		735403600F051C38E050FBDE /* VideoPlayerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14D3FE509DDFB9EA6569161 /* VideoPlayerCoordinator.swift */; };
 		73713753B981A3971272B7E3 /* FocusScaleModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D657D13170DAA4F01D4B99E8 /* FocusScaleModifier.swift */; };
@@ -284,6 +285,7 @@
 		C90F8CB508076E72254A82AA /* DownloadItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611F5F5E09D2E5E70B4D921D /* DownloadItemTests.swift */; };
 		CB8A5B33DC46E1D442D55956 /* PrivacySecurityConnectedDevicesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3A6F8801C8046B8B055A99 /* PrivacySecurityConnectedDevicesList.swift */; };
 		CBAEF4A3CF55793AB18B8A0D /* UserAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFCCAA7179A62CDE9CECD2E /* UserAvatar.swift */; };
+		CCA01F1FD9DF944BFDEBD578 /* SeekCoalescer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC9FEFF022E1379C8523576 /* SeekCoalescer.swift */; };
 		CCD551977D38C74BA8A43DDF /* SettingsTVActionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96FE07986012B06BD4B2E9DD /* SettingsTVActionRow.swift */; };
 		CD087ACC17110EF35BCAE4A8 /* IdentifyResultsGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74AE99230CEB07F7CC4FCCFA /* IdentifyResultsGridView.swift */; };
 		CD8E6C6DE6EC7575C36BE5DB /* CinemaxStreamProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B604F5FE24467521C25021 /* CinemaxStreamProxy.swift */; };
@@ -342,6 +344,7 @@
 		F7B273773AA4C5CAA1D8BD3F /* UserSwitchSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF66FBCB52822C36CFD91DA /* UserSwitchSheet.swift */; };
 		F7DB378B44C1CB5274C228BA /* ChipEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94FA6A5683705668178431E2 /* ChipEditor.swift */; };
 		F9659FCF10476792907A642D /* AdminFormScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B63AFBF054B1A7A1253C755 /* AdminFormScreen.swift */; };
+		F9A891C275B494CA3A05BF0C /* SeekCoalescer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC9FEFF022E1379C8523576 /* SeekCoalescer.swift */; };
 		F9C5CED88AB7F8798BA4A5E2 /* CinemaxStreamProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B604F5FE24467521C25021 /* CinemaxStreamProxy.swift */; };
 		FA0D8EAA93AE77CCF5E5D66B /* MediaDetailEpisodeOverviewSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520518BCFA8AF149838E5906 /* MediaDetailEpisodeOverviewSheet.swift */; };
 		FA853F39728C4E3652D2C5E5 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C346F0B7AFF504DA6593370E /* HomeViewModel.swift */; };
@@ -418,6 +421,7 @@
 		0B79F879DA7A6AF02AB6D780 /* IdentifyFlowModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifyFlowModel.swift; sourceTree = "<group>"; };
 		0BB0CBCFC322E533A14A4EBB /* SleepTimerOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepTimerOption.swift; sourceTree = "<group>"; };
 		0C318571F3DB0BCA88B80EE5 /* DownloadsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsScreen.swift; sourceTree = "<group>"; };
+		0CC9FEFF022E1379C8523576 /* SeekCoalescer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeekCoalescer.swift; sourceTree = "<group>"; };
 		0E5C1E6AA06EF0B35E4B4CD2 /* ToastOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastOverlay.swift; sourceTree = "<group>"; };
 		0E8781EB49CEE6EFE3A6560A /* ContentRatingClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentRatingClassifierTests.swift; sourceTree = "<group>"; };
 		0EB9A108C0F29A3010E8E65A /* AdminUserDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminUserDetailScreen.swift; sourceTree = "<group>"; };
@@ -469,6 +473,7 @@
 		53363AB0D63349A37334B381 /* QuickConnectAuthorizeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickConnectAuthorizeViewModelTests.swift; sourceTree = "<group>"; };
 		5364D454BCC297C0F2D9A3DB /* CinemaxWidget.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = CinemaxWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		5392E5D6360E4430456477E9 /* ServerDiscoverySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerDiscoverySheet.swift; sourceTree = "<group>"; };
+		53E3E989946C44C0AAA0640F /* SeekCoalescerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeekCoalescerTests.swift; sourceTree = "<group>"; };
 		54C56CCEB123ABB29AC4D2A8 /* AdminPlaybackScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminPlaybackScreen.swift; sourceTree = "<group>"; };
 		55122A5776984A5A63808F80 /* AdminNetworkScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminNetworkScreen.swift; sourceTree = "<group>"; };
 		554633B7F0AE3A72EE4B56BB /* MediaDetailButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDetailButtonStyles.swift; sourceTree = "<group>"; };
@@ -852,6 +857,7 @@
 				53363AB0D63349A37334B381 /* QuickConnectAuthorizeViewModelTests.swift */,
 				4E7EF991448FA04C0201CBBD /* SearchRelevanceTests.swift */,
 				7F79C18163C57966CF114BD2 /* SearchViewModelTests.swift */,
+				53E3E989946C44C0AAA0640F /* SeekCoalescerTests.swift */,
 				B01CD5F39E429B665FA12B0C /* ServerSetupViewModelTests.swift */,
 				07BE0FC86294412983D44667 /* SessionResilienceTests.swift */,
 				3C5B18A062473FEFA3852339 /* StreamProxyTests.swift */,
@@ -1016,6 +1022,7 @@
 				BEE8ECEE461A97A3A4667563 /* PlayerTimeFormat.swift */,
 				A3BDB7771E48A8279519D115 /* PlayerTransportViews.swift */,
 				2704DEBD38156198513A11C4 /* RemoteCommandController.swift */,
+				0CC9FEFF022E1379C8523576 /* SeekCoalescer.swift */,
 				4D0C0F047D7CB697E80F4CA5 /* SkipSegmentController.swift */,
 				74EFA596296688A96C374135 /* SleepTimerController.swift */,
 				AFAC463F8054600F3BCEB911 /* TrickplayController.swift */,
@@ -1338,6 +1345,7 @@
 				0ED6BB9632625BE9F922F728 /* QuickConnectAuthorizeViewModelTests.swift in Sources */,
 				AB379BDB42B5C1F4D687B681 /* SearchRelevanceTests.swift in Sources */,
 				330E22BA7BBD29DD3BE0D93A /* SearchViewModelTests.swift in Sources */,
+				71B23336490FEFD9143B5D99 /* SeekCoalescerTests.swift in Sources */,
 				A19C134787C25532BB34B306 /* ServerSetupViewModelTests.swift in Sources */,
 				B5D1EB16B91B2F81BE6405B0 /* SessionResilienceTests.swift in Sources */,
 				EBCB3B503EE80BA039D62EB4 /* StreamProxyTests.swift in Sources */,
@@ -1475,6 +1483,7 @@
 				15B101DB7D9B770EAD24E7CA /* RemoteCommandController.swift in Sources */,
 				72281CF32299F9545AA48ED7 /* SearchScreen.swift in Sources */,
 				B80500609E8D56844738FB4A /* SearchViewModel.swift in Sources */,
+				CCA01F1FD9DF944BFDEBD578 /* SeekCoalescer.swift in Sources */,
 				95D94E036EDA6AE3326386D4 /* ServerDiscoverySheet.swift in Sources */,
 				4B66D96B583EDB78690FD695 /* ServerHelpSheet.swift in Sources */,
 				97AF9B841BA015AD94A9B390 /* ServerSetupScreen.swift in Sources */,
@@ -1647,6 +1656,7 @@
 				B54B725BA68563ACADEC4B8C /* RemoteCommandController.swift in Sources */,
 				A38CC2D23545EA9986CB053F /* SearchScreen.swift in Sources */,
 				1695AF73A0D756A11490FF4B /* SearchViewModel.swift in Sources */,
+				F9A891C275B494CA3A05BF0C /* SeekCoalescer.swift in Sources */,
 				60C9BC65C7DCC678C8D21DA4 /* ServerDiscoverySheet.swift in Sources */,
 				4979E3EF3554A8E4DF2E07EF /* ServerHelpSheet.swift in Sources */,
 				91ED326A57E034CF33FCA565 /* ServerSetupScreen.swift in Sources */,
@@ -1790,6 +1800,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				OTHER_LDFLAGS = "-e _NSExtensionMain";
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cinemax.tvos.topshelf;
 				PRODUCT_NAME = CinemaxTopShelf;
 				SDKROOT = appletvos;
@@ -1803,13 +1814,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Widgets/CinemaxWidget.entitlements;
-				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = Widgets/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cinemax.ios.widget;
 				PRODUCT_NAME = CinemaxWidget;
 				SDKROOT = iphoneos;
@@ -1825,12 +1836,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = iOS/Cinemax.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cinemax.ios;
 				PRODUCT_NAME = Cinemax;
 				SDKROOT = iphoneos;
@@ -1879,13 +1890,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Widgets/CinemaxWidget.entitlements;
-				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = Widgets/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cinemax.ios.widget;
 				PRODUCT_NAME = CinemaxWidget;
 				SDKROOT = iphoneos;
@@ -1907,6 +1918,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cinemax.tvos;
 				PRODUCT_NAME = CinemaxTV;
 				SDKROOT = appletvos;
@@ -1927,6 +1939,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				OTHER_LDFLAGS = "-e _NSExtensionMain";
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cinemax.tvos.topshelf;
 				PRODUCT_NAME = CinemaxTopShelf;
 				SDKROOT = appletvos;
@@ -1942,12 +1955,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = iOS/Cinemax.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 4T334S4NP6;
 				INFOPLIST_FILE = iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cinemax.ios;
 				PRODUCT_NAME = Cinemax;
 				SDKROOT = iphoneos;
@@ -2029,6 +2042,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				DEVELOPMENT_TEAM = 4T334S4NP6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cinemax.tvos;
 				PRODUCT_NAME = CinemaxTV;
 				SDKROOT = appletvos;

--- a/Shared/Screens/VideoPlayer/SeekCoalescer.swift
+++ b/Shared/Screens/VideoPlayer/SeekCoalescer.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Pure seek-target math for the VLC player's *coalesced* ±N skip / chapter-jump
+/// logic, extracted from `VLCStreamViewController` so the clamping and
+/// relative-accumulation rules are unit-testable without a live player.
+///
+/// The view controller still owns the debounce timer, the `pendingScrubTargetMs`
+/// storage, the HUD repaint, and the engine seek — this type only answers
+/// "given the current state, what absolute millisecond target should the pending
+/// seek hold?".
+///
+/// Why this exists (see `VLCStreamViewController` MARK "Coalesced seeking"): a ±N
+/// skip used to fire an immediate *relative* `player.seek(by:)` on every press,
+/// and over HTTP each seek makes libVLC tear down + reopen its byte-range request
+/// — so mashing the button storms a self-hosted / reverse-proxied origin into a
+/// stall. Instead we accumulate an ABSOLUTE target and commit one engine seek a
+/// beat after the last press. Accumulating absolutely also makes the math exact:
+/// a relative `seek(by:)` raced libVLC's lagging position, so rapid taps never
+/// reliably summed to N×.
+enum SeekCoalescer {
+    /// Near-end guard: never seek to within this many ms of the reported length.
+    /// libVLC treats a seek to the very end as end-of-media, so we keep headroom.
+    static let endGuardMs: Int32 = 250
+
+    /// Clamp an absolute target into the valid range `[0, lengthMs - endGuardMs]`.
+    /// `lengthMs <= 0` means "length not known yet" → only the lower bound applies.
+    static func clamp(target: Int32, lengthMs: Int32) -> Int32 {
+        var clamped = max(0, target)
+        if lengthMs > 0 { clamped = min(clamped, max(0, lengthMs - endGuardMs)) }
+        return clamped
+    }
+
+    /// Resolve the (unclamped) absolute target for a relative ±`deltaSeconds`
+    /// skip. The base is the *pending* coalesced target when a skip is already in
+    /// flight — so rapid taps sum exactly — else the live position. Arithmetic is
+    /// done in `Int` and saturated back into `Int32` so extreme inputs can't trap.
+    static func relativeTarget(deltaSeconds: Int, pendingMs: Int32?, currentMs: Int32) -> Int32 {
+        let base = Int(pendingMs ?? currentMs)
+        return Int32(clamping: base + deltaSeconds * 1000)
+    }
+}

--- a/Shared/Screens/VideoPlayer/VLCStreamPresenter.swift
+++ b/Shared/Screens/VideoPlayer/VLCStreamPresenter.swift
@@ -615,31 +615,27 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
     // MARK: Coalesced seeking
     //
     // A ±N skip used to fire an immediate relative `player.seek(by:)` on every
-    // press. Over HTTP each seek makes libVLC tear down the current byte-range
-    // request and open a fresh one at the new offset — so mashing the button
-    // unleashes a storm of open/cancel range requests that overloads a
-    // self-hosted / reverse-proxied server (and every other client hitting it)
-    // and can stall the stream into a freeze (the same failure mode as the AVI
-    // index storm, but user-driven and on any container). Instead we accumulate
-    // an ABSOLUTE target and commit ONE engine seek a beat after the last press.
-    // The HUD jumps to the projected position immediately, so it reads as more
-    // responsive, not less. Accumulation is also now exact — `seek(by:)` was
-    // relative to libVLC's lagging position, so five quick taps never reliably
-    // summed to 5×N.
+    // press, which storms a self-hosted / reverse-proxied origin with byte-range
+    // open/cancel churn and can stall the stream. Instead we accumulate an
+    // ABSOLUTE target and commit ONE engine seek a beat after the last press; the
+    // HUD jumps to the projected position immediately so it reads as responsive,
+    // not less. The pure target math (exact accumulation + near-end clamp) lives
+    // in `SeekCoalescer` so it can be unit-tested without a live player; this
+    // method owns only the debounce timer, the pending-target storage, the HUD
+    // repaint, and the engine seek.
 
     /// Accumulate a ±N skip: advance the pending target from the last target
     /// (or the live position if none) and re-arm the debounced commit.
     private func seek(bySeconds delta: Int) {
-        let base = Int(pendingScrubTargetMs ?? currentMs)
-        accumulateSeek(toAbsoluteMs: Int32(clamping: base + delta * 1000))
+        accumulateSeek(toAbsoluteMs: SeekCoalescer.relativeTarget(
+            deltaSeconds: delta, pendingMs: pendingScrubTargetMs, currentMs: currentMs))
     }
 
     /// Set an absolute pending target, paint it immediately, and (re)arm the
     /// single debounced engine seek. Shared by ±N skips and chapter jumps.
     private func accumulateSeek(toAbsoluteMs target: Int32) {
         let len = lengthMs
-        var clamped = max(0, target)
-        if len > 0 { clamped = min(clamped, max(0, len - 250)) }
+        let clamped = SeekCoalescer.clamp(target: target, lengthMs: len)
         pendingScrubTargetMs = clamped // also holds the bar until VLC catches up
         paintPosition(clamped, lengthMs: len)
         seekCommitWork?.cancel()

--- a/Tests/CinemaxKitTests/SeekCoalescerTests.swift
+++ b/Tests/CinemaxKitTests/SeekCoalescerTests.swift
@@ -1,0 +1,84 @@
+import Testing
+@testable import Cinemax
+
+/// `SeekCoalescer` is the pure seek-target math behind the player's coalesced
+/// ±N skip / chapter-jump logic. Expected values are derived directly from the
+/// implementation: relative skips accumulate from the pending target (else the
+/// live position) and sum exactly; absolute targets clamp to
+/// `[0, lengthMs - endGuardMs]` with `endGuardMs == 250`.
+@Suite("SeekCoalescer")
+struct SeekCoalescerTests {
+
+    // MARK: - clamp(target:lengthMs:)
+
+    @Test("negative target clamps to zero")
+    func clampNegative() {
+        #expect(SeekCoalescer.clamp(target: -1, lengthMs: 100_000) == 0)
+        #expect(SeekCoalescer.clamp(target: Int32.min, lengthMs: 100_000) == 0)
+    }
+
+    @Test("target beyond length clamps to length minus end guard")
+    func clampUpperBound() {
+        // 100_000 - 250 = 99_750
+        #expect(SeekCoalescer.clamp(target: 100_000, lengthMs: 100_000) == 99_750)
+        #expect(SeekCoalescer.clamp(target: 999_999, lengthMs: 100_000) == 99_750)
+    }
+
+    @Test("target within range is returned unchanged")
+    func clampWithinRange() {
+        #expect(SeekCoalescer.clamp(target: 50_000, lengthMs: 100_000) == 50_000)
+        #expect(SeekCoalescer.clamp(target: 0, lengthMs: 100_000) == 0)
+        // exactly on the guarded ceiling
+        #expect(SeekCoalescer.clamp(target: 99_750, lengthMs: 100_000) == 99_750)
+    }
+
+    @Test("unknown length (<= 0) applies only the lower bound")
+    func clampUnknownLength() {
+        #expect(SeekCoalescer.clamp(target: 5_000, lengthMs: 0) == 5_000)
+        #expect(SeekCoalescer.clamp(target: -5_000, lengthMs: 0) == 0)
+        #expect(SeekCoalescer.clamp(target: 5_000, lengthMs: -1) == 5_000)
+    }
+
+    @Test("very short media: the end guard never produces a negative ceiling")
+    func clampShortMedia() {
+        // lengthMs - 250 would be negative → max(0, …) keeps the ceiling at 0
+        #expect(SeekCoalescer.clamp(target: 1_000, lengthMs: 100) == 0)
+        #expect(SeekCoalescer.clamp(target: 1_000, lengthMs: 250) == 0)
+        // one ms above the guard window leaves a 1 ms reachable window
+        #expect(SeekCoalescer.clamp(target: 1_000, lengthMs: 251) == 1)
+    }
+
+    // MARK: - relativeTarget(deltaSeconds:pendingMs:currentMs:)
+
+    @Test("with no pending target, the base is the live position")
+    func relativeFromCurrent() {
+        #expect(SeekCoalescer.relativeTarget(deltaSeconds: 15, pendingMs: nil, currentMs: 10_000) == 25_000)
+        #expect(SeekCoalescer.relativeTarget(deltaSeconds: -15, pendingMs: nil, currentMs: 10_000) == -5_000)
+    }
+
+    @Test("rapid taps accumulate from the pending target and sum exactly")
+    func relativeAccumulatesExactly() {
+        // Three quick +15s taps from 10s: each builds on the last pending target,
+        // so the total is exactly 10s + 3×15s = 55s (a relative seek-by would drift).
+        let cur: Int32 = 10_000
+        let t1 = SeekCoalescer.relativeTarget(deltaSeconds: 15, pendingMs: nil, currentMs: cur)
+        let t2 = SeekCoalescer.relativeTarget(deltaSeconds: 15, pendingMs: t1, currentMs: cur)
+        let t3 = SeekCoalescer.relativeTarget(deltaSeconds: 15, pendingMs: t2, currentMs: cur)
+        #expect(t1 == 25_000)
+        #expect(t2 == 40_000)
+        #expect(t3 == 55_000)
+    }
+
+    @Test("the relative result is not clamped — clamping is a separate stage")
+    func relativeIsUnclamped() {
+        // A backward skip past zero stays negative; accumulateSeek clamps next.
+        #expect(SeekCoalescer.relativeTarget(deltaSeconds: -30, pendingMs: 10_000, currentMs: 0) == -20_000)
+    }
+
+    @Test("Int32 extremes saturate instead of trapping")
+    func relativeNoOverflow() {
+        // base + delta*1000 is computed in Int, then Int32(clamping:) saturates.
+        #expect(SeekCoalescer.relativeTarget(deltaSeconds: 10_000_000, pendingMs: Int32.max, currentMs: 0) == Int32.max)
+        #expect(SeekCoalescer.relativeTarget(deltaSeconds: -10_000_000, pendingMs: Int32.min, currentMs: 0) == Int32.min)
+    }
+}


### PR DESCRIPTION
Recreated from #38, which GitHub auto-closed when its base branch `fix/restart-player` was deleted on merge of #37. Same single commit, now targeting `main`.

## What

Extracts the player's **coalesced ±N skip / chapter-jump target math** out of the 2,870-line `VLCStreamViewController` into a standalone, unit-tested `SeekCoalescer` enum — following the repo's existing extract-and-test pattern (`PlayerTimeFormat`, `PlaybackReporter`).

This is the highest-risk pure logic in the player (exact absolute accumulation so rapid taps sum to N×, and a 250 ms near-end clamp), previously `private` inside the VC — untestable without a live libVLC player.

## Changes

- **`Shared/Screens/VideoPlayer/SeekCoalescer.swift`** (new) — pure `clamp(target:lengthMs:)` + `relativeTarget(deltaSeconds:pendingMs:currentMs:)`.
- **`VLCStreamPresenter.swift`** — `seek(bySeconds:)` / `accumulateSeek` call `SeekCoalescer`. Pure behavior-equivalent rewiring (`final class` direct dispatch unchanged).
- **`Tests/CinemaxKitTests/SeekCoalescerTests.swift`** (new) — 9 tests: end-guard clamp, bounds, unknown/short length, exact tap accumulation, unclamped relative result, Int32 saturation.

## Verification

iOS: **129 tests / 25 suites pass** (incl. the new `SeekCoalescer` suite). tvOS: **BUILD SUCCEEDED**. No behavior change — only the math moved out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)