### PR TITLE
docs: resolve App Store review (5.2.3 + 1.5)

### DIFF
--- a/docs/app-review-reply.md
+++ b/docs/app-review-reply.md
@@ -1,0 +1,52 @@
+# App Review — Resolution Center reply
+
+Copy-paste into App Store Connect → Resolution Center, then resubmit.
+Submission round addressing: Guideline 5.2.3 (Intellectual Property) and Guideline 1.5 (Safety / Support URL).
+
+---
+
+Hello,
+
+Thank you for the review. We have addressed both points.
+
+**Guideline 5.2.3 — Intellectual Property (offline downloads)**
+
+We would like to clarify how Cinemax works, and we have updated the App Store
+description to make this unambiguous.
+
+Cinemax is a third-party *client* for Jellyfin (jellyfin.org), a free, open-source,
+self-hosted media server. The app contains no media of its own and connects only to a
+Jellyfin server that the user installs and runs themselves. Every movie, episode and
+file shown in the app comes exclusively from the user's own personal server and their
+own library.
+
+The "offline" feature lets a user save videos *from their own Jellyfin server* onto
+their device so they can watch their personal library without a network connection (for
+example while travelling). It does not download, convert, or save media from any
+third-party service or source (such as Apple Music, YouTube, SoundCloud, Vimeo, etc.).
+There is no mechanism in the app to obtain content from anywhere other than the user's
+own self-hosted server, which they fully control and authorize.
+
+To remove any ambiguity, we have rewritten the relevant section of the description from
+"Download movies, episodes, seasons or full series" to clearly state that the feature
+provides offline access to the user's *own* library hosted on their *own* Jellyfin
+server, with no downloading from third-party sources. We also added a closing sentence
+stating that all videos come exclusively from the user's own server and that the app
+neither contains content nor allows downloading from third-party sources.
+
+This is the same model used by other self-hosted media-server clients on the App Store.
+
+**Guideline 1.5 — Support URL**
+
+We have created a dedicated support page with contact information, getting-started
+guidance and a FAQ, and updated the Support URL in App Store Connect to:
+
+https://b-raillard.github.io/Cinemax/support.html
+
+The page provides a support email address, instructions for getting help and reporting
+problems, and answers to common questions.
+
+Thank you, and please let us know if anything else is needed.
+
+Best regards,
+Bastien Raillard

--- a/docs/app-store-metadata.md
+++ b/docs/app-store-metadata.md
@@ -16,7 +16,7 @@ Document non public, sert de copy-paste source pour App Store Connect. Identique
 | **Catégorie secondaire** | **Divertissement** (Entertainment) |
 | **Copyright** | `2026 Bastien Raillard` |
 | **Email de contact** | `bastienraillard@gmail.com` |
-| **URL de support** | `https://github.com/b-raillard/Cinemax/issues` |
+| **URL de support** | `https://b-raillard.github.io/Cinemax/support.html` |
 | **URL marketing** *(optionnel)* | `https://github.com/b-raillard/Cinemax` |
 | **URL politique de confidentialité** | `https://b-raillard.github.io/Cinemax/privacy.html` |
 
@@ -32,9 +32,9 @@ Lecteur Jellyfin pour Apple
 
 ### Texte promotionnel (170 caractères max — modifiable sans review)
 ```
-Nouvelle version : lecteur VLC intégré pour la prise en charge native du MKV, du Dolby Vision et du HDR. Téléchargements hors-ligne sur iPhone et iPad.
+Nouvelle version : lecteur VLC intégré pour la prise en charge native du MKV, du Dolby Vision et du HDR. Accès hors ligne à votre médiathèque sur iPhone/iPad.
 ```
-*(159 caractères)*
+*(158 caractères)*
 
 ### Description (4000 caractères max)
 ```
@@ -55,8 +55,9 @@ Cinemax est un client moderne pour vos serveurs Jellyfin, conçu spécifiquement
 • AirPlay vers Apple TV et HomePod
 • Minuteur d'arrêt avec rappel « Toujours en train de regarder ? »
 
-— TÉLÉCHARGEMENTS HORS LIGNE (iPhone / iPad)
-• Téléchargez films, épisodes, saisons ou séries complètes
+— ACCÈS HORS LIGNE À VOTRE PROPRE MÉDIATHÈQUE (iPhone / iPad)
+• Enregistrez sur votre appareil les vidéos de votre propre serveur Jellyfin pour les regarder sans connexion (idéal en voyage)
+• Concerne uniquement votre médiathèque personnelle hébergée sur votre serveur — aucun téléchargement depuis des services ou sources tiers
 • Lecture sans connexion, dans la même interface que vos médias en ligne
 • Gestion fine de l'espace de stockage
 
@@ -83,7 +84,7 @@ Cinemax est un client moderne pour vos serveurs Jellyfin, conçu spécifiquement
 • Toutes les communications se font directement entre votre appareil et votre serveur Jellyfin
 • Code source ouvert : https://github.com/b-raillard/Cinemax
 
-Cinemax requiert un serveur Jellyfin déjà installé (jellyfin.org). L'application n'est ni développée ni soutenue par l'équipe officielle Jellyfin.
+Cinemax requiert un serveur Jellyfin déjà installé (jellyfin.org). Toutes les vidéos proviennent exclusivement de votre propre serveur : l'application ne contient aucun contenu et ne permet pas de télécharger des médias depuis des sources tierces. Cinemax n'est ni développé ni soutenu par l'équipe officielle Jellyfin.
 ```
 
 ### Mots-clés (100 caractères max, séparés par virgules, sans espace)
@@ -98,7 +99,7 @@ Première version publique de Cinemax !
 
 • Lecteur VLC intégré par défaut, prise en charge native du MKV, Dolby Vision et HDR
 • Picture-in-Picture sur iPhone et iPad
-• Téléchargements hors-ligne (iPhone / iPad)
+• Accès hors ligne à votre médiathèque personnelle (iPhone / iPad)
 • Interface optimisée pour la Siri Remote sur Apple TV
 • Tableau de bord d'administration complet sur iPhone et iPad
 • Skip Intro / Skip Crédits, chapitres, lecture automatique de l'épisode suivant
@@ -119,9 +120,9 @@ Jellyfin player for Apple
 
 ### Promotional Text (170 chars max)
 ```
-New release: built-in VLC engine for native MKV, Dolby Vision and HDR playback. Offline downloads on iPhone and iPad.
+New release: built-in VLC engine for native MKV, Dolby Vision and HDR playback. Offline access to your own library on iPhone and iPad.
 ```
-*(117 chars)*
+*(133 chars)*
 
 ### Description (4000 chars max)
 ```
@@ -142,8 +143,9 @@ Cinemax is a modern client for your Jellyfin media servers, designed specificall
 • AirPlay to Apple TV and HomePod
 • Sleep timer with "Still watching?" prompt
 
-— OFFLINE DOWNLOADS (iPhone / iPad)
-• Download movies, episodes, seasons or full series
+— OFFLINE ACCESS TO YOUR OWN LIBRARY (iPhone / iPad)
+• Save videos from your own Jellyfin server to your device to watch them without a connection (great for travel)
+• Applies only to your personal library hosted on your server — no downloading from any third-party service or source
 • Playback without connection, in the same interface as your online media
 • Fine-grained storage management
 
@@ -170,7 +172,7 @@ Cinemax is a modern client for your Jellyfin media servers, designed specificall
 • All communications happen directly between your device and your Jellyfin server
 • Open source: https://github.com/b-raillard/Cinemax
 
-Cinemax requires a Jellyfin server already running (jellyfin.org). This app is neither developed nor endorsed by the official Jellyfin team.
+Cinemax requires a Jellyfin server already running (jellyfin.org). All videos come exclusively from your own server: the app contains no content and does not allow downloading media from any third-party source. Cinemax is neither developed nor endorsed by the official Jellyfin team.
 ```
 
 ### Keywords (100 chars max, comma-separated, no spaces)
@@ -185,7 +187,7 @@ First public release of Cinemax!
 
 • Built-in VLC engine by default, native MKV, Dolby Vision and HDR support
 • Picture-in-Picture on iPhone and iPad
-• Offline downloads (iPhone / iPad)
+• Offline access to your own library (iPhone / iPad)
 • Siri Remote-optimized interface on Apple TV
 • Full administration dashboard on iPhone and iPad
 • Skip Intro / Skip Credits, chapters, autoplay next episode

--- a/docs/support.html
+++ b/docs/support.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Cinemax — Support / Aide</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 2rem 1.25rem 4rem;
+    line-height: 1.6;
+    color: #1c1c1e;
+    background: #fafafa;
+  }
+  @media (prefers-color-scheme: dark) {
+    body { color: #f2f2f7; background: #0c0c0e; }
+    a { color: #4ade80; }
+    hr { border-color: #2a2a2e; }
+    .card { background: #161618; }
+  }
+  h1 { font-size: 1.85rem; margin-bottom: 0.25rem; }
+  h2 { font-size: 1.3rem; margin-top: 2rem; border-bottom: 1px solid currentColor; padding-bottom: 0.25rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.5rem; }
+  .lang-switch { font-size: 0.9rem; margin-bottom: 1.5rem; }
+  .updated { color: #6b6b70; font-size: 0.9rem; }
+  hr { margin: 4rem 0; opacity: 0.3; }
+  a { color: #16a34a; }
+  .card {
+    background: #ffffff;
+    border-radius: 12px;
+    padding: 1rem 1.25rem;
+    margin: 1.25rem 0;
+  }
+  .card p { margin: 0.35rem 0; }
+  ul { padding-left: 1.25rem; }
+</style>
+</head>
+<body>
+
+<p class="lang-switch"><a href="#fr">Français</a> · <a href="#en">English</a></p>
+
+<section id="fr">
+<h1>Cinemax — Aide &amp; Support</h1>
+<p class="updated">Dernière mise à jour : 18 juin 2026</p>
+
+<p>
+  Cinemax est un client tiers pour les serveurs multimédias
+  <a href="https://jellyfin.org">Jellyfin</a>, pour iPhone, iPad et Apple TV.
+  Cette page vous explique comment obtenir de l'aide et répond aux questions
+  les plus fréquentes.
+</p>
+
+<div class="card">
+  <p><strong>Besoin d'aide ? Contactez-nous :</strong></p>
+  <p>📧 E-mail : <a href="mailto:bastienraillard@gmail.com">bastienraillard@gmail.com</a></p>
+  <p>🐛 Signaler un bug ou proposer une idée :
+     <a href="https://github.com/b-raillard/Cinemax/issues">github.com/b-raillard/Cinemax/issues</a></p>
+  <p>Nous répondons généralement aux e-mails sous 48 à 72 heures.</p>
+</div>
+
+<h2>Pour commencer</h2>
+<p>
+  Cinemax <strong>nécessite un serveur Jellyfin déjà installé</strong> et accessible
+  depuis votre appareil. L'application ne contient aucun contenu et ne fournit pas
+  de serveur : elle se connecte au serveur Jellyfin que <em>vous</em> hébergez et
+  affiche votre propre médiathèque.
+</p>
+<ul>
+  <li>Vous n'avez pas encore de serveur ? Consultez <a href="https://jellyfin.org">jellyfin.org</a> pour l'installer.</li>
+  <li>Au premier lancement, saisissez l'adresse de votre serveur (ex. <code>http://192.168.1.10:8096</code> ou votre URL distante).</li>
+  <li>Connectez-vous avec votre nom d'utilisateur et votre mot de passe Jellyfin, ou via Quick Connect.</li>
+</ul>
+
+<h2>Questions fréquentes</h2>
+
+<h3>L'application ne trouve pas mon serveur sur le réseau local</h3>
+<p>
+  Sur iPhone / iPad, autorisez l'accès au <strong>réseau local</strong> dans
+  Réglages → Cinemax. Vous pouvez aussi saisir manuellement l'adresse complète
+  de votre serveur (URL + port).
+</p>
+
+<h3>La lecture ne démarre pas ou l'image se fige</h3>
+<p>
+  Cinemax utilise le moteur VLC par défaut, qui prend en charge nativement la
+  plupart des formats (MKV, Dolby Vision, HDR). Si un fichier pose problème,
+  essayez le lecteur natif : Réglages → Interface → « Utiliser le lecteur natif ».
+  Vérifiez aussi que votre serveur Jellyfin est à jour et que sa connexion réseau
+  est stable.
+</p>
+
+<h3>À quoi sert le téléchargement hors ligne ?</h3>
+<p>
+  Sur iPhone et iPad, vous pouvez enregistrer sur votre appareil des vidéos
+  <strong>provenant de votre propre serveur Jellyfin</strong> afin de les regarder
+  sans connexion (par exemple en voyage). Cette fonction concerne uniquement votre
+  médiathèque personnelle hébergée sur votre serveur ; elle ne permet pas de
+  télécharger des contenus depuis des services ou des sources tierces. Les fichiers
+  téléchargés peuvent être supprimés à tout moment depuis l'écran « Téléchargements ».
+</p>
+
+<h3>Mes données sont-elles privées ?</h3>
+<p>
+  Oui. Cinemax ne collecte aucune donnée et n'utilise aucun service d'analyse ni de
+  publicité. Toutes les communications se font directement entre votre appareil et
+  votre serveur Jellyfin. Voir la
+  <a href="https://b-raillard.github.io/Cinemax/privacy.html">politique de confidentialité</a>.
+</p>
+
+<h3>Cinemax est-il affilié à Jellyfin ?</h3>
+<p>
+  Non. Cinemax est un client indépendant et open source. Il n'est ni développé ni
+  soutenu par l'équipe officielle Jellyfin.
+</p>
+
+<h2>Signaler un problème</h2>
+<p>
+  Pour signaler un bug, merci d'indiquer : le modèle de votre appareil et sa version
+  d'iOS / tvOS, la version de Cinemax, la version de votre serveur Jellyfin, et les
+  étapes pour reproduire le problème. Envoyez ces informations par
+  <a href="mailto:bastienraillard@gmail.com">e-mail</a> ou ouvrez une
+  <a href="https://github.com/b-raillard/Cinemax/issues">issue GitHub</a>.
+</p>
+</section>
+
+<hr>
+
+<section id="en">
+<h1>Cinemax — Help &amp; Support</h1>
+<p class="updated">Last updated: June 18, 2026</p>
+
+<p>
+  Cinemax is a third-party client for <a href="https://jellyfin.org">Jellyfin</a>
+  media servers, for iPhone, iPad and Apple TV. This page explains how to get help
+  and answers the most common questions.
+</p>
+
+<div class="card">
+  <p><strong>Need help? Contact us:</strong></p>
+  <p>📧 Email: <a href="mailto:bastienraillard@gmail.com">bastienraillard@gmail.com</a></p>
+  <p>🐛 Report a bug or request a feature:
+     <a href="https://github.com/b-raillard/Cinemax/issues">github.com/b-raillard/Cinemax/issues</a></p>
+  <p>We typically reply to emails within 48–72 hours.</p>
+</div>
+
+<h2>Getting started</h2>
+<p>
+  Cinemax <strong>requires a Jellyfin server that is already installed</strong> and
+  reachable from your device. The app contains no content and does not provide a
+  server: it connects to the Jellyfin server <em>you</em> host and displays your own
+  media library.
+</p>
+<ul>
+  <li>Don't have a server yet? See <a href="https://jellyfin.org">jellyfin.org</a> to set one up.</li>
+  <li>On first launch, enter your server address (e.g. <code>http://192.168.1.10:8096</code> or your remote URL).</li>
+  <li>Sign in with your Jellyfin username and password, or via Quick Connect.</li>
+</ul>
+
+<h2>Frequently asked questions</h2>
+
+<h3>The app can't find my server on the local network</h3>
+<p>
+  On iPhone / iPad, allow <strong>Local Network</strong> access in
+  Settings → Cinemax. You can also enter your server's full address (URL + port)
+  manually.
+</p>
+
+<h3>Playback won't start or the picture freezes</h3>
+<p>
+  Cinemax uses the VLC engine by default, which natively supports most formats
+  (MKV, Dolby Vision, HDR). If a file misbehaves, try the native player:
+  Settings → Interface → "Use Native Player". Also make sure your Jellyfin server
+  is up to date and its network connection is stable.
+</p>
+
+<h3>What are offline downloads for?</h3>
+<p>
+  On iPhone and iPad, you can save videos <strong>from your own Jellyfin server</strong>
+  to your device so you can watch them without a connection (for example while
+  travelling). This feature applies only to your personal media library hosted on your
+  server; it does not allow downloading content from any third-party service or source.
+  Downloaded files can be removed at any time from the "Downloads" screen.
+</p>
+
+<h3>Is my data private?</h3>
+<p>
+  Yes. Cinemax collects no data and uses no analytics or advertising. All
+  communication happens directly between your device and your Jellyfin server. See the
+  <a href="https://b-raillard.github.io/Cinemax/privacy.html">privacy policy</a>.
+</p>
+
+<h3>Is Cinemax affiliated with Jellyfin?</h3>
+<p>
+  No. Cinemax is an independent, open-source client. It is neither developed nor
+  endorsed by the official Jellyfin team.
+</p>
+
+<h2>Reporting a problem</h2>
+<p>
+  When reporting a bug, please include: your device model and its iOS / tvOS version,
+  the Cinemax version, your Jellyfin server version, and the steps to reproduce the
+  issue. Send this information by
+  <a href="mailto:bastienraillard@gmail.com">email</a> or open a
+  <a href="https://github.com/b-raillard/Cinemax/issues">GitHub issue</a>.
+</p>
+</section>
+
+</body>
+</html>


### PR DESCRIPTION
Fixes the two App Review rejection items so the app can be resubmitted.

## Guideline 1.5 — Support URL
Apple rejected the GitHub *issues* tab as the Support URL (a bug tracker, not a support page). This adds **`docs/support.html`** — a public FR/EN support page (contact email, getting-started guide, FAQ, bug-reporting instructions) served via GitHub Pages alongside the existing `privacy.html`.

**Action required after merge:** GitHub Pages serves from `main/docs`, so once merged the page is live at `https://b-raillard.github.io/Cinemax/support.html`. Set that as the Support URL in App Store Connect.

## Guideline 5.2.3 — Audio/Video downloading
Apple read "Téléchargez films, épisodes, saisons ou séries complètes" as a generic media downloader. Reworded the **description, promo text and What's New** (FR + EN) so the offline feature clearly reads as offline playback of the user's **own self-hosted Jellyfin library** — never third-party sources. Added a closing line stating all content comes exclusively from the user's own server.

## Also included
- `docs/app-review-reply.md` — ready-to-paste Resolution Center reply covering both guidelines.

## Note
Supersedes the stale, unmerged `claude/apple-store-review-feedback-dg9nac` branch (equivalent fix from a prior session, never merged). That branch can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)