### PR TITLE
diag(player): temporary NETDIAG probe for the transcode-open failure (do not merge)

### DIFF
--- a/Shared/Screens/VideoPlayer/CinemaxStreamProxy.swift
+++ b/Shared/Screens/VideoPlayer/CinemaxStreamProxy.swift
@@ -162,6 +162,116 @@ final class StreamTransportPolicy {
     }
 }
 
+// MARK: - Playback network diagnostics (TEMPORARY, DEBUG-only)
+
+#if DEBUG
+/// **Temporary diagnostic — delete once the transcode-open failure is
+/// understood.** Adds no behavior; only logs.
+///
+/// The question it exists to answer: when libVLC reports
+/// `cannot resolve <host> port 443` while opening an HLS transcode, can THIS
+/// PROCESS resolve and fetch that exact URL at that exact instant? Observed so
+/// far on one corporate Wi-Fi: libVLC opens direct-play URLs fine and fails on
+/// `master.m3u8`, on the same host; on 5G both work. No mechanism established —
+/// hence measurement rather than another hypothesis.
+///
+/// Three readings per probe, deliberately chosen so ONE trip to that network
+/// settles it:
+///   1. `NWPath` — interface, and whether the path advertises IPv4 / IPv6 / DNS.
+///   2. `getaddrinfo(host, "443", AF_UNSPEC)` — the same call libVLC makes,
+///      from our process: return code + EVERY address, tagged v4/v6.
+///   3. A plain `URLSession` GET of the URL libVLC is about to open. This is a
+///      **dry run of the loopback proxy**: it does exactly what the proxy would
+///      do. A 200 with an `#EXTM3U` body while libVLC says "cannot resolve" is
+///      proof the proxy fix would work — and a failure here is proof it would
+///      not, saving the implementation.
+///
+/// Runs entirely on its own serial queue with the completion-handler API: the
+/// blocking `getaddrinfo` must not sit on a cooperative thread, and nothing
+/// here may perturb the timing of the playback it is measuring.
+enum PlaybackNetworkDiagnostics {
+    private static let queue = DispatchQueue(label: "com.cinemax.playbackdiag", qos: .utility)
+
+    private static let session: URLSession = {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.urlCache = nil
+        cfg.requestCachePolicy = .reloadIgnoringLocalCacheData
+        cfg.timeoutIntervalForRequest = 10
+        cfg.waitsForConnectivity = false
+        return URLSession(configuration: cfg)
+    }()
+
+    /// `label` distinguishes the call sites in the log, e.g.
+    /// `"pre-open Transcode"` / `"after-failure Transcode"`.
+    static func probe(_ label: String, url: URL) {
+        queue.async {
+            let host = url.host ?? "?"
+            proxyLog.notice("NETDIAG [\(label, privacy: .public)] host=\(host, privacy: .public) ext=\(url.pathExtension, privacy: .public) \(pathSummary(), privacy: .public)")
+
+            let (rc, addresses) = resolve(host: host)
+            if rc == 0 {
+                proxyLog.notice("NETDIAG [\(label, privacy: .public)] getaddrinfo=OK addrs=[\(addresses.joined(separator: " "), privacy: .public)]")
+            } else {
+                let reason = String(cString: gai_strerror(rc))
+                proxyLog.error("NETDIAG [\(label, privacy: .public)] getaddrinfo=FAIL rc=\(rc) (\(reason, privacy: .public))")
+            }
+
+            var req = URLRequest(url: url)
+            req.httpMethod = "GET"
+            let started = Date()
+            session.dataTask(with: req) { data, response, error in
+                let ms = Int(Date().timeIntervalSince(started) * 1000)
+                if let error {
+                    proxyLog.error("NETDIAG [\(label, privacy: .public)] urlsession=FAIL after \(ms)ms — \(error.localizedDescription, privacy: .public)")
+                    return
+                }
+                let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+                let bytes = data?.count ?? 0
+                // First line of the body: `#EXTM3U` confirms a real playlist came back.
+                let firstLine = String(decoding: (data ?? Data()).prefix(32), as: UTF8.self)
+                    .split(whereSeparator: \.isNewline).first.map(String.init) ?? ""
+                proxyLog.notice("NETDIAG [\(label, privacy: .public)] urlsession=OK status=\(code) bytes=\(bytes) in \(ms)ms firstLine=\(firstLine, privacy: .public)")
+            }.resume()
+        }
+    }
+
+    /// Interface + address-family + DNS support of the current path. `NWPath` is
+    /// readable synchronously off a fresh monitor (same trick as `NetworkMonitor`).
+    private static func pathSummary() -> String {
+        let path = NWPathMonitor().currentPath
+        let interfaces = path.availableInterfaces.map { "\($0.type)" }.joined(separator: ",")
+        return "path=\(path.status) ifaces=[\(interfaces)] v4=\(path.supportsIPv4) v6=\(path.supportsIPv6) dns=\(path.supportsDNS)"
+    }
+
+    /// The same lookup libVLC performs, from our process. Returns every address
+    /// so a v6-only / v4-only answer is visible rather than inferred.
+    /// Internal (not private) so `StreamProxyTests` can verify the C interop —
+    /// a pointer bug here would silently waste the one field trip this probe
+    /// exists to make count.
+    static func resolve(host: String) -> (rc: Int32, addresses: [String]) {
+        var hints = addrinfo()
+        hints.ai_family = AF_UNSPEC
+        hints.ai_socktype = SOCK_STREAM
+        var res: UnsafeMutablePointer<addrinfo>?
+        let rc = getaddrinfo(host, "443", &hints, &res)
+        guard rc == 0, let head = res else { return (rc, []) }
+        defer { freeaddrinfo(head) }
+        var out: [String] = []
+        var buf = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+        var cur: UnsafeMutablePointer<addrinfo>? = head
+        while let node = cur {
+            if getnameinfo(node.pointee.ai_addr, node.pointee.ai_addrlen,
+                           &buf, socklen_t(buf.count), nil, 0, NI_NUMERICHOST) == 0 {
+                let family = node.pointee.ai_family == AF_INET6 ? "v6" : "v4"
+                out.append(family + ":" + buf.withUnsafeBufferPointer { String(cString: $0.baseAddress!) })
+            }
+            cur = node.pointee.ai_next
+        }
+        return (rc, out)
+    }
+}
+#endif
+
 // MARK: - Loopback HTTP → URLSession proxy
 
 /// Tiny on-device HTTP/1.1 proxy bound to `127.0.0.1`. libVLC connects to it in

--- a/Shared/Screens/VideoPlayer/VLCStreamPresenter.swift
+++ b/Shared/Screens/VideoPlayer/VLCStreamPresenter.swift
@@ -2372,6 +2372,11 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
         } else {
             url = authed
         }
+        #if DEBUG
+        // Probes the ORIGIN url (not `url`, which may be loopback) so the
+        // reading is comparable across direct-play and transcode opens.
+        PlaybackNetworkDiagnostics.probe("pre-open \(info.playMethod.rawValue)", url: authed)
+        #endif
         guard let media = makeMedia(url) else { handlePlaybackError(); return }
         startEventLoop()
         activateSessionThenPlay(media)
@@ -3032,6 +3037,15 @@ private final class VLCStreamViewController: UIViewController, UIScrollViewDeleg
     private func handlePlaybackError() {
         cancelOpenWatchdog()
         endSeekLoading() // the media is being reloaded (or given up on)
+        #if DEBUG
+        // Second reading, taken as close as possible to libVLC's own failure:
+        // separates "the process couldn't resolve either, right then" from
+        // "only libVLC couldn't".
+        PlaybackNetworkDiagnostics.probe(
+            "after-failure \(info.playMethod.rawValue)",
+            url: VLCStreamPresenter.authedURL(info.url, token: info.authToken)
+        )
+        #endif
         if !didRetry {
             didRetry = true
             logger.error("VLC error for \(self.itemId, privacy: .public) at \(self.elapsedSincePlay(), privacy: .public) — retrying once")

--- a/Tests/CinemaxKitTests/StreamProxyTests.swift
+++ b/Tests/CinemaxKitTests/StreamProxyTests.swift
@@ -75,6 +75,30 @@ struct StreamProxyTests {
         #expect(revived.path.hasPrefix("/s/"))
     }
 
+    // MARK: - Playback network diagnostics (temporary probe)
+
+    @Test("the diagnostic resolver reports loopback correctly (C interop sanity)")
+    func diagnosticResolverHandlesLoopback() {
+        // Not a network test — `localhost` resolves from /etc/hosts. It exists to
+        // catch a getaddrinfo/getnameinfo pointer bug BEFORE the probe is carried
+        // onto the one network where it has to produce a usable reading.
+        let (rc, addresses) = PlaybackNetworkDiagnostics.resolve(host: "localhost")
+        #expect(rc == 0)
+        #expect(!addresses.isEmpty)
+        // Every entry is family-tagged, and loopback resolves to a loopback literal.
+        #expect(addresses.allSatisfy { $0.hasPrefix("v4:") || $0.hasPrefix("v6:") })
+        #expect(addresses.contains { $0 == "v4:127.0.0.1" || $0 == "v6:::1" })
+    }
+
+    @Test("the diagnostic resolver reports failure instead of inventing addresses")
+    func diagnosticResolverReportsFailure() {
+        let (rc, addresses) = PlaybackNetworkDiagnostics.resolve(
+            host: "cinemax-does-not-exist.invalid" // .invalid is reserved, never resolves
+        )
+        #expect(rc != 0)
+        #expect(addresses.isEmpty)
+    }
+
     // MARK: - Servable streams (pure)
 
     @Test("HLS/DASH manifests are refused — the single-target proxy can't serve a URL tree")


### PR DESCRIPTION
> **Draft, à ne pas merger.** Code de diagnostic temporaire, `#if DEBUG`, aucun changement de comportement. À révoquer une fois la cause établie. Tu peux simplement `git checkout diag/vlc-transcode-network` et déployer sur le téléphone.

## Pourquoi mesurer plutôt que corriger

Établi : sur un Wi-Fi d'entreprise, libVLC ouvre les URL **direct-play** sans problème et échoue sur `master.m3u8` avec `cannot resolve <host> port 443` — même hôte, même processus, à la seconde où `URLSession` renvoie 200. En 5G et sur simulateur, les deux marchent.

Aucun mécanisme n'est établi. Deux hypothèses de ma part se sont déjà révélées fausses, donc cette branche ne corrige rien : elle mesure.

## Ce que la sonde relève

Trois lectures, choisies pour qu'**un seul passage sur ce réseau suffise** :

1. **`NWPath`** — interface active, et si le chemin annonce IPv4 / IPv6 / **DNS**.
2. **`getaddrinfo(host, "443", AF_UNSPEC)`** — l'appel exact que fait libVLC, depuis notre processus : code retour + **toutes** les adresses, taguées v4/v6.
3. **Un `GET` `URLSession` de l'URL que libVLC s'apprête à ouvrir.** C'est un **essai à blanc du correctif proxy** : il fait précisément ce que ferait le proxy. Un `200` + `#EXTM3U` pendant que libVLC dit « cannot resolve » prouve que le proxy réglerait le problème ; un échec prouve l'inverse et m'évite d'écrire ce code pour rien.

Deux points d'appel : avant **chaque** ouverture — donc l'ouverture direct-play qui *fonctionne* fournit une ligne de base sur le même réseau — et en tête de `handlePlaybackError`, au plus près de l'échec de libVLC. La sonde vise toujours l'URL d'origine, jamais l'URL loopback, pour que les lectures restent comparables.

Tout tourne sur sa propre file série en API à complétion : `getaddrinfo` bloque et n'a rien à faire sur un thread coopératif, et rien ici ne doit perturber le timing de la lecture qu'on mesure.

## Protocole de test

1. Build sur l'iPhone, **« Lecteur natif » désactivé** (moteur VLC).
2. Sur le Wi-Fi entreprise : lance d'abord un **direct-play** (le MKV qui marche) → ligne de base.
3. Puis l'**AVI** (transcode) → l'échec.
4. Envoie-moi les lignes `NETDIAG`.

## Comment je lirai le résultat

| Lecture | Conclusion |
|---|---|
| `getaddrinfo=OK` + `urlsession=OK status=200` pendant que libVLC dit « cannot resolve » | Le problème est **dans** la pile réseau de libVLC → le proxy HLS est le bon correctif, et il marchera |
| `getaddrinfo=FAIL` au même instant | Le résolveur du processus tombe lui aussi à ce moment-là → autre piste, le proxy ne suffirait pas |
| `urlsession=FAIL` | Le réseau bloque cette URL pour tout le monde → ni proxy ni VLC n'y peuvent quoi que ce soit, c'est côté réseau/serveur |
| `v6=true dns=false`, ou des adresses v6 uniquement | La configuration du chemin réseau est en cause, et on saura enfin laquelle |

## Vérification

- Builds iOS ✅ et tvOS ✅ (séparément)
- **338 tests verts**, dont 2 nouveaux qui valident l'interop C de `resolve(host:)` (loopback + un nom `.invalid` réservé) — une erreur de pointeur là-dedans aurait gâché le déplacement en silence

CLAUDE.md n'est pas touché : rien de durable ici, et documenter du code temporaire serait une erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)