### PR TITLE
fix(support page): readable contact card in dark mode

### DIFF
--- a/docs/support.html
+++ b/docs/support.html
@@ -15,12 +15,6 @@
     color: #1c1c1e;
     background: #fafafa;
   }
-  @media (prefers-color-scheme: dark) {
-    body { color: #f2f2f7; background: #0c0c0e; }
-    a { color: #4ade80; }
-    hr { border-color: #2a2a2e; }
-    .card { background: #161618; }
-  }
   h1 { font-size: 1.85rem; margin-bottom: 0.25rem; }
   h2 { font-size: 1.3rem; margin-top: 2rem; border-bottom: 1px solid currentColor; padding-bottom: 0.25rem; }
   h3 { font-size: 1.05rem; margin-top: 1.5rem; }
@@ -36,6 +30,13 @@
   }
   .card p { margin: 0.35rem 0; }
   ul { padding-left: 1.25rem; }
+  /* Dark-mode overrides last so they win over the light/base rules above. */
+  @media (prefers-color-scheme: dark) {
+    body { color: #f2f2f7; background: #0c0c0e; }
+    a { color: #4ade80; }
+    hr { border-color: #2a2a2e; }
+    .card { background: #161618; }
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
The contact card on the support page was unreadable in dark mode (white text on a white card).

**Cause:** the base `.card { background: #ffffff }` rule was declared *after* the `@media (prefers-color-scheme: dark)` block, so by CSS source-order it overrode the dark `.card { background: #161618 }`. The body text in dark mode is near-white, hence white-on-white.

**Fix:** move the dark-mode overrides to the end of the stylesheet so they win. `.card` is the only custom-background element, so nothing else was affected. Both light and dark modes are now readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)