### PR TITLE
fix(home): center hero carousel dots below action buttons

### DIFF
--- a/Shared/Screens/HomeScreen.swift
+++ b/Shared/Screens/HomeScreen.swift
@@ -397,7 +397,7 @@ struct HomeScreen: View {
                 }
             }
         }
-        .overlay(alignment: .bottomTrailing) {
+        .overlay(alignment: .bottom) {
             if candidates.count > 1 {
                 heroPageDots(count: candidates.count, active: active)
             }
@@ -421,8 +421,8 @@ struct HomeScreen: View {
                     .frame(width: 7, height: 7)
             }
         }
-        .padding(.trailing, heroPadding)
-        .padding(.bottom, heroPadding + CinemaSpacing.spacing6)
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, heroPadding)
         .allowsHitTesting(false)
         .accessibilityHidden(true)
     }


### PR DESCRIPTION
The iOS hero carousel page indicators were pinned to .bottomTrailing at the same vertical level as the Lecture / Plus d'infos buttons, so they overlapped and got clipped by the buttons row. Move them to a centered .bottom overlay that spans full width and sits just above the hero's bottom edge, below the action buttons.