### PR TITLE
Configurable Home genre rows, cross-platform library layout & API perf

### DIFF
--- a/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient+Library.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient+Library.swift
@@ -124,13 +124,31 @@ extension JellyfinAPIClient {
         if let cached: [String] = cache.get(cacheKey) { return cached }
 
         guard let client = getClient() else { throw JellyfinError.notConnected }
-        let params = Paths.GetQueryFiltersParameters(
-            userID: userId,
+
+        // Prefer /Genres — it reads the genres table directly. The legacy
+        // /Items/Filters scan is recursive and walks every episode under every
+        // series, which is very slow and can effectively hang on large
+        // libraries. Keep /Items/Filters as a fallback for servers/configs where
+        // /Genres returns nothing.
+        let genresParams = Paths.GetGenresParameters(
             includeItemTypes: includeItemTypes,
-            isRecursive: true
+            userID: userId,
+            enableImages: false,
+            enableTotalRecordCount: false
         )
-        let response = try await client.send(Paths.getQueryFilters(parameters: params))
-        let result = response.value.genres?.compactMap(\.name) ?? []
+        let genresResponse = try await client.send(Paths.getGenres(parameters: genresParams))
+        var result = (genresResponse.value.items ?? []).compactMap(\.name)
+
+        if result.isEmpty {
+            let filterParams = Paths.GetQueryFiltersParameters(
+                userID: userId,
+                includeItemTypes: includeItemTypes,
+                isRecursive: true
+            )
+            let filterResponse = try await client.send(Paths.getQueryFilters(parameters: filterParams))
+            result = filterResponse.value.genres?.compactMap(\.name) ?? []
+        }
+
         cache.set(cacheKey, value: result, ttl: 300)
         return result
     }
@@ -143,9 +161,20 @@ extension JellyfinAPIClient {
     }
 
     public func getItem(userId: String, itemId: String) async throws -> BaseItemDto {
+        // Short-TTL cache: at playback start the same item is fetched ~3× in a
+        // burst (the PlaybackInfo resolve, the chapter/trickplay load, the
+        // now-playing metadata enrich). A 10s window collapses that burst into
+        // one network round-trip. Every path that mutates this item's userData
+        // invalidates the key explicitly so a stale entry is never served: the
+        // play-state / favorite mutators, AND `reportPlaybackStopped` (so the
+        // detail screen's immediate post-dismiss reload gets the fresh resume
+        // position — tvOS reloads synchronously on dismiss).
+        let cacheKey = "item-\(itemId)-\(userId)"
+        if let cached: BaseItemDto = cache.get(cacheKey) { return cached }
         do {
             guard let client = getClient() else { throw JellyfinError.notConnected }
             let response = try await client.send(Paths.getItem(itemID: itemId, userID: userId))
+            cache.set(cacheKey, value: response.value, ttl: 10)
             return response.value
         } catch {
             notifyIfUnauthorized(error)
@@ -154,10 +183,20 @@ extension JellyfinAPIClient {
     }
 
     public func getSimilarItems(itemId: String, userId: String, limit: Int = 12) async throws -> [BaseItemDto] {
+        // "More like this" is stable per item — cache 5 min so re-opening a
+        // detail screen (or bouncing in/out of the player) doesn't re-fetch it
+        // every time. Cache the raw items and apply the rating filter on the way
+        // out so a mid-session content-age change is always honored.
+        let cacheKey = "similar-\(itemId)-\(userId)-\(limit)"
+        if let cached: [BaseItemDto] = cache.get(cacheKey) {
+            return applyRatingFilter(cached)
+        }
         guard let client = getClient() else { throw JellyfinError.notConnected }
         let params = Paths.GetSimilarItemsParameters(userID: userId, limit: limit)
         let response = try await client.send(Paths.getSimilarItems(itemID: itemId, parameters: params))
-        return applyRatingFilter(response.value.items ?? [])
+        let items = response.value.items ?? []
+        cache.set(cacheKey, value: items, ttl: 300)
+        return applyRatingFilter(items)
     }
 
     public func searchItems(userId: String, searchTerm: String, limit: Int = 20) async throws -> [BaseItemDto] {
@@ -214,7 +253,10 @@ extension JellyfinAPIClient {
         _ = try await client.send(Paths.markUnplayedItem(itemID: itemId, userID: userId))
         // Only the resume list depends on play state — leave genres / latest /
         // serverInfo caches intact so the next navigation doesn't refetch them.
+        // Also drop this item's short-TTL getItem entry so the detail screen
+        // reflects the new play state immediately rather than after 10s.
         cache.invalidate(prefix: "resume-")
+        cache.invalidate(prefix: "item-\(itemId)-")
     }
 
     public func markItemPlayed(itemId: String, userId: String) async throws {
@@ -222,8 +264,10 @@ extension JellyfinAPIClient {
             guard let client = getClient() else { throw JellyfinError.notConnected }
             _ = try await client.send(Paths.markPlayedItem(itemID: itemId, userID: userId))
             // Marking watched pulls the item out of Continue Watching — drop the
-            // resume list so the row catches up. Other caches stay intact.
+            // resume list so the row catches up, plus this item's short-TTL
+            // getItem entry. Other caches stay intact.
             cache.invalidate(prefix: "resume-")
+            cache.invalidate(prefix: "item-\(itemId)-")
         } catch {
             notifyIfUnauthorized(error)
             throw error
@@ -238,10 +282,12 @@ extension JellyfinAPIClient {
             } else {
                 _ = try await client.send(Paths.unmarkFavoriteItem(itemID: itemId, userID: userId))
             }
-            // The Favorites row refetches uncached; the only cached surface
-            // carrying favorite state is the resume list's userData. Scope the
-            // invalidation to it rather than nuking genres / latest / serverInfo.
+            // The Favorites row refetches uncached; the cached surfaces carrying
+            // favorite state are the resume list's userData and this item's
+            // short-TTL getItem entry. Scope the invalidation to those rather
+            // than nuking genres / latest / serverInfo.
             cache.invalidate(prefix: "resume-")
+            cache.invalidate(prefix: "item-\(itemId)-")
         } catch {
             notifyIfUnauthorized(error)
             throw error

--- a/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient+Playback.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient+Playback.swift
@@ -414,6 +414,12 @@ extension JellyfinAPIClient {
             positionTicks: positionTicks
         )
         _ = try? await client.send(Paths.reportPlaybackStopped(body))
+        // Playback just moved this item's resume position server-side. Drop its
+        // short-TTL getItem entry (and the resume list) so the detail screen's
+        // immediate post-dismiss reload — tvOS reloads synchronously on dismiss —
+        // paints the fresh resume bar instead of the pre-playback position.
+        cache.invalidate(prefix: "item-\(itemId)-")
+        cache.invalidate(prefix: "resume-")
     }
 
     /// Compact, single-tag diagnostic for the playback decision.

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -664,13 +664,18 @@
 "settings.homePage.continueWatching" = "Continue Watching";
 "settings.homePage.recentlyAdded" = "Recently Added";
 "settings.homePage.genreRows" = "Genre Rows";
+"settings.homePage.genreRows.choose" = "Choose genres";
+"settings.homePage.genreRows.hint" = "Genres shown as rows on Home";
+"settings.homePage.genreRows.empty" = "No genres available";
+"settings.homePage.genreRows.selectAll" = "Select all";
+"settings.homePage.genreRows.deselectAll" = "Deselect all";
 "settings.homePage.favorites" = "Favorites";
 "settings.detailPage" = "Detail Page";
 "settings.detailPage.qualityBadges" = "Quality badges";
 "settings.detailPage.trailerButton" = "Trailer button";
-"settings.libraryLayout" = "Library landing";
-"settings.libraryLayout.browse" = "Browse";
-"settings.libraryLayout.grid" = "Grid";
+"settings.libraryLayout" = "Library";
+"settings.libraryLayout.browse" = "By genre";
+"settings.libraryLayout.grid" = "Show all";
 
 // MARK: - Media Detail
 

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -266,13 +266,18 @@
 "settings.homePage.continueWatching" = "Reprendre";
 "settings.homePage.recentlyAdded" = "Ajouts récents";
 "settings.homePage.genreRows" = "Rangées par genre";
+"settings.homePage.genreRows.choose" = "Choisir les genres";
+"settings.homePage.genreRows.hint" = "Genres affichés en rangées sur l'accueil";
+"settings.homePage.genreRows.empty" = "Aucun genre disponible";
+"settings.homePage.genreRows.selectAll" = "Tout sélectionner";
+"settings.homePage.genreRows.deselectAll" = "Tout désélectionner";
 "settings.homePage.favorites" = "Favoris";
 "settings.detailPage" = "Page de détail";
 "settings.detailPage.qualityBadges" = "Badges de qualité";
 "settings.detailPage.trailerButton" = "Bouton Bande-annonce";
-"settings.libraryLayout" = "Page d'accueil bibliothèque";
-"settings.libraryLayout.browse" = "Parcourir";
-"settings.libraryLayout.grid" = "Grille";
+"settings.libraryLayout" = "Bibliothèque";
+"settings.libraryLayout.browse" = "Par genre";
+"settings.libraryLayout.grid" = "Tout afficher";
 
 // MARK: - Media Detail
 

--- a/Shared/DesignSystem/SettingsKeys.swift
+++ b/Shared/DesignSystem/SettingsKeys.swift
@@ -32,6 +32,15 @@ enum SettingsKey {
     static let homeShowFavorites = "home.showFavorites"
     static let homeShowGenreRows = "home.showGenreRows"
     static let homeShowWatchingNow = "home.showWatchingNow"
+    /// JSON `[String]` — the genres the user picked to surface as Home rows.
+    /// An **empty string** (the default) means "never configured" → Home shows
+    /// a deterministic default set; once the user touches the picker the value
+    /// becomes a JSON array (possibly `[]`, meaning an explicit empty choice).
+    /// Stored as a string so `@AppStorage` drives live re-renders even inside a
+    /// `navigationDestination` rendered from an extension method (where
+    /// `@Observable` changes don't re-render — see CLAUDE.md). Read/write
+    /// through `HomeGenrePreferences`.
+    static let homeSelectedGenres = "home.selectedGenres"
 
     // Detail page
     static let detailShowQualityBadges = "detail.showQualityBadges"
@@ -50,9 +59,13 @@ enum SettingsKey {
     /// setting; written only through `SearchViewModel`'s mutators.
     static let searchRecentQueries = "search.recentQueries"
 
-    // Library landing (tvOS only)
-    /// `"browse"` (default) shows hero + genre rows; `"grid"` shows a flat poster grid using the default sort.
-    static let libraryTVBrowseLayout = "library.tvBrowseLayout"
+    // Library landing (iOS + tvOS)
+    /// `"browse"` (default) shows the cinematic hero + genre rows ("By genre");
+    /// `"grid"` shows a flat poster grid using the default sort ("Show all").
+    /// Honored on both platforms — the iOS toggle lives in Appearance, the
+    /// tvOS one in Appearance too. Raw key keeps its legacy `tv` name to
+    /// preserve any existing on-device preference; the value is platform-neutral.
+    static let libraryBrowseLayout = "library.tvBrowseLayout"
 
     // Privacy & Security
     /// Maximum content age (years) for items shown across the app.
@@ -97,7 +110,7 @@ enum SettingsKey {
 
         static let searchSaveHistory = true
 
-        static let libraryTVBrowseLayout = LibraryTVBrowseLayout.browse.rawValue
+        static let libraryBrowseLayout = LibraryBrowseLayout.browse.rawValue
 
         static let privacyMaxContentAge = 0
 
@@ -108,13 +121,67 @@ enum SettingsKey {
     }
 }
 
-/// tvOS landing layout for `MediaLibraryScreen`. Controls whether the screen
-/// opens on the cinematic browse view (hero + genre rows + browse grid) or on
-/// the flat poster grid using the default sort. Filter state still toggles to
-/// the grid regardless — this only governs the *unfiltered* landing.
-enum LibraryTVBrowseLayout: String, CaseIterable, Identifiable {
+/// Landing layout for `MediaLibraryScreen` (iOS + tvOS). Controls whether the
+/// screen opens on the cinematic browse view (hero + genre rows + browse grid,
+/// "By genre") or on the flat poster grid using the default sort ("Show all").
+/// Filter state still toggles to the grid regardless — this only governs the
+/// *unfiltered* landing.
+enum LibraryBrowseLayout: String, CaseIterable, Identifiable {
     case browse
     case grid
 
     var id: String { rawValue }
+}
+
+/// Read/write helper for the user-configurable Home genre rows
+/// (`SettingsKey.homeSelectedGenres`). Centralizes the JSON encoding and the
+/// "empty string = never configured" sentinel so `HomeViewModel` (not a View,
+/// reads `UserDefaults` directly) and the Settings genre pickers (Views, bind
+/// through `@AppStorage`) agree on the exact same semantics.
+enum HomeGenrePreferences {
+    /// How many genre rows Home shows when the user hasn't picked any. A
+    /// deterministic prefix of the server's (sorted) genre list — coherent,
+    /// not random (see the de-randomization decision).
+    static let defaultRowCount = 6
+
+    /// `true` once the user has made an explicit choice in the picker. Distinct
+    /// from "has selected genres" so an explicit empty choice (zero rows) is not
+    /// mistaken for the unconfigured default.
+    static func isConfigured() -> Bool {
+        guard let raw = UserDefaults.standard.string(forKey: SettingsKey.homeSelectedGenres) else { return false }
+        return !raw.isEmpty
+    }
+
+    /// The user's explicit genre picks (empty if unconfigured or explicitly empty).
+    static func selectedGenres() -> [String] {
+        decode(UserDefaults.standard.string(forKey: SettingsKey.homeSelectedGenres))
+    }
+
+    /// Persist an explicit selection. Always marks the preference configured —
+    /// even for an empty array, which means "no genre rows".
+    static func setSelectedGenres(_ genres: [String]) {
+        guard let data = try? JSONEncoder().encode(genres),
+              let json = String(data: data, encoding: .utf8) else { return }
+        UserDefaults.standard.set(json, forKey: SettingsKey.homeSelectedGenres)
+    }
+
+    /// The genres to actually render as Home rows, given the full available
+    /// list (already sorted by the caller). Unconfigured → default prefix;
+    /// configured → the explicit picks intersected with what's available and
+    /// re-ordered to the canonical (available) order. No cap on count.
+    static func effectiveGenres(available: [String]) -> [String] {
+        guard isConfigured() else { return Array(available.prefix(defaultRowCount)) }
+        let chosen = Set(selectedGenres())
+        return available.filter { chosen.contains($0) }
+    }
+
+    /// Decodes the JSON `[String]` payload of `homeSelectedGenres`. Shared by
+    /// the static accessors and the picker Views (which hold the raw string in
+    /// `@AppStorage` for reactivity and decode it for display).
+    static func decode(_ raw: String?) -> [String] {
+        guard let raw, !raw.isEmpty,
+              let data = raw.data(using: .utf8),
+              let arr = try? JSONDecoder().decode([String].self, from: data) else { return [] }
+        return arr
+    }
 }

--- a/Shared/Screens/HomeScreen.swift
+++ b/Shared/Screens/HomeScreen.swift
@@ -19,6 +19,9 @@ struct HomeScreen: View {
     @State private var deepLinkTarget: DeepLinkTarget?
     @AppStorage(SettingsKey.homeShowGenreRows) private var showGenreRows: Bool = SettingsKey.Default.homeShowGenreRows
     @AppStorage(SettingsKey.homeShowWatchingNow) private var showWatchingNow: Bool = SettingsKey.Default.homeShowWatchingNow
+    /// Raw JSON of the user's picked genres. Held here only to observe changes
+    /// made in Settings → Interface → Home page and refresh the rows live.
+    @AppStorage(SettingsKey.homeSelectedGenres) private var selectedGenresJSON: String = ""
 
     var body: some View {
         ZStack {
@@ -61,6 +64,10 @@ struct HomeScreen: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .cinemaxFavoritesChanged)) { _ in
             Task { await viewModel.refreshFavorites(using: appState) }
+        }
+        // Genre selection changed in Settings → refresh just the genre rows.
+        .onChange(of: selectedGenresJSON) {
+            Task { await viewModel.reloadGenreRows(using: appState) }
         }
         // Widget / Top Shelf deep link: push the item's detail. Attached at
         // the screen root (NOT inside the lazy scroll content — see the

--- a/Shared/Screens/MovieLibraryScreen.swift
+++ b/Shared/Screens/MovieLibraryScreen.swift
@@ -25,8 +25,10 @@ struct MediaLibraryScreen: View {
     #endif
     #if os(tvOS)
     @State private var showSortPicker = false
-    @AppStorage(SettingsKey.libraryTVBrowseLayout) private var libraryTVBrowseLayout: String = SettingsKey.Default.libraryTVBrowseLayout
     #endif
+    /// Browse ("By genre") vs flat grid ("Show all") landing layout. Honored on
+    /// both platforms; the toggle lives in Settings → Appearance.
+    @AppStorage(SettingsKey.libraryBrowseLayout) private var libraryBrowseLayout: String = SettingsKey.Default.libraryBrowseLayout
 
     /// `nil` for library tabs of Other / Mixed kind — disables the
     /// `includeItemTypes` filter at query time so every item in the parent
@@ -164,17 +166,20 @@ struct MediaLibraryScreen: View {
     }
 
     /// Filtered grid is shown when:
-    /// - iOS: any non-default state (sort or filter)
     /// - tvOS: any active *filter*, OR the user opted into the flat grid layout
-    ///   in Settings → Interface. Sort changes alone don't switch out of browse,
-    ///   matching the iOS default-sort browse experience.
+    ///   ("Show all") in Settings → Appearance. Sort changes alone don't switch
+    ///   out of browse.
+    /// - iOS: any non-default state (sort or filter), OR the user opted into the
+    ///   flat grid layout ("Show all"). The sort sheet flipping to grid is the
+    ///   existing iOS behavior; the layout toggle additionally forces grid even
+    ///   in the pristine default state.
     private var shouldShowFilteredView: Bool {
         #if os(tvOS)
         if viewModel.sortFilter.isFiltered { return true }
-        return LibraryTVBrowseLayout(rawValue: libraryTVBrowseLayout) == .grid
         #else
-        return viewModel.sortFilter.isNonDefault
+        if viewModel.sortFilter.isNonDefault { return true }
         #endif
+        return LibraryBrowseLayout(rawValue: libraryBrowseLayout) == .grid
     }
 
     // MARK: Browse View (hero + genre rows + browse-genres grid)

--- a/Shared/Screens/Settings/SettingsAppearanceView+iOS.swift
+++ b/Shared/Screens/Settings/SettingsAppearanceView+iOS.swift
@@ -15,6 +15,7 @@ struct IOSAppearanceDetailView: View {
     @Environment(\.motionEffectsEnabled) private var motionEffects
     @AppStorage(SettingsKey.rainbowUnlocked) private var rainbowUnlocked: Bool = SettingsKey.Default.rainbowUnlocked
     @AppStorage(SettingsKey.motionEffects) private var motionEffectsStorage: Bool = SettingsKey.Default.motionEffects
+    @AppStorage(SettingsKey.libraryBrowseLayout) private var libraryBrowseLayout: String = SettingsKey.Default.libraryBrowseLayout
     @State private var fontScale: Double = UserDefaults.standard.object(forKey: SettingsKey.uiScale) as? Double ?? SettingsKey.Default.uiScale
     private let fontScaleOptions: [Double] = [0.80, 0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15, 1.20, 1.25, 1.30]
 
@@ -127,12 +128,59 @@ struct IOSAppearanceDetailView: View {
                         .tint(themeManager.accent)
                     }
                 }
+
+                iOSSettingsDivider
+
+                iOSSettingsRow {
+                    // Label on its own line, the two-option control full-width
+                    // below it — side-by-side gets squeezed to "Par…/Tout…" once
+                    // the label + buttons can't share one row (e.g. FR @ 100%).
+                    VStack(alignment: .leading, spacing: CinemaSpacing.spacing3) {
+                        HStack {
+                            iOSRowIcon(systemName: "square.grid.2x2", color: themeManager.accent)
+                            Text(loc.localized("settings.libraryLayout"))
+                                .font(CinemaFont.label(.large))
+                                .foregroundStyle(CinemaColor.onSurface)
+                            Spacer()
+                        }
+                        libraryLayoutPicker
+                    }
+                }
             }
             .glassPanel(cornerRadius: CinemaRadius.extraLarge)
         }
     }
 
     // MARK: - Appearance-specific helpers
+
+    /// Full-width two-option control. "By genre" = browse (hero + genre rows);
+    /// "Show all" = flat grid. Each button takes half the row so the full FR
+    /// labels ("Par genre" / "Tout afficher") fit without truncation.
+    var libraryLayoutPicker: some View {
+        HStack(spacing: CinemaSpacing.spacing2) {
+            libraryLayoutButton(.browse, label: loc.localized("settings.libraryLayout.browse"))
+            libraryLayoutButton(.grid, label: loc.localized("settings.libraryLayout.grid"))
+        }
+    }
+
+    func libraryLayoutButton(_ option: LibraryBrowseLayout, label: String) -> some View {
+        let isSelected = (LibraryBrowseLayout(rawValue: libraryBrowseLayout) ?? .browse) == option
+        return Button {
+            libraryBrowseLayout = option.rawValue
+        } label: {
+            Text(label)
+                .font(.system(size: CinemaScale.pt(15), weight: .semibold))
+                .foregroundStyle(isSelected ? themeManager.onAccent : CinemaColor.onSurfaceVariant)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity)
+                .frame(height: 36)
+                .background(
+                    RoundedRectangle(cornerRadius: CinemaRadius.medium)
+                        .fill(isSelected ? themeManager.accent : CinemaColor.surfaceContainerHigh)
+                )
+        }
+        .buttonStyle(.plain)
+    }
 
     var selectedAccent: AccentOption {
         AccentOption(rawValue: themeManager.accentColorKey) ?? .green

--- a/Shared/Screens/Settings/SettingsScreen+iOS.swift
+++ b/Shared/Screens/Settings/SettingsScreen+iOS.swift
@@ -426,6 +426,29 @@ extension SettingsScreen {
     var iOSHomePageSection: some View {
         VStack(spacing: 0) {
             iOSToggleRowsJoined(homePageToggleRows, accent: themeManager.accent, animated: motionEffects)
+
+            // "Genre rows" is a section toggle; when on, drill into a native
+            // multi-select to choose which genres surface as rows on Home.
+            if showGenreRows {
+                iOSSettingsDivider
+                NavigationLink {
+                    IOSHomeGenrePickerView()
+                } label: {
+                    iOSSettingsRow {
+                        HStack {
+                            iOSRowIcon(systemName: "theatermasks", color: themeManager.accent)
+                            Text(loc.localized("settings.homePage.genreRows.choose"))
+                                .font(CinemaFont.label(.large))
+                                .foregroundStyle(CinemaColor.onSurface)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: CinemaScale.pt(13), weight: .semibold))
+                                .foregroundStyle(CinemaColor.onSurfaceVariant)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+            }
         }
         .glassPanel(cornerRadius: CinemaRadius.extraLarge)
     }
@@ -557,6 +580,97 @@ extension SettingsScreen {
                 .tint(themeManager.accent)
             }
         }
+    }
+}
+
+// MARK: - iOS Home Genre Rows Picker
+
+/// Native multi-select `List` for choosing which genres appear as rows on
+/// Home. Pushed from the Home page settings section. Standalone `View` so its
+/// `@State` (fetched genres) and `@AppStorage` selection drive re-renders even
+/// though it's reached through a `NavigationLink` inside the settings stack.
+/// Selection persists through `HomeGenrePreferences` (`home.selectedGenres`).
+struct IOSHomeGenrePickerView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(ThemeManager.self) private var themeManager
+    @Environment(LocalizationManager.self) private var loc
+    /// Held only for reactivity — the source of truth is `HomeGenrePreferences`.
+    @AppStorage(SettingsKey.homeSelectedGenres) private var selectionJSON: String = ""
+    @State private var availableGenres: [String] = []
+    @State private var isLoading = true
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if availableGenres.isEmpty {
+                EmptyStateView(
+                    systemImage: "theatermasks",
+                    title: loc.localized("settings.homePage.genreRows.empty")
+                )
+            } else {
+                List(availableGenres, id: \.self, selection: selectionBinding) { genre in
+                    Text(genre)
+                        .font(CinemaFont.label(.large))
+                        .foregroundStyle(CinemaColor.onSurface)
+                        .listRowBackground(CinemaColor.surfaceContainer)
+                }
+                .environment(\.editMode, .constant(.active))
+                .scrollContentBackground(.hidden)
+                .tint(themeManager.accent)
+            }
+        }
+        .background(CinemaColor.surface.ignoresSafeArea())
+        .navigationTitle(loc.localized("settings.homePage.genreRows"))
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if !availableGenres.isEmpty {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(loc.localized(allSelected
+                        ? "settings.homePage.genreRows.deselectAll"
+                        : "settings.homePage.genreRows.selectAll")) {
+                        HomeGenrePreferences.setSelectedGenres(allSelected ? [] : availableGenres)
+                    }
+                    .tint(themeManager.accent)
+                }
+            }
+        }
+        .task { await loadGenres() }
+    }
+
+    /// `true` when every available genre is currently selected — drives the
+    /// select-all / deselect-all toggle label and action.
+    private var allSelected: Bool {
+        !availableGenres.isEmpty && selectionBinding.wrappedValue.count == availableGenres.count
+    }
+
+    /// `Set` binding the multi-select `List` drives. The getter falls back to a
+    /// default prefix while unconfigured so the checkmarks match what Home
+    /// shows; the first edit materializes the explicit selection.
+    private var selectionBinding: Binding<Set<String>> {
+        Binding(
+            get: {
+                let explicit = HomeGenrePreferences.decode(selectionJSON)
+                if explicit.isEmpty && !HomeGenrePreferences.isConfigured() {
+                    return Set(availableGenres.prefix(HomeGenrePreferences.defaultRowCount))
+                }
+                return Set(explicit)
+            },
+            set: { newValue in
+                // Persist in canonical (available) order — matches Home's row order.
+                HomeGenrePreferences.setSelectedGenres(availableGenres.filter { newValue.contains($0) })
+            }
+        )
+    }
+
+    private func loadGenres() async {
+        guard let userId = appState.currentUserId else { isLoading = false; return }
+        let genres = (try? await appState.apiClient.getGenres(
+            userId: userId, includeItemTypes: [.movie, .series]
+        )) ?? []
+        availableGenres = genres.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+        isLoading = false
     }
 }
 

--- a/Shared/Screens/Settings/SettingsScreen+tvOS.swift
+++ b/Shared/Screens/Settings/SettingsScreen+tvOS.swift
@@ -460,6 +460,9 @@ extension SettingsScreen {
     var tvHomePageSection: some View {
         VStack(alignment: .leading, spacing: CinemaSpacing.spacing3) {
             tvToggleList(homePageToggleRows)
+            if showGenreRows {
+                TVHomeGenrePickerView()
+            }
         }
     }
 
@@ -580,11 +583,11 @@ extension SettingsScreen {
 
     // MARK: - Sleep Timer Row (tvOS)
 
-    /// Library landing layout (browse vs flat grid). tvOS-only setting; iOS
-    /// always uses the browse view because the screen has a real toolbar.
+    /// Library landing layout ("By genre" browse vs "Show all" flat grid). The
+    /// iOS equivalent is an inline segmented control in `IOSAppearanceDetailView`.
     var tvLibraryLayoutRow: some View {
         let isFocused = focusedItem == .toggle("libraryLayout")
-        let selected = LibraryTVBrowseLayout(rawValue: libraryTVBrowseLayout) ?? .browse
+        let selected = LibraryBrowseLayout(rawValue: libraryBrowseLayout) ?? .browse
         return Button {
             showLibraryLayoutPicker = true
         } label: {
@@ -613,9 +616,9 @@ extension SettingsScreen {
         .hoverEffectDisabled()
         .focused($focusedItem, equals: .toggle("libraryLayout"))
         .confirmationDialog(loc.localized("settings.libraryLayout"), isPresented: $showLibraryLayoutPicker) {
-            ForEach(LibraryTVBrowseLayout.allCases) { option in
+            ForEach(LibraryBrowseLayout.allCases) { option in
                 Button(loc.localized(option == .browse ? "settings.libraryLayout.browse" : "settings.libraryLayout.grid")) {
-                    libraryTVBrowseLayout = option.rawValue
+                    libraryBrowseLayout = option.rawValue
                 }
             }
         }
@@ -718,6 +721,149 @@ extension View {
                     .strokeBorder(accent.opacity(isFocused ? 0.8 : 0), lineWidth: 1.5)
             )
             .animation(animated ? .easeOut(duration: 0.15) : nil, value: isFocused)
+    }
+}
+
+// MARK: - tvOS Home Genre Rows Picker
+
+/// Focusable genre chips for choosing which genres appear as rows on Home.
+/// Standalone `View` so it owns its `@State` (fetched genres) and re-renders
+/// from `@AppStorage` even though it's hosted in the state-machine settings
+/// detail rendered from an extension method (where `@Observable` wouldn't).
+/// Selection persists through `HomeGenrePreferences` (`home.selectedGenres`).
+struct TVHomeGenrePickerView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(ThemeManager.self) private var themeManager
+    @Environment(LocalizationManager.self) private var loc
+    @Environment(\.motionEffectsEnabled) private var motionEffects
+    /// Held only for reactivity — the source of truth is `HomeGenrePreferences`.
+    @AppStorage(SettingsKey.homeSelectedGenres) private var selectionJSON: String = ""
+    @State private var availableGenres: [String] = []
+    @State private var didLoad = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: CinemaSpacing.spacing3) {
+            Text(loc.localized("settings.homePage.genreRows.hint"))
+                .font(.system(size: CinemaScale.pt(17), weight: .medium))
+                .foregroundStyle(CinemaColor.onSurfaceVariant)
+
+            if availableGenres.isEmpty {
+                Text(loc.localized("settings.homePage.genreRows.empty"))
+                    .font(.system(size: CinemaScale.pt(17), weight: .medium))
+                    .foregroundStyle(CinemaColor.onSurfaceVariant)
+                    .padding(.vertical, CinemaSpacing.spacing2)
+            } else {
+                selectAllChip
+                FlowLayout(spacing: CinemaSpacing.spacing2) {
+                    ForEach(availableGenres, id: \.self) { genre in
+                        chip(genre)
+                    }
+                }
+            }
+        }
+        .padding(.top, CinemaSpacing.spacing2)
+        .task {
+            // getGenres is cached client-side (300s); guard so the tvOS `.task`
+            // re-firing on settings re-entry doesn't thrash @State.
+            guard !didLoad else { return }
+            didLoad = true
+            await loadGenres()
+        }
+    }
+
+    private var selection: Set<String> {
+        let explicit = HomeGenrePreferences.decode(selectionJSON)
+        if explicit.isEmpty && !HomeGenrePreferences.isConfigured() {
+            return Set(availableGenres.prefix(HomeGenrePreferences.defaultRowCount))
+        }
+        return Set(explicit)
+    }
+
+    private var allSelected: Bool {
+        !availableGenres.isEmpty && selection.count == availableGenres.count
+    }
+
+    /// Select-all / deselect-all toggle. Selecting all persists the full list;
+    /// deselecting persists an explicit empty choice (zero genre rows).
+    private var selectAllChip: some View {
+        let scheme: ColorScheme = themeManager.darkModeEnabled ? .dark : .light
+        return Button {
+            HomeGenrePreferences.setSelectedGenres(allSelected ? [] : availableGenres)
+        } label: {
+            HStack(spacing: CinemaSpacing.spacing1) {
+                Image(systemName: allSelected ? "xmark.circle" : "checkmark.circle")
+                    .font(.system(size: CinemaScale.pt(18), weight: .semibold))
+                Text(loc.localized(allSelected
+                    ? "settings.homePage.genreRows.deselectAll"
+                    : "settings.homePage.genreRows.selectAll"))
+                    .font(.system(size: CinemaScale.pt(20), weight: .semibold))
+            }
+            .foregroundStyle(CinemaColor.onSurface)
+            .padding(.horizontal, CinemaSpacing.spacing4)
+            .padding(.vertical, CinemaSpacing.spacing2)
+            .environment(\.colorScheme, scheme)
+            .background(
+                Capsule()
+                    .fill(CinemaColor.surfaceContainerHigh)
+                    .environment(\.colorScheme, scheme)
+            )
+            .clipShape(Capsule())
+        }
+        .buttonStyle(TVFilterChipButtonStyle(accent: themeManager.accent))
+        .focusEffectDisabled()
+        .hoverEffectDisabled()
+    }
+
+    @ViewBuilder
+    private func chip(_ genre: String) -> some View {
+        let isSelected = selection.contains(genre)
+        // A focused tvOS button flips its label's UITraitCollection to light
+        // mode, which would invert every Color.dynamic token (near-black text
+        // on a near-white capsule in dark mode). Re-inject the real scheme on
+        // the label content AND the background fill — same mechanism as
+        // `tvSettingsFocusable`. See CLAUDE.md trait caveat.
+        let scheme: ColorScheme = themeManager.darkModeEnabled ? .dark : .light
+        Button {
+            toggle(genre)
+        } label: {
+            HStack(spacing: CinemaSpacing.spacing1) {
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: CinemaScale.pt(15), weight: .bold))
+                }
+                Text(genre)
+                    .font(.system(size: CinemaScale.pt(20), weight: isSelected ? .bold : .medium))
+            }
+            .foregroundStyle(isSelected ? themeManager.onAccent : CinemaColor.onSurface)
+            .padding(.horizontal, CinemaSpacing.spacing4)
+            .padding(.vertical, CinemaSpacing.spacing2)
+            .environment(\.colorScheme, scheme)
+            .background(
+                Capsule()
+                    .fill(isSelected ? themeManager.accentContainer : CinemaColor.surfaceContainerHigh)
+                    .environment(\.colorScheme, scheme)
+            )
+            .clipShape(Capsule())
+        }
+        .buttonStyle(TVFilterChipButtonStyle(accent: themeManager.accent))
+        .focusEffectDisabled()
+        .hoverEffectDisabled()
+    }
+
+    private func toggle(_ genre: String) {
+        var next = selection
+        if next.contains(genre) { next.remove(genre) } else { next.insert(genre) }
+        // Persist in canonical (available) order so Home renders rows in the
+        // same order the chips appear here.
+        HomeGenrePreferences.setSelectedGenres(availableGenres.filter { next.contains($0) })
+    }
+
+    private func loadGenres() async {
+        guard let userId = appState.currentUserId else { return }
+        let genres = (try? await appState.apiClient.getGenres(
+            userId: userId, includeItemTypes: [.movie, .series]
+        )) ?? []
+        availableGenres = genres.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
     }
 }
 #endif

--- a/Shared/Screens/Settings/SettingsScreen.swift
+++ b/Shared/Screens/Settings/SettingsScreen.swift
@@ -197,7 +197,7 @@ struct SettingsScreen: View {
     @AppStorage(SettingsKey.homeShowWatchingNow) var showWatchingNow: Bool = SettingsKey.Default.homeShowWatchingNow
     @AppStorage(SettingsKey.detailShowQualityBadges) var showQualityBadges: Bool = SettingsKey.Default.detailShowQualityBadges
     @AppStorage(SettingsKey.detailShowTrailerButton) var showTrailerButton: Bool = SettingsKey.Default.detailShowTrailerButton
-    @AppStorage(SettingsKey.libraryTVBrowseLayout) var libraryTVBrowseLayout: String = SettingsKey.Default.libraryTVBrowseLayout
+    @AppStorage(SettingsKey.libraryBrowseLayout) var libraryBrowseLayout: String = SettingsKey.Default.libraryBrowseLayout
     @AppStorage(SettingsKey.sleepTimerDefaultMinutes) var sleepTimerMinutes: Int = SettingsKey.Default.sleepTimerDefaultMinutes
     @AppStorage(SettingsKey.debugFastSleepTimer) var debugFastSleepTimer: Bool = SettingsKey.Default.debugFastSleepTimer
     @AppStorage(SettingsKey.debugShowSkipToEnd) var debugShowSkipToEnd: Bool = SettingsKey.Default.debugShowSkipToEnd

--- a/Shared/ViewModels/HomeViewModel.swift
+++ b/Shared/ViewModels/HomeViewModel.swift
@@ -209,6 +209,15 @@ final class HomeViewModel {
         }
     }
 
+    /// Re-fetches only the genre rows — fired from `HomeScreen` when the user
+    /// changes their genre selection in Settings (the `home.selectedGenres`
+    /// `@AppStorage` flips). Bypasses the `hasLoaded` guard so the change is
+    /// reflected live without re-running the whole Home load.
+    func reloadGenreRows(using appState: AppState) async {
+        guard let userId = appState.currentUserId else { return }
+        await loadGenreRows(userId: userId, appState: appState)
+    }
+
     private func loadGenreRows(userId: String, appState: AppState) async {
         let allGenres: [String]
         do {
@@ -220,32 +229,51 @@ final class HomeViewModel {
             return
         }
 
-        guard !allGenres.isEmpty else {
+        // Sort once so Home's row order matches the Settings picker order (both
+        // use the same comparator) and stays coherent across launches.
+        let sortedGenres = allGenres.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+
+        guard !sortedGenres.isEmpty else {
             genreRows = []
             return
         }
 
-        let picked = Array(allGenres.shuffled().prefix(4))
+        // User-configurable: the explicit picks (no cap), or a deterministic
+        // default set when unconfigured. Each row's item fetch is still bounded
+        // (limit 10) — we bound the fetch, not the number of rows.
+        let picked = HomeGenrePreferences.effectiveGenres(available: sortedGenres)
 
-        // Fetch items for each picked genre in parallel. Preserve the order of `picked`.
+        guard !picked.isEmpty else {
+            genreRows = []
+            return
+        }
+
+        // Fetch items for each picked genre. Since the row count is now
+        // user-driven (no cap), bound the fan-out to chunks of 6 so a large
+        // selection doesn't fire dozens of concurrent `getItems` at a
+        // self-hosted server at once. Order is rebuilt from `picked` afterwards.
         // Distinguish failure (→ retry chip) from empty success (→ drop the row).
         enum FetchResult { case success([BaseItemDto]); case failure }
+        let concurrencyLimit = 6
         var results: [String: FetchResult] = [:]
-        await withTaskGroup(of: (String, FetchResult).self) { group in
-            for genre in picked {
-                group.addTask {
-                    do {
-                        let items = try await Self.fetchGenreItems(
-                            genre: genre, userId: userId, appState: appState
-                        )
-                        return (genre, .success(items))
-                    } catch {
-                        return (genre, .failure)
+        for start in stride(from: 0, to: picked.count, by: concurrencyLimit) {
+            let chunk = picked[start..<min(start + concurrencyLimit, picked.count)]
+            await withTaskGroup(of: (String, FetchResult).self) { group in
+                for genre in chunk {
+                    group.addTask {
+                        do {
+                            let items = try await Self.fetchGenreItems(
+                                genre: genre, userId: userId, appState: appState
+                            )
+                            return (genre, .success(items))
+                        } catch {
+                            return (genre, .failure)
+                        }
                     }
                 }
-            }
-            for await (genre, result) in group {
-                results[genre] = result
+                for await (genre, result) in group {
+                    results[genre] = result
+                }
             }
         }
 
@@ -285,8 +313,8 @@ final class HomeViewModel {
             userId: userId,
             parentId: nil,
             includeItemTypes: [.movie, .series],
-            sortBy: [.random],
-            sortOrder: nil,
+            sortBy: [.dateCreated],
+            sortOrder: [.descending],
             genres: [genre],
             years: nil,
             isFavorite: nil,

--- a/Shared/ViewModels/MediaLibraryViewModel.swift
+++ b/Shared/ViewModels/MediaLibraryViewModel.swift
@@ -141,16 +141,17 @@ final class MediaLibraryViewModel {
             )
 
             // The hero query already returns the full `totalCount` (Jellyfin's
-            // `totalRecordCount` is the count before `limit`), so there's no need
-            // for a second random-sorted `limit: 1` call just for the title count
-            // — a random sort is a full shuffle server-side, paying for it twice
-            // per library load is pure waste.
+            // `totalRecordCount` is the count before `limit`), so a single fetch
+            // covers both the count and the hero item. Sort by `dateCreated`
+            // descending (newest first) rather than `.random`: a random sort is
+            // an un-indexed full shuffle the server re-runs on every load, and
+            // the coherent newest-first ordering is the intended behavior.
             async let heroResult = appState.apiClient.getItems(
                 userId: userId,
                 parentId: parentId,
                 includeItemTypes: typeFilter,
-                sortBy: [.random],
-                sortOrder: [.ascending],
+                sortBy: [.dateCreated],
+                sortOrder: [.descending],
                 limit: 20
             )
 
@@ -159,7 +160,7 @@ final class MediaLibraryViewModel {
 
             genres = fetchedGenres
             totalCount = heroData.totalCount
-            heroItem = heroData.items.randomElement()
+            heroItem = heroData.items.first
 
             try await fetchGenreItems(using: appState, userId: userId, genres: fetchedGenres)
             isLoading = false


### PR DESCRIPTION
## Summary

Three threads of work on top of `main`:

### 1. User-configurable Home genre rows
Settings → Interface → Home page now lets you choose exactly which genres surface as rows on Home.
- **iOS**: native `List` multi-select (forced edit mode), pushed from a "Choose genres" row.
- **tvOS**: focusable chips (`TVFilterChipButtonStyle`) inline in the Home page section.
- **Select all / Deselect all** on both (iOS toolbar button, tvOS capsule above the chips).
- Selection persists in `home.selectedGenres` `@AppStorage` (empty-string sentinel = unconfigured → deterministic default of 6 genres; explicit JSON otherwise), so the picker re-renders live in the extension-method settings context and Home refreshes its rows live on change.
- **No row cap** — the per-row item fetch is bounded instead, and the fan-out is capped to concurrency chunks of 6.

### 2. Cross-platform library landing layout
The "By genre" / "Show all" toggle (previously tvOS-only) is now on iOS too, as a full-width control in Settings → Appearance.
- Generalized `LibraryTVBrowseLayout`→`LibraryBrowseLayout` / `libraryTVBrowseLayout`→`libraryBrowseLayout` (raw `@AppStorage` key kept for preference continuity).
- Renamed the row to **Bibliothèque** / **Library** and stacked the two buttons under the label so the FR labels don't truncate at 100% font scale.

### 3. API performance
- **`getItem`**: 10s coalescing cache for the ~3× identical fetch burst at playback start; invalidated by the play-state / favorite mutators **and** `reportPlaybackStopped` so the detail screen's immediate post-dismiss reload still gets the fresh resume position.
- **`getSimilarItems`**: 5min cache (raw items cached, rating filter applied on read so a mid-session content-age change is honored).
- **`getGenres`**: switched the recursive `/Items/Filters` scan → `/Genres` direct table read (fallback to `/Items/Filters` when empty) — fixes slow/hang on large libraries.
- **Home/Library hero + genre-row items**: `.random` → `dateCreated desc`, dropping the un-indexed server-side full shuffle re-run on every load. (Search "Surprise Me" intentionally keeps `.random`.)

## Verification
- iOS + tvOS builds: **SUCCEEDED**.
- Full test suite: **129 tests / 25 suites passed**.
- Reviewed by the Swift 6 concurrency, tvOS focus, and Jellyfin API specialized reviewers — all findings addressed (the tvOS focus color-inversion on the new chips and the `getItem` stale-resume cache-coherence bug were both fixed).
- FR/EN localization parity holds; design-system sweep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)