### PR TITLE
fix(a11y): VoiceOver toggle semantics, Dynamic Type, and UX-state fixes

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -91,6 +91,7 @@
 "search.placeholder" = "Search movies, shows...";
 "search.listening" = "Listening...";
 "search.noResults" = "No results found";
+"search.error.network" = "Couldn't reach the server. Check your connection and try again.";
 "empty.library.filtered.title" = "No matches";
 "empty.library.filtered.subtitle" = "Try adjusting your filters or clearing them.";
 "empty.library.filtered.action" = "Clear filters";
@@ -626,6 +627,7 @@
 "settings.debug" = "Debug";
 "settings.debug.fastSleepTimer" = "Fast sleep timer (15 s)";
 "settings.debug.skipToEnd" = "Skip-to-end button";
+"debug.skipToEnd" = "⏭ Skip to end (Debug)";
 "settings.interface" = "Interface";
 "settings.interface.playback" = "Playback";
 "settings.interface.menu" = "Main Menu";
@@ -818,6 +820,7 @@
 
 "accessibility.playItem" = "Play %@";
 "accessibility.moreInfoAbout" = "More information about %@";
+"accessibility.resumeProgress" = "%d%% watched";
 
 // MARK: - Admin — formatting glyphs
 

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -91,6 +91,7 @@
 "search.placeholder" = "Rechercher des films, séries...";
 "search.listening" = "Écoute en cours...";
 "search.noResults" = "Aucun résultat";
+"search.error.network" = "Serveur injoignable. Vérifiez votre connexion et réessayez.";
 "empty.library.filtered.title" = "Aucun résultat";
 "empty.library.filtered.subtitle" = "Essayez d'ajuster vos filtres ou de les effacer.";
 "empty.library.filtered.action" = "Effacer les filtres";
@@ -228,6 +229,7 @@
 "settings.debug" = "Débogage";
 "settings.debug.fastSleepTimer" = "Veille rapide (15 s)";
 "settings.debug.skipToEnd" = "Bouton aller à la fin";
+"debug.skipToEnd" = "⏭ Aller à la fin (Debug)";
 "settings.interface" = "Interface";
 "settings.interface.playback" = "Lecture";
 "settings.interface.menu" = "Menu principal";
@@ -819,6 +821,7 @@
 
 "accessibility.playItem" = "Lire %@";
 "accessibility.moreInfoAbout" = "Plus d'informations sur %@";
+"accessibility.resumeProgress" = "%d %% regardé";
 
 // MARK: - Admin — formatting glyphs
 

--- a/Shared/Screens/Admin/ApiKeys/AdminApiKeysScreen.swift
+++ b/Shared/Screens/Admin/ApiKeys/AdminApiKeysScreen.swift
@@ -121,10 +121,10 @@ struct AdminApiKeysScreen: View {
                 .foregroundStyle(.orange)
             VStack(alignment: .leading, spacing: 3) {
                 Text(loc.localized("admin.apiKeys.warning.title"))
-                    .font(CinemaFont.label(.large))
+                    .font(CinemaFont.dynamicLabel(.large))
                     .foregroundStyle(CinemaColor.onSurface)
                 Text(loc.localized("admin.apiKeys.warning.message"))
-                    .font(CinemaFont.label(.small))
+                    .font(CinemaFont.dynamicLabel(.small))
                     .foregroundStyle(CinemaColor.onSurfaceVariant)
             }
             Spacer()
@@ -151,7 +151,7 @@ struct AdminApiKeysScreen: View {
                     VStack(alignment: .leading, spacing: 2) {
                         HStack(spacing: CinemaSpacing.spacing2) {
                             Text(key.appName ?? "—")
-                                .font(CinemaFont.label(.large))
+                                .font(CinemaFont.dynamicLabel(.large))
                                 .foregroundStyle(CinemaColor.onSurface)
                             if isCurrentSession {
                                 Text(loc.localized("admin.apiKeys.thisSession"))
@@ -168,7 +168,7 @@ struct AdminApiKeysScreen: View {
                                 format: loc.localized("admin.apiKeys.createdOn"),
                                 date.formatted(date: .abbreviated, time: .shortened)
                             ))
-                            .font(CinemaFont.label(.small))
+                            .font(CinemaFont.dynamicLabel(.small))
                             .foregroundStyle(CinemaColor.onSurfaceVariant)
                         }
                     }
@@ -246,12 +246,12 @@ struct AdminApiKeysScreen: View {
                     )
 
                     Text(loc.localized("admin.apiKeys.create.hint"))
-                        .font(CinemaFont.label(.small))
+                        .font(CinemaFont.dynamicLabel(.small))
                         .foregroundStyle(CinemaColor.onSurfaceVariant)
 
                     if let err = viewModel.createErrorMessage {
                         Text(err)
-                            .font(CinemaFont.label(.medium))
+                            .font(CinemaFont.dynamicLabel(.medium))
                             .foregroundStyle(CinemaColor.error)
                     }
 
@@ -306,7 +306,7 @@ struct AdminApiKeysScreen: View {
                                 .foregroundStyle(CinemaColor.onSurface)
                             if let name = key.appName {
                                 Text(name)
-                                    .font(CinemaFont.label(.medium))
+                                    .font(CinemaFont.dynamicLabel(.medium))
                                     .foregroundStyle(CinemaColor.onSurfaceVariant)
                             }
                         }
@@ -319,7 +319,7 @@ struct AdminApiKeysScreen: View {
 
                     VStack(alignment: .leading, spacing: CinemaSpacing.spacing2) {
                         Text(loc.localized("admin.apiKeys.created.tokenLabel"))
-                            .font(CinemaFont.label(.medium))
+                            .font(CinemaFont.dynamicLabel(.medium))
                             .foregroundStyle(CinemaColor.onSurfaceVariant)
 
                         Text(key.accessToken ?? "—")
@@ -343,7 +343,7 @@ struct AdminApiKeysScreen: View {
                     .padding(.top, CinemaSpacing.spacing2)
 
                     Text(loc.localized("admin.apiKeys.created.reminder"))
-                        .font(CinemaFont.label(.small))
+                        .font(CinemaFont.dynamicLabel(.small))
                         .foregroundStyle(.orange)
                 }
                 .padding(CinemaSpacing.spacing4)

--- a/Shared/Screens/Admin/Metadata/MetadataActionsTab.swift
+++ b/Shared/Screens/Admin/Metadata/MetadataActionsTab.swift
@@ -159,10 +159,13 @@ struct MetadataActionsTab: View {
         iOSSettingsRow {
             HStack {
                 Text(label)
-                    .font(CinemaFont.label(.large))
+                    .font(CinemaFont.dynamicLabel(.large))
                     .foregroundStyle(CinemaColor.onSurface)
                 Spacer()
-                Button { isOn.wrappedValue.toggle() } label: {
+                Button {
+                    isOn.wrappedValue.toggle()
+                    Haptics.tap()
+                } label: {
                     CinemaToggleIndicator(
                         isOn: isOn.wrappedValue,
                         accent: themeManager.accent,
@@ -170,6 +173,14 @@ struct MetadataActionsTab: View {
                     )
                 }
                 .buttonStyle(.plain)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(label)
+            .accessibilityValue(loc.localized(isOn.wrappedValue ? "a11y.toggle.on" : "a11y.toggle.off"))
+            .accessibilityAddTraits(.isToggle)
+            .accessibilityAction {
+                isOn.wrappedValue.toggle()
+                Haptics.tap()
             }
         }
     }

--- a/Shared/Screens/Admin/Metadata/MetadataEditorScreen.swift
+++ b/Shared/Screens/Admin/Metadata/MetadataEditorScreen.swift
@@ -177,7 +177,7 @@ struct MetadataGeneralTab: View {
             ) {
                 VStack(alignment: .leading, spacing: CinemaSpacing.spacing3) {
                     Text(loc.localized("admin.metadata.general.genres"))
-                        .font(CinemaFont.label(.small).weight(.bold))
+                        .font(CinemaFont.dynamicLabel(.small).weight(.bold))
                         .foregroundStyle(CinemaColor.onSurfaceVariant)
                     ChipEditor(
                         items: arrayBinding(\.genres),
@@ -185,7 +185,7 @@ struct MetadataGeneralTab: View {
                     )
 
                     Text(loc.localized("admin.metadata.general.tags"))
-                        .font(CinemaFont.label(.small).weight(.bold))
+                        .font(CinemaFont.dynamicLabel(.small).weight(.bold))
                         .foregroundStyle(CinemaColor.onSurfaceVariant)
                         .padding(.top, CinemaSpacing.spacing2)
                     ChipEditor(
@@ -194,7 +194,7 @@ struct MetadataGeneralTab: View {
                     )
 
                     Text(loc.localized("admin.metadata.general.studios"))
-                        .font(CinemaFont.label(.small).weight(.bold))
+                        .font(CinemaFont.dynamicLabel(.small).weight(.bold))
                         .foregroundStyle(CinemaColor.onSurfaceVariant)
                         .padding(.top, CinemaSpacing.spacing2)
                     ChipEditor(
@@ -227,7 +227,7 @@ struct MetadataGeneralTab: View {
         iOSSettingsRow {
             HStack {
                 Text(label)
-                    .font(CinemaFont.label(.medium))
+                    .font(CinemaFont.dynamicLabel(.medium))
                     .foregroundStyle(CinemaColor.onSurfaceVariant)
                     .frame(width: 110, alignment: .leading)
                 TextField(placeholder, text: binding)
@@ -242,7 +242,7 @@ struct MetadataGeneralTab: View {
         iOSSettingsRow {
             HStack {
                 Text(loc.localized("admin.metadata.general.year"))
-                    .font(CinemaFont.label(.medium))
+                    .font(CinemaFont.dynamicLabel(.medium))
                     .foregroundStyle(CinemaColor.onSurfaceVariant)
                     .frame(width: 110, alignment: .leading)
                 TextField("2024", text: yearBinding)
@@ -258,7 +258,7 @@ struct MetadataGeneralTab: View {
         iOSSettingsRow {
             HStack {
                 Text(label)
-                    .font(CinemaFont.label(.medium))
+                    .font(CinemaFont.dynamicLabel(.medium))
                     .foregroundStyle(CinemaColor.onSurfaceVariant)
                     .frame(width: 110, alignment: .leading)
                 if let date = binding.wrappedValue {
@@ -276,7 +276,7 @@ struct MetadataGeneralTab: View {
                         binding.wrappedValue = Date()
                     }
                     .foregroundStyle(themeManager.accent)
-                    .font(CinemaFont.label(.medium))
+                    .font(CinemaFont.dynamicLabel(.medium))
                 }
                 Spacer()
             }
@@ -287,7 +287,7 @@ struct MetadataGeneralTab: View {
         iOSSettingsRow {
             HStack {
                 Text(loc.localized("admin.metadata.general.communityRating"))
-                    .font(CinemaFont.label(.medium))
+                    .font(CinemaFont.dynamicLabel(.medium))
                     .foregroundStyle(CinemaColor.onSurfaceVariant)
                     .frame(width: 110, alignment: .leading)
                 TextField("7.5", text: communityRatingBinding)
@@ -295,7 +295,7 @@ struct MetadataGeneralTab: View {
                     .font(CinemaFont.body)
                     .foregroundStyle(CinemaColor.onSurface)
                 Text(loc.localized("admin.metadata.ratingDenominator"))
-                    .font(CinemaFont.label(.small))
+                    .font(CinemaFont.dynamicLabel(.small))
                     .foregroundStyle(CinemaColor.onSurfaceVariant)
             }
         }

--- a/Shared/Screens/Admin/Network/AdminNetworkScreen.swift
+++ b/Shared/Screens/Admin/Network/AdminNetworkScreen.swift
@@ -91,7 +91,7 @@ struct AdminNetworkScreen: View {
                 .font(.system(size: CinemaScale.pt(18)))
                 .foregroundStyle(.orange)
             Text(loc.localized("admin.network.warning"))
-                .font(CinemaFont.label(.small))
+                .font(CinemaFont.dynamicLabel(.small))
                 .foregroundStyle(CinemaColor.onSurfaceVariant)
             Spacer()
         }
@@ -225,7 +225,7 @@ struct AdminNetworkScreen: View {
             HStack {
                 iOSRowIcon(systemName: icon, color: themeManager.accent)
                 Text(label)
-                    .font(CinemaFont.label(.large))
+                    .font(CinemaFont.dynamicLabel(.large))
                     .foregroundStyle(CinemaColor.onSurface)
                 Spacer()
                 TextField("0", text: binding)
@@ -245,7 +245,7 @@ struct AdminNetworkScreen: View {
                 HStack(spacing: CinemaSpacing.spacing2) {
                     iOSRowIcon(systemName: icon, color: themeManager.accent)
                     Text(label)
-                        .font(CinemaFont.label(.large))
+                        .font(CinemaFont.dynamicLabel(.large))
                         .foregroundStyle(CinemaColor.onSurface)
                     Spacer()
                 }
@@ -262,19 +262,7 @@ struct AdminNetworkScreen: View {
 
     @ViewBuilder
     private func toggleRow(icon: String, label: String, binding: Binding<Bool>) -> some View {
-        iOSSettingsRow {
-            HStack {
-                iOSRowIcon(systemName: icon, color: themeManager.accent)
-                Text(label)
-                    .font(CinemaFont.label(.large))
-                    .foregroundStyle(CinemaColor.onSurface)
-                Spacer()
-                Button { binding.wrappedValue.toggle() } label: {
-                    CinemaToggleIndicator(isOn: binding.wrappedValue, accent: themeManager.accent, animated: motionEffects)
-                }
-                .buttonStyle(.plain)
-            }
-        }
+        iOSToggleRow(icon: icon, label: label, value: binding, accent: themeManager.accent, animated: motionEffects, loc: loc)
     }
 
     @ViewBuilder
@@ -282,7 +270,7 @@ struct AdminNetworkScreen: View {
         iOSSettingsRow {
             VStack(alignment: .leading, spacing: 2) {
                 Text(label)
-                    .font(CinemaFont.label(.medium))
+                    .font(CinemaFont.dynamicLabel(.medium))
                     .foregroundStyle(CinemaColor.onSurfaceVariant)
                 Text(value)
                     .font(.system(size: CinemaScale.pt(13), design: .monospaced))

--- a/Shared/Screens/Admin/Playback/AdminPlaybackScreen.swift
+++ b/Shared/Screens/Admin/Playback/AdminPlaybackScreen.swift
@@ -181,19 +181,7 @@ struct AdminPlaybackScreen: View {
 
     @ViewBuilder
     private func toggleRow(icon: String, label: String, binding: Binding<Bool>) -> some View {
-        iOSSettingsRow {
-            HStack {
-                iOSRowIcon(systemName: icon, color: themeManager.accent)
-                Text(label)
-                    .font(CinemaFont.label(.large))
-                    .foregroundStyle(CinemaColor.onSurface)
-                Spacer()
-                Button { binding.wrappedValue.toggle() } label: {
-                    CinemaToggleIndicator(isOn: binding.wrappedValue, accent: themeManager.accent, animated: motionEffects)
-                }
-                .buttonStyle(.plain)
-            }
-        }
+        iOSToggleRow(icon: icon, label: label, value: binding, accent: themeManager.accent, animated: motionEffects, loc: loc)
     }
 
     @ViewBuilder

--- a/Shared/Screens/Admin/Plugins/AdminPluginsScreen.swift
+++ b/Shared/Screens/Admin/Plugins/AdminPluginsScreen.swift
@@ -134,6 +134,9 @@ struct AdminPluginsScreen: View {
                             CinemaToggleIndicator(isOn: isEnabled, accent: themeManager.accent, animated: motionEffects)
                         }
                         .buttonStyle(.plain)
+                        .accessibilityLabel(plugin.name ?? "—")
+                        .accessibilityValue(loc.localized(isEnabled ? "a11y.toggle.on" : "a11y.toggle.off"))
+                        .accessibilityAddTraits(.isToggle)
                     }
 
                     if plugin.canUninstall == true {

--- a/Shared/Screens/Admin/Users/AdminUserDetailScreen.swift
+++ b/Shared/Screens/Admin/Users/AdminUserDetailScreen.swift
@@ -236,7 +236,7 @@ struct AdminUserDetailScreen: View {
                         color: isOn ? themeManager.accent : CinemaColor.onSurfaceVariant
                     )
                     Text(folder.name ?? "—")
-                        .font(CinemaFont.label(.large))
+                        .font(CinemaFont.dynamicLabel(.large))
                         .foregroundStyle(CinemaColor.onSurface)
                     Spacer()
                 }
@@ -257,7 +257,7 @@ struct AdminUserDetailScreen: View {
                     HStack {
                         iOSRowIcon(systemName: "person.badge.shield.checkmark", color: themeManager.accent)
                         Text(loc.localized("admin.user.parental.rating.label"))
-                            .font(CinemaFont.label(.large))
+                            .font(CinemaFont.dynamicLabel(.large))
                             .foregroundStyle(CinemaColor.onSurface)
                         Spacer()
                         Menu {
@@ -275,7 +275,7 @@ struct AdminUserDetailScreen: View {
                         } label: {
                             HStack(spacing: 4) {
                                 Text(currentParentalRatingLabel)
-                                    .font(CinemaFont.label(.large))
+                                    .font(CinemaFont.dynamicLabel(.large))
                                     .foregroundStyle(CinemaColor.onSurfaceVariant)
                                 Image(systemName: "chevron.up.chevron.down")
                                     .font(.system(size: CinemaScale.pt(11), weight: .semibold))
@@ -336,7 +336,7 @@ struct AdminUserDetailScreen: View {
 
                         if !viewModel.newPassword.isEmpty && !viewModel.passwordsMatch {
                             Text(loc.localized("admin.user.password.mismatch"))
-                                .font(CinemaFont.label(.medium))
+                                .font(CinemaFont.dynamicLabel(.medium))
                                 .foregroundStyle(CinemaColor.error)
                         }
 
@@ -371,7 +371,7 @@ struct AdminUserDetailScreen: View {
                             HStack {
                                 iOSRowIcon(systemName: "key.slash", color: CinemaColor.error)
                                 Text(loc.localized("admin.user.password.resetAction"))
-                                    .font(CinemaFont.label(.large))
+                                    .font(CinemaFont.dynamicLabel(.large))
                                     .foregroundStyle(CinemaColor.error)
                                 Spacer()
                             }
@@ -452,21 +452,33 @@ struct AdminUserDetailScreen: View {
                 iOSRowIcon(systemName: icon, color: themeManager.accent)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(label)
-                        .font(CinemaFont.label(.large))
+                        .font(CinemaFont.dynamicLabel(.large))
                         .foregroundStyle(disabled ? CinemaColor.onSurfaceVariant : CinemaColor.onSurface)
                     if disabled, let hint = disabledHint {
                         Text(hint)
-                            .font(CinemaFont.label(.small))
+                            .font(CinemaFont.dynamicLabel(.small))
                             .foregroundStyle(CinemaColor.onSurfaceVariant)
                     }
                 }
                 Spacer()
-                Button { isOn.wrappedValue.toggle() } label: {
+                Button {
+                    isOn.wrappedValue.toggle()
+                    Haptics.tap()
+                } label: {
                     CinemaToggleIndicator(isOn: isOn.wrappedValue, accent: themeManager.accent, animated: motionEffects)
                 }
                 .buttonStyle(.plain)
                 .disabled(disabled)
                 .opacity(disabled ? 0.5 : 1.0)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(label)
+            .accessibilityValue(loc.localized(isOn.wrappedValue ? "a11y.toggle.on" : "a11y.toggle.off"))
+            .accessibilityAddTraits(.isToggle)
+            .accessibilityAction {
+                guard !disabled else { return }
+                isOn.wrappedValue.toggle()
+                Haptics.tap()
             }
         }
     }

--- a/Shared/Screens/HomeScreen.swift
+++ b/Shared/Screens/HomeScreen.swift
@@ -389,6 +389,12 @@ struct HomeScreen: View {
         // Simultaneous (not exclusive) so button taps inside the hero still
         // land; the direction guard keeps vertical scrolls from switching heroes.
         .simultaneousGesture(heroSwipeGesture(count: candidates.count))
+        // VoiceOver three-finger swipe pages the carousel (the drag gesture above
+        // is invisible to assistive tech).
+        .accessibilityScrollAction { edge in
+            guard candidates.count > 1 else { return }
+            advanceHero(forward: edge == .trailing || edge == .bottom, count: candidates.count)
+        }
         // Task lifecycle is tied to the view — auto-cancels on disappear (pauses
         // rotation) and never strongly retains the screen. Restarts when the
         // candidate count or the motion-effects gate changes.
@@ -417,16 +423,22 @@ struct HomeScreen: View {
                 guard count > 1,
                       abs(value.translation.width) > abs(value.translation.height),
                       abs(value.translation.width) > 50 else { return }
-                let forward = value.translation.width < 0
-                let next = forward
-                    ? (currentHeroIndex + 1) % count
-                    : (currentHeroIndex - 1 + count) % count
-                if motionEffects {
-                    withAnimation(.easeInOut(duration: 0.5)) { heroIndex = next }
-                } else {
-                    heroIndex = next
-                }
+                advanceHero(forward: value.translation.width < 0, count: count)
             }
+    }
+
+    /// Pages the hero carousel one step, wrapping at the ends. Shared by the
+    /// touch swipe gesture and the VoiceOver scroll action.
+    private func advanceHero(forward: Bool, count: Int) {
+        guard count > 1 else { return }
+        let next = forward
+            ? (currentHeroIndex + 1) % count
+            : (currentHeroIndex - 1 + count) % count
+        if motionEffects {
+            withAnimation(.easeInOut(duration: 0.5)) { heroIndex = next }
+        } else {
+            heroIndex = next
+        }
     }
 
     /// Advances the hero every `heroRotationInterval` seconds with a crossfade.
@@ -670,6 +682,11 @@ struct HomeScreen: View {
                 guard let ticks = item.userData?.playbackPositionTicks, ticks > 0 else { return nil }
                 return Double(ticks) / 10_000_000
             }()
+            let resumePercent: Int? = {
+                guard let position = item.userData?.playbackPositionTicks,
+                      let total = item.runTimeTicks, total > 0, position > 0 else { return nil }
+                return Int((Double(position) / Double(total) * 100).rounded())
+            }()
             PlayLink(
                 itemId: id, title: item.name ?? "",
                 startTime: startSeconds,
@@ -701,6 +718,7 @@ struct HomeScreen: View {
                 }
             }
             .accessibilityLabel(item.name ?? "")
+            .accessibilityValue(resumePercent.map { String(format: loc.localized("accessibility.resumeProgress"), $0) } ?? "")
         }
     }
 

--- a/Shared/Screens/LibrarySortFilterSheet.swift
+++ b/Shared/Screens/LibrarySortFilterSheet.swift
@@ -240,6 +240,7 @@ struct LibrarySortFilterSheet: View {
 
             let row = Button {
                 sortFilter.showUnwatchedOnly.toggle()
+                Haptics.tap()
             } label: {
                 HStack {
                     Text(loc.localized("filter.unwatchedOnly"))
@@ -256,6 +257,14 @@ struct LibrarySortFilterSheet: View {
                 .padding(.vertical, CinemaSpacing.spacing3)
                 .background(CinemaColor.surfaceContainerHigh)
                 .clipShape(RoundedRectangle(cornerRadius: CinemaRadius.large))
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(loc.localized("filter.unwatchedOnly"))
+            .accessibilityValue(loc.localized(sortFilter.showUnwatchedOnly ? "a11y.toggle.on" : "a11y.toggle.off"))
+            .accessibilityAddTraits(.isToggle)
+            .accessibilityAction {
+                sortFilter.showUnwatchedOnly.toggle()
+                Haptics.tap()
             }
 
             #if os(tvOS)

--- a/Shared/Screens/NativeVideoPresenter.swift
+++ b/Shared/Screens/NativeVideoPresenter.swift
@@ -415,7 +415,7 @@ final class NativeVideoPresenter {
         // can actually reach it via the Siri Remote.
         if UserDefaults.standard.bool(forKey: SettingsKey.debugShowSkipToEnd) {
             items.append(UIAction(
-                title: "⏭ Skip to End (Debug)",
+                title: loc.localized("debug.skipToEnd"),
                 image: UIImage(systemName: "forward.end.alt.fill")
             ) { [weak self] _ in
                 Task { @MainActor [weak self] in

--- a/Shared/Screens/SearchScreen.swift
+++ b/Shared/Screens/SearchScreen.swift
@@ -212,6 +212,17 @@ struct SearchScreen: View {
             Spacer()
             LoadingStateView()
             Spacer()
+        } else if viewModel.searchFailed && viewModel.hasSearched {
+            // Distinct from "no results": the fetch never reached the server, so
+            // offer a retry rather than implying the library has no matches.
+            Spacer()
+            ErrorStateView(
+                message: loc.localized("search.error.network"),
+                retryTitle: loc.localized("action.retry")
+            ) {
+                viewModel.search(using: appState)
+            }
+            Spacer()
         } else if viewModel.results.isEmpty && viewModel.hasSearched {
             Spacer()
             VStack(spacing: CinemaSpacing.spacing3) {

--- a/Shared/Screens/Settings/MenuSettingsScreen+iOS.swift
+++ b/Shared/Screens/Settings/MenuSettingsScreen+iOS.swift
@@ -195,6 +195,9 @@ extension MenuSettingsScreen {
                 // List row — `.plain` lets the row's tap-handler swallow it.
                 .buttonStyle(.borderless)
                 .sensoryFeedback(.selection, trigger: entry.enabled)
+                .accessibilityLabel(entryLabel(entry))
+                .accessibilityValue(loc.localized(entry.enabled ? "a11y.toggle.on" : "a11y.toggle.off"))
+                .accessibilityAddTraits(.isToggle)
             }
         }
         .padding(.vertical, 2)

--- a/Shared/Screens/Settings/SettingsAppearanceView+iOS.swift
+++ b/Shared/Screens/Settings/SettingsAppearanceView+iOS.swift
@@ -29,15 +29,26 @@ struct IOSAppearanceDetailView: View {
                         iOSRowIcon(systemName: themeManager.darkModeEnabled ? "moon.fill" : "sun.max.fill", color: themeManager.accent)
 
                         Text(themeManager.darkModeEnabled ? loc.localized("settings.darkMode") : loc.localized("settings.lightMode"))
-                            .font(CinemaFont.label(.large))
+                            .font(CinemaFont.dynamicLabel(.large))
                             .foregroundStyle(CinemaColor.onSurface)
 
                         Spacer()
 
-                        Button { themeManager.darkModeEnabled.toggle() } label: {
+                        Button {
+                            themeManager.darkModeEnabled.toggle()
+                            Haptics.tap()
+                        } label: {
                             CinemaToggleIndicator(isOn: themeManager.darkModeEnabled, accent: themeManager.accent, animated: motionEffects)
                         }
                         .buttonStyle(.plain)
+                    }
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(loc.localized("settings.darkMode"))
+                    .accessibilityValue(loc.localized(themeManager.darkModeEnabled ? "a11y.toggle.on" : "a11y.toggle.off"))
+                    .accessibilityAddTraits(.isToggle)
+                    .accessibilityAction {
+                        themeManager.darkModeEnabled.toggle()
+                        Haptics.tap()
                     }
                 }
 
@@ -49,7 +60,7 @@ struct IOSAppearanceDetailView: View {
                             iOSRowIcon(systemName: "paintpalette.fill", color: selectedAccent.color)
 
                             Text(loc.localized("settings.accentColor"))
-                                .font(CinemaFont.label(.large))
+                                .font(CinemaFont.dynamicLabel(.large))
                                 .foregroundStyle(CinemaColor.onSurface)
 
                             Spacer()
@@ -71,7 +82,7 @@ struct IOSAppearanceDetailView: View {
                         iOSRowIcon(systemName: "globe", color: themeManager.accent)
 
                         Text(loc.localized("settings.language"))
-                            .font(CinemaFont.label(.large))
+                            .font(CinemaFont.dynamicLabel(.large))
                             .foregroundStyle(CinemaColor.onSurface)
 
                         Spacer()
@@ -87,16 +98,26 @@ struct IOSAppearanceDetailView: View {
                         iOSRowIcon(systemName: "sparkles", color: themeManager.accent)
 
                         Text(loc.localized("settings.motionEffects"))
-                            .font(CinemaFont.label(.large))
+                            .font(CinemaFont.dynamicLabel(.large))
                             .foregroundStyle(CinemaColor.onSurface)
 
                         Spacer()
 
-                        Button { motionEffectsStorage.toggle() } label: {
+                        Button {
+                            motionEffectsStorage.toggle()
+                            Haptics.tap()
+                        } label: {
                             CinemaToggleIndicator(isOn: motionEffectsStorage, accent: themeManager.accent, animated: motionEffectsStorage)
                         }
                         .buttonStyle(.plain)
-                        .sensoryFeedback(.selection, trigger: motionEffectsStorage)
+                    }
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(loc.localized("settings.motionEffects"))
+                    .accessibilityValue(loc.localized(motionEffectsStorage ? "a11y.toggle.on" : "a11y.toggle.off"))
+                    .accessibilityAddTraits(.isToggle)
+                    .accessibilityAction {
+                        motionEffectsStorage.toggle()
+                        Haptics.tap()
                     }
                 }
 
@@ -106,7 +127,7 @@ struct IOSAppearanceDetailView: View {
                     HStack {
                         iOSRowIcon(systemName: "textformat.size", color: themeManager.accent)
                         Text(loc.localized("settings.fontSize"))
-                            .font(CinemaFont.label(.large))
+                            .font(CinemaFont.dynamicLabel(.large))
                             .foregroundStyle(CinemaColor.onSurface)
                         Spacer()
                         Stepper(
@@ -139,7 +160,7 @@ struct IOSAppearanceDetailView: View {
                         HStack {
                             iOSRowIcon(systemName: "square.grid.2x2", color: themeManager.accent)
                             Text(loc.localized("settings.libraryLayout"))
-                                .font(CinemaFont.label(.large))
+                                .font(CinemaFont.dynamicLabel(.large))
                                 .foregroundStyle(CinemaColor.onSurface)
                             Spacer()
                         }

--- a/Shared/Screens/Settings/SettingsScreen+tvOS.swift
+++ b/Shared/Screens/Settings/SettingsScreen+tvOS.swift
@@ -691,6 +691,15 @@ extension SettingsScreen {
         .focusEffectDisabled()
         .hoverEffectDisabled()
         .focused($focusedItem, equals: .toggle(key))
+        // Collapse the row into one VoiceOver element announcing label + on/off
+        // state + toggle semantics (the CinemaToggleIndicator is purely visual).
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(label)
+        .accessibilityValue(loc.localized(value.wrappedValue ? "a11y.toggle.on" : "a11y.toggle.off"))
+        .accessibilityAddTraits(.isToggle)
+        .accessibilityAction {
+            value.wrappedValue.toggle()
+        }
     }
 
     // MARK: - tvOS Helpers

--- a/Shared/ViewModels/SearchViewModel.swift
+++ b/Shared/ViewModels/SearchViewModel.swift
@@ -220,6 +220,10 @@ final class SearchViewModel {
     var results: [BaseItemDto] = []
     var isSearching = false
     var hasSearched = false
+    /// True when the last search failed to reach the server (every term fetch
+    /// threw) rather than legitimately returning zero matches — lets the view
+    /// show a retryable error state distinct from the "no results" empty state.
+    var searchFailed = false
 
     /// Most-recent-first queries shown as chips on the empty search screen.
     /// Persisted as JSON under `SettingsKey.searchRecentQueries`; mutate only
@@ -327,6 +331,7 @@ final class SearchViewModel {
         guard !query.isEmpty else {
             results = []
             hasSearched = false
+            searchFailed = false
             return
         }
 
@@ -342,14 +347,16 @@ final class SearchViewModel {
             // UI can remain stuck on the spinner after a quick text change.
             defer { self?.isSearching = false }
 
-            let ranked = await Self.fetchRanked(query: query, userId: userId, api: api)
+            let outcome = await Self.fetchRanked(query: query, userId: userId, api: api)
             guard !Task.isCancelled else { return }
-            self?.results = ranked
+            self?.results = outcome.items
+            self?.searchFailed = outcome.failed
             self?.hasSearched = true
             // Only remember queries that produced something — a typo midway
             // through "missio" shouldn't pollute the history, and the debounce
-            // already collapses keystroke noise into the final query.
-            if !ranked.isEmpty {
+            // already collapses keystroke noise into the final query. A failed
+            // fetch never records (the query may be perfectly valid).
+            if !outcome.failed && !outcome.items.isEmpty {
                 self?.recordRecentSearch(query)
             }
         }
@@ -410,7 +417,7 @@ final class SearchViewModel {
         query: String,
         userId: String,
         api: any LibraryAPI
-    ) async -> [BaseItemDto] {
+    ) async -> (items: [BaseItemDto], failed: Bool) {
         let normalizedQuery = normalizeForMatch(query)
         // Drop stop words so per-word fetches and the word-presence tiers stay
         // meaningful — otherwise "the"/"le"/"de" alone match hundreds of titles.
@@ -429,19 +436,27 @@ final class SearchViewModel {
         if words.count > 1 { terms.append(contentsOf: words.prefix(4)) }
         let uniqueTerms = Array(Set(terms))
 
+        // Each task returns nil when its fetch threw. If EVERY term fetch throws
+        // (server unreachable / dropped mid-query) we surface a failure so the UI
+        // can distinguish "couldn't reach the server" from a legitimate zero-match.
         var candidates: [String: BaseItemDto] = [:]
-        await withTaskGroup(of: [BaseItemDto].self) { group in
+        var anySucceeded = false
+        await withTaskGroup(of: [BaseItemDto]?.self) { group in
             for term in uniqueTerms {
                 group.addTask {
-                    (try? await api.searchItems(userId: userId, searchTerm: term, limit: 30)) ?? []
+                    try? await api.searchItems(userId: userId, searchTerm: term, limit: 30)
                 }
             }
-            for await items in group {
+            for await result in group {
+                guard let items = result else { continue }
+                anySucceeded = true
                 for item in items where item.id != nil {
                     candidates[item.id!] = item
                 }
             }
         }
+
+        let failed = !uniqueTerms.isEmpty && !anySucceeded
 
         let scored = candidates.values.compactMap { item -> (item: BaseItemDto, score: Double)? in
             let score = max(
@@ -450,7 +465,7 @@ final class SearchViewModel {
             )
             return score > 0 ? (item, score) : nil
         }
-        return scored.sorted { $0.score > $1.score }.map(\.item)
+        return (scored.sorted { $0.score > $1.score }.map(\.item), failed)
     }
 
     /// Weighted relevance of one title against the query. 0 = no match (filtered out).


### PR DESCRIPTION
## What

Accessibility, Dynamic Type, and UX-state fixes from the audit (theme: a11y/UX). All items implemented with the smallest maintainable diff.

- **P1.1** — tvOS `tvGlassToggle` now announces state + toggle semantics to VoiceOver (`accessibilityElement/Label/Value(a11y.toggle.on|off)/isToggle` + action), mirroring `iOSToggleRow`. Previously read as a plain "button".
- **P1.2** — 9 hand-rolled iOS toggle sites brought into the documented VoiceOver toggle pattern + `Haptics.tap()`:
  - Dark Mode, Motion Effects (`SettingsAppearanceView+iOS`)
  - Admin Network / Playback (routed through the shared `iOSToggleRow` helper), User detail, Metadata actions
  - Library "Unwatched only" (`LibrarySortFilterSheet`)
  - The two previously label-less cases — `AdminPluginsScreen` (plugin toggle, labeled with the plugin name) and `MenuSettingsScreen+iOS` (menu-entry toggle) — now carry a proper `accessibilityLabel`.
- **P1.5** — Search failures are now distinguishable from "no results". `SearchViewModel.fetchRanked` returns a `failed` flag (true only when *every* term fetch throws) without restructuring the ranking; `SearchScreen` shows a retryable `ErrorStateView` with a localized network message instead of the empty-matches state.
- **P1.6** — Reading-heavy settings/admin rows swap `CinemaFont.label(...)` → `dynamicLabel(...)` so they honor OS Dynamic Type (`SettingsAppearanceView+iOS` 6, `AdminUserDetailScreen` 7, `AdminApiKeysScreen` 9, `MetadataEditorScreen` 9, `AdminNetworkScreen` — the toggle-row site now goes through `iOSToggleRow`/`dynamicLabel`, remaining 4 swapped). **Card titles (`PosterCard`/`WideCard`) descoped**: they sit in fixed-width carousels and `PosterCard` relies on a font-matched hidden placeholder for uniform row height — accessibility sizes would break row alignment/truncation (consistent with the CLAUDE.md "hero/display titles keep fixed fonts" rule).
- **P2.9a** — Hero carousel pages via `.accessibilityScrollAction` (VoiceOver three-finger swipe); shared paging logic with the touch gesture.
- **P2.9b** — Continue-Watching card announces resume progress percent via `accessibilityValue`.
- **P2.9c** — Localized the hardcoded debug "⏭ Skip to End" in-player action title.

## Localization

New keys added to **both** FR + EN (parity 709/709): `search.error.network`, `debug.skipToEnd`, `accessibility.resumeProgress`.

## Constraints respected

No offline-download surface; extension-session dual-write untouched; Watch Together stays gated; no VLCKitSPM; TrueHD/`checkForVideoStall` not touched. No new files / no `project.yml` change → no xcodegen regen needed.

## Build evidence

Both run serially, each `** BUILD SUCCEEDED **`:
- iOS — `Cinemax` scheme, iPhone 17 Pro simulator
- tvOS — `CinemaxTV` scheme, Apple TV 4K (3rd generation) simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)