### PR TITLE
perf: audit small fixes — cache key scoping, prefetch reset, memoization, VLC teardown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ docs/design-system/         Canonical design system reference
 
 ### Custom menu / dynamic tabs (`MenuConfigStore`)
 
-`MainTabView` consumes `menuConfig.resolvedTabs` (computed from `mode` / `customKind` / persisted entry arrays / `availableViews` cache). Three modes:
+`MainTabView` consumes `menuConfig.resolvedTabs` (a memoized `private(set)` stored cache of the resolution of `mode` / `customKind` / persisted entry arrays / `availableViews`; recomputed via `recomputeResolvedTabs()` at the end of every mutator that changes an input — `setMode`, `setCustomKind`, `toggleInternal`, `move`, `moveBy`, `reset`, `refreshAvailableViews`, `invalidateViews`, plus `init` — NEVER a `didSet`, per the `@Observable` RULE; the recompute is equality-guarded so an idempotent refresh fires no spurious re-render). Three modes:
 
 - **`.default`** — the canonical 5 tabs (Home, Movies, TV Shows, Search, Settings).
 - **`.custom + .contentType`** — user picks which of the canonical 5 are enabled and in what order.

--- a/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient+Library.swift
+++ b/Packages/CinemaxKit/Sources/CinemaxKit/Networking/JellyfinAPIClient+Library.swift
@@ -51,7 +51,7 @@ extension JellyfinAPIClient {
     }
 
     public func getLatestMedia(userId: String, parentId: String? = nil, limit: Int = 16) async throws -> [BaseItemDto] {
-        let cacheKey = "latest-\(userId)-\(limit)-\(getMaxContentAge())"
+        let cacheKey = "latest-\(userId)-\(parentId ?? "all")-\(limit)-\(getMaxContentAge())"
         if let cached: [BaseItemDto] = cache.get(cacheKey) { return cached }
 
         do {

--- a/Shared/Navigation/MenuConfig.swift
+++ b/Shared/Navigation/MenuConfig.swift
@@ -143,6 +143,19 @@ final class MenuConfigStore {
     /// renders on an offline launch without a network call.
     var availableViews: [LibraryView]
 
+    /// Memoized final tab list for `MainTabView` — the resolution of `mode` /
+    /// `customKind` / entry arrays / `availableViews`. Recomputed by
+    /// `recomputeResolvedTabs()` at the end of every mutator that changes an
+    /// input (see that method); consumers read this stored value so Observation
+    /// re-renders them exactly when the resolved tabs change. `private(set)` so
+    /// only the store's mutators can publish a new value.
+    ///
+    /// No truncation/cap — SwiftUI's `TabView` on iPhone in compact width
+    /// natively creates an overflow ("More") tab when the count exceeds 5,
+    /// rendered with the iOS 26 liquid-glass treatment. We don't replace that
+    /// behaviour with a custom synthetic tab.
+    private(set) var resolvedTabs: [ResolvedTab] = []
+
     var isLoadingViews: Bool = false
     var lastFetchError: String?
 
@@ -162,6 +175,9 @@ final class MenuConfigStore {
         self.contentTypeEntries = Self.applyCap(to: storedContentType)
         self.libraryEntries = Self.applyCap(to: storedLibrary)
         self.availableViews = Self.load([LibraryView].self, forKey: SettingsKey.menuCachedViews) ?? []
+        // Seed the memoized tab list from the restored state (all stored
+        // properties are initialized by this point).
+        recomputeResolvedTabs()
     }
 
     /// Trims the enabled flags of `entries` so the total enabled count does
@@ -190,12 +206,14 @@ final class MenuConfigStore {
     func setMode(_ value: Mode) {
         mode = value
         Self.persist(value.rawValue, forKey: SettingsKey.menuMode)
+        recomputeResolvedTabs()
     }
 
     func setCustomKind(_ value: CustomKind) {
         customKind = value
         Self.persist(value.rawValue, forKey: SettingsKey.menuCustomKind)
         if value == .library { ensureLibraryEntriesPopulated() }
+        recomputeResolvedTabs()
     }
 
     func attach(apiClient: any APIClientProtocol, userId: String?) {
@@ -270,6 +288,7 @@ final class MenuConfigStore {
         copy[idx].enabled.toggle()
         self[keyPath: keyPath] = copy
         persist()
+        recomputeResolvedTabs()
         return wantsEnable ? .enabled : .disabled
     }
 
@@ -287,6 +306,7 @@ final class MenuConfigStore {
             libraryEntries = copy
             persistLibraryEntries()
         }
+        recomputeResolvedTabs()
     }
 
     /// tvOS bridge — swap with neighbor at `delta` offset (-1 = up, +1 = down).
@@ -309,6 +329,9 @@ final class MenuConfigStore {
             libraryEntries = copy
             persistLibraryEntries()
         }
+        // Only reached on a successful swap — the guards above `return` early
+        // when nothing moved, so this never recomputes for a no-op.
+        recomputeResolvedTabs()
     }
 
     // MARK: - Persistence (explicit)
@@ -336,6 +359,7 @@ final class MenuConfigStore {
         Self.persist(customKind.rawValue, forKey: SettingsKey.menuCustomKind)
         persistContentTypeEntries()
         persistLibraryEntries()
+        recomputeResolvedTabs()
     }
 
     // MARK: - Views fetching
@@ -380,6 +404,10 @@ final class MenuConfigStore {
                 libraryEntries = merged
                 persistLibraryEntries()
             }
+            // Refresh the memoized tab list; the equality guard inside makes a
+            // same-views refresh a no-op (no spurious re-render), preserving the
+            // idempotence the two guards above establish.
+            recomputeResolvedTabs()
         } catch {
             guard gen == refreshGeneration else { return }
             lastFetchError = "\(error)"
@@ -394,6 +422,7 @@ final class MenuConfigStore {
         libraryEntries = []
         persistAvailableViews()
         persistLibraryEntries()
+        recomputeResolvedTabs()
     }
 
     private func ensureLibraryEntriesPopulated() {
@@ -478,14 +507,25 @@ final class MenuConfigStore {
 
     // MARK: - Resolution
 
-    /// Final tab list for `MainTabView`. Reactive: any mutation that updates
-    /// the entries / mode / customKind / availableViews recomputes this.
-    ///
-    /// No truncation/cap — SwiftUI's `TabView` on iPhone in compact width
-    /// natively creates an overflow ("More") tab when the count exceeds 5,
-    /// rendered with the iOS 26 liquid-glass treatment. We don't replace
-    /// that behaviour with a custom synthetic tab.
-    var resolvedTabs: [ResolvedTab] {
+    /// Recomputes `resolvedTabs` and publishes it only when the value actually
+    /// changed. The equality guard mirrors the `availableViews`/`libraryEntries`
+    /// guards in `refreshAvailableViews` — an idempotent mutation (e.g. a repeat
+    /// refresh with the same views) must NOT fire a spurious `@Observable`
+    /// notification (which previously surfaced as a "redirected to Home"
+    /// flicker on iOS). Because inputs never carry `didSet` (see the RULE on
+    /// `@Observable` + property observers), every mutator that changes an
+    /// input to the resolution calls this at its end: `setMode`,
+    /// `setCustomKind`, `toggleInternal`, `move`, `moveBy`, `reset`,
+    /// `refreshAvailableViews`, `invalidateViews`, plus `init`.
+    private func recomputeResolvedTabs() {
+        let updated = computeResolvedTabs()
+        if updated != resolvedTabs { resolvedTabs = updated }
+    }
+
+    /// Pure derivation of the tab list from the current mode / customKind /
+    /// entry arrays / `availableViews`. Never observed directly — consumers
+    /// read the memoized `resolvedTabs` instead.
+    private func computeResolvedTabs() -> [ResolvedTab] {
         switch mode {
         case .default: return defaultResolved
         case .custom:

--- a/Shared/Screens/FavoritesScreen.swift
+++ b/Shared/Screens/FavoritesScreen.swift
@@ -103,7 +103,10 @@ struct FavoritesScreen: View {
             Task { await viewModel.load(using: appState) }
         }
         .onReceive(NotificationCenter.default.publisher(for: .cinemaxShouldRefreshCatalogue)) { _ in
-            Task { await viewModel.load(using: appState) }
+            Task {
+                prefetcher.reset()
+                await viewModel.load(using: appState)
+            }
         }
         // A per-item watched/resume toggle (tier-2) — reload immediately so an
         // un-watch drops the item while this grid is on screen.

--- a/Shared/Screens/HomeScreen.swift
+++ b/Shared/Screens/HomeScreen.swift
@@ -250,8 +250,15 @@ struct HomeScreen: View {
                     // as a plain static hero. The carousel carries the
                     // scroll-anchor `id` so the tab-bar pill heuristic is
                     // unchanged (still no leading gap above the first row).
-                    if !heroCandidates.isEmpty {
-                        heroCarousel
+                    //
+                    // Evaluate `heroCandidates` ONCE per render and thread the
+                    // result down: the property loops over resume+latest and
+                    // builds a Set, and was previously recomputed here (the
+                    // emptiness check), inside the carousel body, and via the
+                    // index clamp.
+                    let heroCandidateList = heroCandidates
+                    if !heroCandidateList.isEmpty {
+                        heroCarousel(heroCandidateList)
                             .id(scrollTopID)
                             .padding(.bottom, CinemaSpacing.spacing6)
                     } else {
@@ -417,9 +424,12 @@ struct HomeScreen: View {
     }
 
     @ViewBuilder
-    private var heroCarousel: some View {
-        let candidates = heroCandidates
-        let active = currentHeroIndex
+    private func heroCarousel(_ candidates: [BaseItemDto]) -> some View {
+        // `candidates` is the single per-render evaluation threaded from
+        // `content`; clamp the index against it here instead of re-reading
+        // `heroCandidates` through `currentHeroIndex` (same value — the caller
+        // only renders this when `candidates` is non-empty).
+        let active = candidates.isEmpty ? 0 : min(heroIndex, candidates.count - 1)
         ZStack {
             ForEach(Array(candidates.enumerated()), id: \.element.id) { idx, item in
                 if idx == active {

--- a/Shared/Screens/VideoPlayer/VLCStreamPresenter.swift
+++ b/Shared/Screens/VideoPlayer/VLCStreamPresenter.swift
@@ -490,6 +490,11 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
         hideControlsWorkItem?.cancel()
         pendingTapWork?.cancel()
         cancelPendingSeekCommit()
+        skipHUDHide?.cancel()
+        centerGlyphHide?.cancel()
+        skipGlyphHide?.cancel()
+        pendingTimeRefreshes.forEach { $0.cancel() }
+        pendingTimeRefreshes = []
         segmentFetchTask?.cancel()
         chapterFetchTask?.cancel()
         chapterThumbTasks.forEach { $0.cancel() }
@@ -504,6 +509,10 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
         #if os(iOS)
         pipController = nil
         #endif
+        videoHost?.willMove(toParent: nil)
+        videoHost?.view.removeFromSuperview()
+        videoHost?.removeFromParent()
+        videoHost = nil
         player.stop()
         deactivatePlaybackAudioSession()
     }

--- a/Shared/Screens/WatchedHistoryScreen.swift
+++ b/Shared/Screens/WatchedHistoryScreen.swift
@@ -103,7 +103,10 @@ struct WatchedHistoryScreen: View {
             prefetchPosters()
         }
         .onReceive(NotificationCenter.default.publisher(for: .cinemaxShouldRefreshCatalogue)) { _ in
-            Task { await viewModel.load(using: appState) }
+            Task {
+                prefetcher.reset()
+                await viewModel.load(using: appState)
+            }
         }
         // A per-item watched toggle (tier-2) — reload immediately so an un-watch
         // drops the item from history while this grid is on screen.

--- a/Tests/CinemaxKitTests/MenuConfigStoreTests.swift
+++ b/Tests/CinemaxKitTests/MenuConfigStoreTests.swift
@@ -175,6 +175,126 @@ struct MenuConfigStoreTests {
         #expect(store.resolvedTabs.map(\.id) == ["home", "movies", "tvShows", "search", "settings"])
     }
 
+    // MARK: - Resolution memoization (recompute-in-mutators)
+
+    // `resolvedTabs` is a memoized stored cache recomputed at the end of every
+    // mutator that changes an input (mode / customKind / entry arrays /
+    // availableViews). These tests lock in that every mutation category keeps
+    // the cache in sync — a missed `recomputeResolvedTabs()` call in any
+    // mutator would surface here as a stale bar.
+
+    @Test("resolvedTabs: setMode flips the cached array between default and custom")
+    func resolvedTabsReflectsModeFlip() {
+        clearMenuDefaults()
+        let store = MenuConfigStore()
+        #expect(store.resolvedTabs.map(\.id) == ["home", "movies", "tvShows", "search", "settings"])
+
+        // Disable movies in the custom entries while still in default mode —
+        // default mode ignores custom entries, so the cache must not change yet.
+        #expect(store.toggle(MenuEntry.moviesID) == .disabled)
+        #expect(store.resolvedTabs.contains { $0.id == "movies" })
+
+        // Flipping to custom now surfaces the disabled state.
+        store.setMode(.custom)
+        #expect(!store.resolvedTabs.contains { $0.id == "movies" })
+
+        // Back to default → canonical 5 regardless of custom entry state.
+        store.setMode(.default)
+        #expect(store.resolvedTabs.map(\.id) == ["home", "movies", "tvShows", "search", "settings"])
+    }
+
+    @Test("resolvedTabs: setCustomKind switches the cached set between content-type and library")
+    func resolvedTabsReflectsKindFlip() {
+        clearMenuDefaults()
+        let store = MenuConfigStore()
+        store.setMode(.custom)
+        #expect(store.resolvedTabs.map(\.id) == ["home", "movies", "tvShows", "search", "settings"])
+
+        // Seed a library view + entries, then flip the kind — setCustomKind
+        // recomputes the cache off the freshly-seeded state.
+        store.availableViews = [LibraryView(id: "v1", name: "Ciné", collectionType: "movies")]
+        store.libraryEntries = [
+            .init(id: MenuEntry.homeID, enabled: true),
+            .init(id: MenuEntry.libraryID(viewId: "v1"), enabled: true),
+            .init(id: MenuEntry.settingsID, enabled: true)
+        ]
+        store.setCustomKind(.library)
+        #expect(store.resolvedTabs.map(\.id) == ["home", MenuEntry.libraryID(viewId: "v1"), "settings"])
+
+        // Flip back to content-type → built-in tabs again.
+        store.setCustomKind(.contentType)
+        #expect(store.resolvedTabs.map(\.id) == ["home", "movies", "tvShows", "search", "settings"])
+    }
+
+    @Test("resolvedTabs: toggling a content-type entry updates the cache immediately")
+    func resolvedTabsReflectsEntryToggle() {
+        clearMenuDefaults()
+        let store = MenuConfigStore()
+        store.setMode(.custom)
+        #expect(store.resolvedTabs.map(\.id) == ["home", "movies", "tvShows", "search", "settings"])
+
+        #expect(store.toggle(MenuEntry.seriesID) == .disabled)
+        #expect(store.resolvedTabs.map(\.id) == ["home", "movies", "search", "settings"])
+
+        #expect(store.toggle(MenuEntry.seriesID) == .enabled)
+        #expect(store.resolvedTabs.map(\.id) == ["home", "movies", "tvShows", "search", "settings"])
+    }
+
+    @Test("resolvedTabs: reordering entries (move + moveBy) reorders the cache")
+    func resolvedTabsReflectsReorder() {
+        clearMenuDefaults()
+        let store = MenuConfigStore()
+        store.setMode(.custom)
+
+        // move offset 0 → 3: [movies, series, home, search, settings]
+        store.move(fromOffsets: IndexSet(integer: 0), toOffset: 3)
+        #expect(store.resolvedTabs.map(\.id) == ["movies", "tvShows", "home", "search", "settings"])
+
+        // moveBy swaps neighbors: home (index 2) up one → [movies, home, series, …]
+        store.moveBy(MenuEntry.homeID, delta: -1)
+        #expect(store.resolvedTabs.map(\.id) == ["movies", "home", "tvShows", "search", "settings"])
+    }
+
+    @Test("resolvedTabs: refreshAvailableViews surfaces new library tabs and is idempotent for unchanged views")
+    func resolvedTabsReflectsRefreshAndIsIdempotent() async {
+        clearMenuDefaults()
+        let api = MockAPIClient()
+        api.stubbedUserViews = [makeView(id: "B", name: "Films")]
+
+        let store = MenuConfigStore()
+        store.attach(apiClient: api, userId: "user1")
+        store.setMode(.custom)
+        store.setCustomKind(.library)
+
+        await store.refreshAvailableViews()
+        #expect(store.resolvedTabs.contains { $0.id == MenuEntry.libraryID(viewId: "B") })
+
+        // Idempotent: a repeat refresh with the SAME views leaves the cache
+        // byte-identical (mirrors the existing availableViews/libraryEntries
+        // equality guards — no spurious re-resolution).
+        let snapshot = store.resolvedTabs
+        await store.refreshAvailableViews()
+        #expect(store.resolvedTabs == snapshot)
+
+        // A changed view set updates the cache.
+        api.stubbedUserViews = [makeView(id: "B", name: "Films"), makeView(id: "C", name: "Docs")]
+        await store.refreshAvailableViews()
+        #expect(store.resolvedTabs != snapshot)
+        #expect(store.resolvedTabs.contains { $0.id == MenuEntry.libraryID(viewId: "C") })
+    }
+
+    @Test("resolvedTabs: reset restores the canonical 5 tabs")
+    func resolvedTabsReflectsReset() {
+        clearMenuDefaults()
+        let store = MenuConfigStore()
+        store.setMode(.custom)
+        #expect(store.toggle(MenuEntry.moviesID) == .disabled)
+        #expect(!store.resolvedTabs.contains { $0.id == "movies" })
+
+        store.reset()
+        #expect(store.resolvedTabs.map(\.id) == ["home", "movies", "tvShows", "search", "settings"])
+    }
+
     @Test("resolvedTabs: library mode maps views to tabs and skips ids without a cached view")
     func resolvedLibraryMode() {
         clearMenuDefaults()


### PR DESCRIPTION
## Summary

Third and final batch from the performance audit — the five small "en passant" findings:

- **`getLatestMedia` cache key now includes `parentId`** (`latest-<user>-<parentId|all>-<limit>-<age>`): closes a latent collision where a library-scoped call and the Home call would serve each other's cached response. In-memory cache only — worst case post-deploy is a one-time miss.
- **Favorites + Watched History call `prefetcher.reset()` on tier-1 catalogue refresh**, bringing both screens into conformance with the documented prefetch RULE (refreshed image tags re-prefetch).
- **`MenuConfigStore.resolvedTabs` is memoized**: a stored cache recomputed by the 8 mutators + `init` (equality-guarded, per the no-`didSet` RULE) instead of being rebuilt on every read. Output byte-identical; Observation granularity strictly improves (consumers re-render only when the resolved tabs actually change). MainTabView untouched.
- **`heroCandidates` is evaluated once per Home body render** and threaded down (was recomputed at every read site in the same render).
- **VLC `teardown()` completeness**: cancels the 4 previously-forgotten `DispatchWorkItem`s (HUD/glyph fades, pending time repaints) and formally detaches the `videoHost` child hosting controller (`willMove`/`removeFromSuperview`/`removeFromParent`) — janitorial, no behavior change.

## Verification

- Each commit passed an implementer + independent reviewer gate (the memoization got an Opus review verifying all 9 recompute sites, purity of the resolution helpers, and the tvOS snapshot/freeze machinery untouched); final whole-branch review: ready to merge, zero Critical/Important.
- Test suite 186 → 192 (6 new MenuConfigStore tests driving the real mutators incl. refresh idempotence); full suite green at HEAD; iOS + tvOS builds green at every commit.
- No new user-facing strings; no persisted-format or migration surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)