### PR TITLE
fix(tests): deflake PlaybackReporter startFires under CI load

### DIFF
--- a/Tests/CinemaxKitTests/PlaybackReporterTests.swift
+++ b/Tests/CinemaxKitTests/PlaybackReporterTests.swift
@@ -65,7 +65,11 @@ struct PlaybackReporterTests {
         )
 
         reporter.reportStart(startTime: nil)
-        try await Task.sleep(for: .milliseconds(30))
+        // The API call rides a Task.detached — on a loaded CI host a fixed
+        // sleep races its scheduling, so poll (bounded) for the effect instead.
+        for _ in 0..<200 where mock.startCount == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
         #expect(mock.startCount == 1)
     }
 


### PR DESCRIPTION
## What

`startFires` asserted `mock.startCount == 1` after a fixed 30ms sleep, but `PlaybackReporter.reportStart` dispatches its API call via `Task.detached` — on a loaded CI host the detached task may not have been scheduled within 30ms, failing the suite intermittently. Seen on PR #60's Build & Test re-run (`Expectation failed: (mock.startCount → 0) == 1`) on a diff that doesn't touch the reporter at all.

## Fix

Replace the fixed sleep with a bounded poll (up to ~2s, returns as soon as the count lands). The `== 0` no-op assertions keep their short sleeps: under load they can only false-pass, never flake-fail, and lengthening them would just slow the suite.

## Notes

- Test-only change; no product code touched.
- Recommend merging this first — every open PR's Build & Test rolls this dice until it lands on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)