### PR TITLE
fix: three P0 stability fixes (NaN ticks crash, stale genre index, lost background observer)

### DIFF
--- a/Shared/Screens/NativeVideoPresenter.swift
+++ b/Shared/Screens/NativeVideoPresenter.swift
@@ -814,7 +814,15 @@ final class NativeVideoPresenter {
         return item
     }
 
+    /// Registered once per presentation and torn down in `cleanup()` — NOT in
+    /// `cleanupPlayer()`, which also runs on every episode navigation and used
+    /// to leave the 2nd episode onward of a native-path binge with no
+    /// background reporting at all. Remove-before-add keeps a second call
+    /// idempotent (today `present` is the only caller, and it runs once per
+    /// presenter instance — the PiP restore re-hosts the existing
+    /// `AVPlayerViewController` instead of re-presenting).
     private func setupBackgroundObserver() {
+        removeBackgroundObserver()
         backgroundObserver = NotificationCenter.default.addObserver(
             forName: .cinemaxDidEnterBackground, object: nil, queue: .main
         ) { [weak self] _ in
@@ -837,12 +845,15 @@ final class NativeVideoPresenter {
             NotificationCenter.default.removeObserver(obs)
             itemEndObserver = nil
         }
+        playerVC?.player?.pause()
+        playerVC?.player?.replaceCurrentItem(with: nil)
+    }
+
+    private func removeBackgroundObserver() {
         if let obs = backgroundObserver {
             NotificationCenter.default.removeObserver(obs)
             backgroundObserver = nil
         }
-        playerVC?.player?.pause()
-        playerVC?.player?.replaceCurrentItem(with: nil)
     }
 
     private func cleanup() {
@@ -856,6 +867,7 @@ final class NativeVideoPresenter {
         isInPictureInPicture = false
         didRestoreFromPiP = false
         #endif
+        removeBackgroundObserver()
         cleanupPlayer()
         playerVC = nil
         PlaybackAudioSession.deactivate()

--- a/Shared/Screens/VideoPlayer/PlaybackReporter.swift
+++ b/Shared/Screens/VideoPlayer/PlaybackReporter.swift
@@ -50,9 +50,29 @@ final class PlaybackReporter {
         return (player.currentTime().seconds, player.rate == 0)
     }
 
+    /// Converts a playback position in seconds to Jellyfin's 100 ns ticks.
+    ///
+    /// `Int(seconds * 10_000_000)` **traps** ("Double value cannot be converted
+    /// to Int because it is either infinite or NaN") the moment the source
+    /// isn't finite — and `AVPlayer.currentTime()` is exactly that whenever no
+    /// item is attached: `NativeVideoPresenter.present` builds
+    /// `AVPlayer(playerItem: nil)` and only hands it the item after an async
+    /// audio-session hop, so a dismiss (`reportStop`) or a background
+    /// (`reportBackgroundProgress`) inside that window crashed. Same trap class
+    /// as the `Int32(clamping:)` conversions in `VLCStreamPresenter`:
+    /// non-finite ⇒ 0, out of `Int` range ⇒ clamped, negative ⇒ 0.
+    nonisolated static func positionTicks(fromSeconds seconds: Double) -> Int {
+        guard seconds.isFinite else { return 0 }
+        let ticks = (seconds * 10_000_000).rounded()
+        // `ticks` can itself be infinite here (a finite but astronomically
+        // large `seconds` overflows the multiply), so never force the cast.
+        guard let exact = Int(exactly: ticks) else { return ticks < 0 ? 0 : Int.max }
+        return max(0, exact)
+    }
+
     func reportStart(startTime: Double?) {
         guard let ctx = context() else { return }
-        let positionTicks = startTime.map { Int($0 * 10_000_000) } ?? 0
+        let positionTicks = startTime.map { Self.positionTicks(fromSeconds: $0) } ?? 0
         let client = apiClient
         let uid = userId
         let itemId = ctx.itemId
@@ -68,7 +88,7 @@ final class PlaybackReporter {
 
     func reportStop() {
         guard let ctx = context() else { return }
-        let positionTicks = Int((currentState(ctx)?.seconds ?? 0) * 10_000_000)
+        let positionTicks = Self.positionTicks(fromSeconds: currentState(ctx)?.seconds ?? 0)
         let client = apiClient
         let uid = userId
         let itemId = ctx.itemId
@@ -87,7 +107,7 @@ final class PlaybackReporter {
     /// AVPlayer is still technically playing audio.
     func reportBackgroundProgress() {
         guard let ctx = context(), let state = currentState(ctx) else { return }
-        let positionTicks = Int(state.seconds * 10_000_000)
+        let positionTicks = Self.positionTicks(fromSeconds: state.seconds)
         let client = apiClient
         let uid = userId
         let itemId = ctx.itemId
@@ -116,7 +136,7 @@ final class PlaybackReporter {
 
     private func reportPeriodicProgress() {
         guard let ctx = context(), let state = currentState(ctx) else { return }
-        let positionTicks = Int(state.seconds * 10_000_000)
+        let positionTicks = Self.positionTicks(fromSeconds: state.seconds)
         let isPaused = state.isPaused
         let client = apiClient
         let uid = userId

--- a/Shared/ViewModels/HomeViewModel.swift
+++ b/Shared/ViewModels/HomeViewModel.swift
@@ -471,17 +471,27 @@ final class HomeViewModel {
 
     /// Re-fetches a single genre after the user taps its retry chip.
     /// Updates `genreRows` in place so only the affected row re-renders.
+    /// The index is deliberately re-resolved by genre AFTER the await, in both
+    /// the success and the failure path: `genreRows` can shrink or be replaced
+    /// wholesale while the fetch is in flight (a pull-to-refresh runs
+    /// `loadGenreRows`, a Settings genre-selection change runs
+    /// `reloadGenreRows`, another retry chip can remove a row), and reusing the
+    /// pre-await index crashes with `Fatal error: Index out of range` or writes
+    /// into the wrong row. A nil lookup means the row is gone — the superseding
+    /// load owns the state, so bail silently.
     func retryGenre(_ genre: String, using appState: AppState) async {
         guard let userId = appState.currentUserId,
-              let index = genreRows.firstIndex(where: { $0.genre == genre }) else { return }
+              genreRows.contains(where: { $0.genre == genre }) else { return }
         do {
             let items = try await Self.fetchGenreItems(genre: genre, userId: userId, appState: appState)
+            guard let index = genreRows.firstIndex(where: { $0.genre == genre }) else { return }
             if items.isEmpty {
                 genreRows.remove(at: index)
             } else {
                 genreRows[index].state = .items(items)
             }
         } catch {
+            guard let index = genreRows.firstIndex(where: { $0.genre == genre }) else { return }
             genreRows[index].state = .failed
         }
     }

--- a/Tests/CinemaxKitTests/HomeViewModelTests.swift
+++ b/Tests/CinemaxKitTests/HomeViewModelTests.swift
@@ -171,6 +171,65 @@ struct HomeViewModelTests {
         #expect(vm.resumeItems.count == 1)
         #expect(vm.nextUpItems.count == 1)
     }
+
+    // MARK: - Genre retry (stale-index regression)
+    //
+    // `retryGenre` suspends on the fetch; `genreRows` can be emptied or
+    // reordered meanwhile (pull-to-refresh, a genre-selection change, another
+    // retry chip). Reusing the pre-await index crashed with "Index out of
+    // range" or wrote into the wrong row.
+
+    @Test("retryGenre bails silently when its row disappears during the fetch")
+    func retryGenreRowRemovedMidFlight() async {
+        let api = MockAPIClient()
+        let vm = HomeViewModel()
+        vm.genreRows = [GenreRow(genre: "Action", state: .failed),
+                        GenreRow(genre: "Comedy", state: .failed)]
+        // Runs while `retryGenre` is suspended — same effect as a concurrent
+        // `loadGenreRows` wiping the rows.
+        api.getItemsHandler = { _ in
+            await MainActor.run { vm.genreRows = [] }
+            return ([], 0)
+        }
+
+        await vm.retryGenre("Action", using: makeAppState(api: api))
+
+        #expect(vm.genreRows.isEmpty)
+    }
+
+    @Test("retryGenre re-resolves the index when rows shift during the fetch")
+    func retryGenreIndexShiftsMidFlight() async {
+        let api = MockAPIClient()
+        let vm = HomeViewModel()
+        vm.genreRows = [GenreRow(genre: "Action", state: .failed),
+                        GenreRow(genre: "Comedy", state: .failed),
+                        GenreRow(genre: "Drama", state: .failed)]
+        // Drop the row ahead of the retried one: "Drama" moves from index 2 to 1
+        // and the old index would now be out of bounds.
+        api.getItemsHandler = { _ in
+            await MainActor.run { vm.genreRows.removeFirst() }
+            return ([makeSeasonEpisode(id: "d1", name: "Dramatic")], 1)
+        }
+
+        await vm.retryGenre("Drama", using: makeAppState(api: api))
+
+        #expect(vm.genreRows.map(\.genre) == ["Comedy", "Drama"])
+        #expect(vm.genreRows.first(where: { $0.genre == "Drama" })?.state != .failed)
+        #expect(vm.genreRows.first(where: { $0.genre == "Comedy" })?.state == .failed)
+    }
+
+    @Test("retryGenre no-ops when the genre isn't in genreRows at all")
+    func retryGenreUnknownGenre() async {
+        let api = MockAPIClient()
+        let vm = HomeViewModel()
+        vm.genreRows = [GenreRow(genre: "Action", state: .failed)]
+
+        await vm.retryGenre("Comedy", using: makeAppState(api: api))
+
+        #expect(vm.genreRows.count == 1)
+        #expect(vm.genreRows[0].state == .failed)
+        #expect(api.getItemsCalls.isEmpty)
+    }
 }
 
 /// Tri-state sentinel: a missing/empty `home.selectedGenres` string means

--- a/Tests/CinemaxKitTests/PlaybackReporterTests.swift
+++ b/Tests/CinemaxKitTests/PlaybackReporterTests.swift
@@ -84,6 +84,111 @@ struct PlaybackReporterTests {
         try await Task.sleep(for: .milliseconds(30))
         #expect(mock.startCount == 0)
     }
+
+    // MARK: - Non-finite position guards
+    //
+    // `AVPlayer.currentTime()` is an invalid CMTime (`.seconds == NaN`) until a
+    // player item is attached, and `NativeVideoPresenter.present` creates the
+    // player before the async audio-session hop that attaches one. A dismiss or
+    // a background inside that window used to trap in `Int(seconds * 10_000_000)`.
+
+    @Test("ticks conversion is NaN/infinity-safe and clamps out-of-range values")
+    func ticksConversionIsSafe() {
+        #expect(PlaybackReporter.positionTicks(fromSeconds: .nan) == 0)
+        #expect(PlaybackReporter.positionTicks(fromSeconds: .infinity) == 0)
+        #expect(PlaybackReporter.positionTicks(fromSeconds: -.infinity) == 0)
+        #expect(PlaybackReporter.positionTicks(fromSeconds: .signalingNaN) == 0)
+        #expect(PlaybackReporter.positionTicks(fromSeconds: 0) == 0)
+        #expect(PlaybackReporter.positionTicks(fromSeconds: 12.5) == 125_000_000)
+        // Negative positions are meaningless to the server — floor at 0.
+        #expect(PlaybackReporter.positionTicks(fromSeconds: -3) == 0)
+        // Finite but astronomically large: the multiply itself overflows to
+        // +infinity, which must clamp rather than trap.
+        #expect(PlaybackReporter.positionTicks(fromSeconds: .greatestFiniteMagnitude) == Int.max)
+    }
+
+    @Test("reportStop with a NaN time source reports 0 ticks instead of trapping")
+    func stopWithNaNTimeSource() async throws {
+        let mock = CountingPlaybackAPI()
+        let reporter = PlaybackReporter(
+            apiClient: mock, userId: "u1",
+            context: { .init(itemId: "item1", info: .stubbed(), player: nil) },
+            timeSource: { (seconds: .nan, isPaused: false) }
+        )
+
+        reporter.reportStop()
+        for _ in 0..<200 where mock.stopCount == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(mock.stopCount == 1)
+        #expect(mock.lastStopTicks == 0)
+    }
+
+    @Test("reportBackgroundProgress with an infinite time source reports 0 ticks")
+    func backgroundProgressWithInfiniteTimeSource() async throws {
+        let mock = CountingPlaybackAPI()
+        let reporter = PlaybackReporter(
+            apiClient: mock, userId: "u1",
+            context: { .init(itemId: "item1", info: .stubbed(), player: nil) },
+            timeSource: { (seconds: .infinity, isPaused: false) }
+        )
+
+        reporter.reportBackgroundProgress()
+        for _ in 0..<200 where mock.progressCount == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(mock.progressCount == 1)
+        #expect(mock.lastProgressTicks == 0)
+    }
+
+    @Test("periodic progress with a NaN time source reports 0 ticks")
+    func periodicProgressWithNaNTimeSource() async throws {
+        let mock = CountingPlaybackAPI()
+        let reporter = PlaybackReporter(
+            apiClient: mock, userId: "u1",
+            context: { .init(itemId: "item1", info: .stubbed(), player: nil) },
+            timeSource: { (seconds: .nan, isPaused: true) }
+        )
+
+        for _ in 0..<10 { reporter.onTick() }
+        for _ in 0..<200 where mock.progressCount == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(mock.progressCount == 1)
+        #expect(mock.lastProgressTicks == 0)
+    }
+
+    @Test("reportStart with a NaN startTime reports 0 ticks")
+    func startWithNaNStartTime() async throws {
+        let mock = CountingPlaybackAPI()
+        let reporter = PlaybackReporter(
+            apiClient: mock, userId: "u1",
+            context: { .init(itemId: "item1", info: .stubbed(), player: nil) }
+        )
+
+        reporter.reportStart(startTime: .nan)
+        for _ in 0..<200 where mock.startCount == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(mock.startCount == 1)
+        #expect(mock.lastStartTicks == 0)
+    }
+
+    @Test("a finite time source still reports the real position")
+    func finiteTimeSourceReportsPosition() async throws {
+        let mock = CountingPlaybackAPI()
+        let reporter = PlaybackReporter(
+            apiClient: mock, userId: "u1",
+            context: { .init(itemId: "item1", info: .stubbed(), player: nil) },
+            timeSource: { (seconds: 42, isPaused: false) }
+        )
+
+        reporter.reportStop()
+        for _ in 0..<200 where mock.stopCount == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(mock.lastStopTicks == 420_000_000)
+    }
 }
 
 // MARK: - Test helpers
@@ -96,19 +201,25 @@ private final class CountingPlaybackAPI: PlaybackAPI, Sendable {
         var start = 0
         var progress = 0
         var stop = 0
+        var lastStartTicks: Int?
+        var lastProgressTicks: Int?
+        var lastStopTicks: Int?
     }
     private let state = OSAllocatedUnfairLock(initialState: Counts())
 
     var startCount: Int { state.withLock { $0.start } }
     var progressCount: Int { state.withLock { $0.progress } }
     var stopCount: Int { state.withLock { $0.stop } }
+    var lastStartTicks: Int? { state.withLock { $0.lastStartTicks } }
+    var lastProgressTicks: Int? { state.withLock { $0.lastProgressTicks } }
+    var lastStopTicks: Int? { state.withLock { $0.lastStopTicks } }
 
     func reportPlaybackStart(
         itemId: String, userId: String,
         mediaSourceId: String?, playSessionId: String?,
         positionTicks: Int?, playMethod: CinemaxKit.PlayMethod
     ) async {
-        state.withLock { $0.start += 1 }
+        state.withLock { $0.start += 1; $0.lastStartTicks = positionTicks }
     }
 
     func reportPlaybackProgress(
@@ -116,7 +227,7 @@ private final class CountingPlaybackAPI: PlaybackAPI, Sendable {
         mediaSourceId: String?, playSessionId: String?,
         positionTicks: Int?, isPaused: Bool, playMethod: CinemaxKit.PlayMethod
     ) async {
-        state.withLock { $0.progress += 1 }
+        state.withLock { $0.progress += 1; $0.lastProgressTicks = positionTicks }
     }
 
     func reportPlaybackStopped(
@@ -124,7 +235,7 @@ private final class CountingPlaybackAPI: PlaybackAPI, Sendable {
         mediaSourceId: String?, playSessionId: String?,
         positionTicks: Int?
     ) async {
-        state.withLock { $0.stop += 1 }
+        state.withLock { $0.stop += 1; $0.lastStopTicks = positionTicks }
     }
 
     func getMediaSegments(itemId: String, includeSegmentTypes: [MediaSegmentType]?) async throws -> [MediaSegmentDto] {


### PR DESCRIPTION
Three independent P0 crash/correctness fixes from the stability audit, each verified against the code and committed separately.

## 1. `PlaybackReporter` — NaN-safe ticks conversion (crash, native/AVPlayer path)

`NativeVideoPresenter.present` creates `AVPlayer(playerItem: nil)` and only attaches the item after an async audio-session hop. `currentTime()` with no item is an invalid `CMTime` whose `.seconds` is **NaN**, so every `Int(seconds * 10_000_000)` in the reporter trapped (`Double value cannot be converted to Int…`). Repro: tap Play on the native path, then dismiss — or background (`reportBackgroundProgress`) — inside the attach window.

All four conversions (start / stop / background / periodic) now route through one `PlaybackReporter.positionTicks(fromSeconds:)`: non-finite ⇒ 0, out of `Int` range ⇒ clamped, negative ⇒ 0. Same trap class and the same clamping convention as the `Int32(clamping:)` sites in `VLCStreamPresenter` (~L555 / ~L3158).

## 2. `HomeViewModel.retryGenre` — stale index across a suspension (crash)

The index was resolved *before* `fetchGenreItems` and reused after it, on both the success path (`remove(at:)` / subscript write) and in the `catch`. `genreRows` can shrink or be replaced during the suspension (pull-to-refresh → `loadGenreRows` assigns `genreRows = []` on failure; a Settings genre-selection change; a second retry chip) ⇒ `Fatal error: Index out of range`, or a write into the wrong row. Same class as the RULE-ized "En direct" crash, but across a suspension rather than a render.

Now re-resolved by genre after the await in both paths, bailing silently when the row is gone (the superseding load owns the state). The pre-await membership check is kept so an unknown genre still skips the fetch.

## 3. `NativeVideoPresenter` — background observer lost on episode navigation

`setupBackgroundObserver()` ran once in `present`, but removal lived in `cleanupPlayer()`, which `navigateToEpisode` also calls. From the 2nd episode of a native-path binge onward no observer remained, so backgrounding stopped sending the `reportBackgroundProgress` "paused" report (stale server session state, missed final resume-position update).

Removal moved to `cleanup()` (the dismissal path) so it tracks the presenter's lifetime, not the player item's.

**Double-registration check** — traced every caller:
- `setupBackgroundObserver()` has exactly one caller: `present(info:)`.
- `present(info:)` is called once per presenter instance (`VideoPlayerCoordinator` L111, guarded by `currentGeneration`; `VideoPlayerView` L136, guarded by `didPresent`) — a new presenter is constructed for each playback.
- The PiP restore path does **not** re-present: `restoreUserInterfaceForPictureInPictureStop…` → `restoreFromPiP` → `makeIOSHostingVC(for:)` re-hosts the existing `AVPlayerViewController`. `cleanup()` has not run at that point either (the PiP-triggered modal dismiss is suppressed by `shouldFireOnDismiss`/`isInPictureInPicture`), which is correct: the observer must stay live while playback continues in PiP.
- `retryWithDirectURL` touches neither the observer nor `cleanupPlayer()`.
- Every teardown path (`TVDismissDelegate.onDismiss`, `PlayerHostingVC.onDismissed`, `didStopPictureInPicture` with `didRestoreFromPiP == false`) goes through `cleanup()`, so the observer is always removed exactly once.

No double-add is reachable today; registration was still made idempotent (remove-before-add) to lock the invariant.

## Tests

`Tests/CinemaxKitTests/PlaybackReporterTests.swift` — 6 new tests: the pure conversion (NaN / ±∞ / signalingNaN / negative / `greatestFiniteMagnitude` / a real value) plus `reportStop`, `reportBackgroundProgress`, periodic progress and `reportStart` driven by a non-finite `TimeSource`, asserting the report fires with 0 ticks instead of trapping. `CountingPlaybackAPI` now records reported ticks.

`Tests/CinemaxKitTests/HomeViewModelTests.swift` — 3 new tests using `MockAPIClient.getItemsHandler` to mutate `genreRows` *while the fetch is suspended*: row removed mid-flight, index shifted mid-flight, and unknown genre (no fetch). The middle one reproduces the out-of-bounds write deterministically.

Per the brief, tests were not executed here (the orchestrator runs the full suite at consolidation) — the test target was compiled with `build-for-testing`.

## Verification

- `xcodebuild build -scheme Cinemax -destination 'iPhone 17 Pro'` → `** BUILD SUCCEEDED **`
- `xcodebuild build -scheme CinemaxTV -destination 'Apple TV 4K (3rd generation)'` → `** BUILD SUCCEEDED **`
- `xcodebuild build-for-testing -scheme Cinemax` → `** TEST BUILD SUCCEEDED **` (compiles the new tests)

Run serially, `set -o pipefail`, confirmed by reading the output banner.

## CLAUDE.md

No update: all three are internal correctness fixes with no user-visible behavior change, no new file, no new `@AppStorage` key, no structural change, and no new rule that isn't already covered by the existing index-snapshot / clamping conventions. `project.yml` untouched, so no `xcodegen generate` / pbxproj churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
