### PR TITLE
nettoyage + perf + fix : code mort, redondance du scoring, lecture keychain dupliquée, prédicat de tri invalide

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -9,7 +9,6 @@
 "tab.tvShows" = "TV Shows";
 "tab.search" = "Search";
 "tab.settings" = "Settings";
-"app.name" = "Cinemax";
 
 // MARK: - Common Actions
 

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -9,7 +9,6 @@
 "tab.tvShows" = "Séries";
 "tab.search" = "Recherche";
 "tab.settings" = "Réglages";
-"app.name" = "Cinemax";
 
 // MARK: - Common Actions
 

--- a/Shared/Navigation/AppNavigation.swift
+++ b/Shared/Navigation/AppNavigation.swift
@@ -101,8 +101,6 @@ final class AppState {
     // Stored so it is only rebuilt when serverURL changes, not on every access.
     var imageBuilder = ImageURLBuilder(serverURL: AppState.placeholderServerURL)
 
-    var imageServerURL: URL { serverURL ?? Self.placeholderServerURL }
-
     /// Hydrates auth state from the keychain. Network probes (server info,
     /// admin flag) are dispatched in the background so the UI doesn't wait
     /// on them — important when the user launches the app offline, where

--- a/Shared/Screens/Admin/Metadata/MetadataEditorViewModel.swift
+++ b/Shared/Screens/Admin/Metadata/MetadataEditorViewModel.swift
@@ -49,7 +49,6 @@ final class MetadataEditorViewModel {
 
     // Cast
     var editingPerson: BaseItemPerson?
-    var pendingPersonDelete: Int?
 
     // Identify — full flow state lives on the shared `IdentifyFlowModel` so
     // the standalone `IdentifyScreen` and this tab stay feature-identical.

--- a/Shared/Screens/Admin/Users/AdminUserDetailViewModel.swift
+++ b/Shared/Screens/Admin/Users/AdminUserDetailViewModel.swift
@@ -32,7 +32,6 @@ final class AdminUserDetailViewModel {
     // vice versa).
     var newPassword: String = ""
     var confirmPassword: String = ""
-    var resetPasswordAtNextLogin: Bool = false
 
     var selectedTab: AdminUserDetailTab = .profile
     var isSaving = false

--- a/Shared/Screens/MediaDetailScreen.swift
+++ b/Shared/Screens/MediaDetailScreen.swift
@@ -1416,14 +1416,6 @@ struct MediaDetailScreen: View {
         #endif
     }
 
-    private var actionButtonSpacing: CGFloat {
-        #if os(tvOS)
-        CinemaSpacing.spacing5
-        #else
-        12
-        #endif
-    }
-
     private var playButtonWidth: CGFloat {
         #if os(tvOS)
         240

--- a/Shared/Screens/Settings/MenuSettingsScreen.swift
+++ b/Shared/Screens/Settings/MenuSettingsScreen.swift
@@ -76,8 +76,4 @@ struct MenuSettingsScreen: View {
     var activeEntries: [MenuEntry] {
         store.customKind == .contentType ? store.contentTypeEntries : store.libraryEntries
     }
-
-    var enabledCount: Int {
-        activeEntries.filter { $0.enabled }.count
-    }
 }

--- a/Shared/Screens/Settings/SettingsScreen+iOS.swift
+++ b/Shared/Screens/Settings/SettingsScreen+iOS.swift
@@ -560,12 +560,18 @@ extension SettingsScreen {
     // MARK: - iOS Reusable Components
 
     var profileHeader: some View {
-        HStack(spacing: CinemaSpacing.spacing4) {
-            profileAvatar
+        // One keychain read for the whole header. `username` is not a stored
+        // value — every access is a `SecItemCopyMatching` round-trip to
+        // securityd plus a `JSONDecoder` init and decode — and this header
+        // paid it twice per body pass: once for the label, once more inside
+        // `profileAvatar`. Read it once here and thread it down.
+        let name = username
+        return HStack(spacing: CinemaSpacing.spacing4) {
+            profileAvatar(name: name)
                 .frame(width: 56, height: 56)
 
             VStack(alignment: .leading, spacing: CinemaSpacing.spacing1) {
-                Text(username)
+                Text(name)
                     .font(CinemaFont.headline(.small))
                     .foregroundStyle(CinemaColor.onSurface)
 
@@ -583,15 +589,18 @@ extension SettingsScreen {
     /// Account avatar. Renders the Jellyfin primary image for the signed-in
     /// user when available, with an accent gradient + initial underneath as
     /// the fallback (covers "no image set" and offline cases uniformly).
+    /// Takes the display name as a parameter rather than re-reading `username`:
+    /// its only caller (`profileHeader`) already resolved it, and that property
+    /// hits the keychain on every access.
     @ViewBuilder
-    var profileAvatar: some View {
+    func profileAvatar(name: String) -> some View {
         // `appState.currentUser` is hydrated by `refreshCurrentUser()` via
         // `getUserByID` for every account — unlike `getUsers()` which is
         // admin-only and 401s for regular users (the avatar silently never
         // rendered for them when this fetched its own copy).
         UserAvatar(
             userId: appState.currentUserId,
-            name: username,
+            name: name,
             primaryImageTag: appState.currentUser?.primaryImageTag,
             size: 56
         )

--- a/Shared/Screens/Settings/SettingsScreen.swift
+++ b/Shared/Screens/Settings/SettingsScreen.swift
@@ -234,10 +234,6 @@ struct SettingsScreen: View {
         appState.keychain.getUserSession()?.username ?? "User"
     }
 
-    var userInitial: String {
-        String(username.prefix(1)).uppercased()
-    }
-
     var serverName: String {
         appState.serverInfo?.name ?? "Jellyfin Server"
     }

--- a/Shared/Screens/Settings/SettingsTVProfileSection.swift
+++ b/Shared/Screens/Settings/SettingsTVProfileSection.swift
@@ -23,7 +23,24 @@ extension SettingsScreen {
         } else {
             users = serverUsers
         }
-        return users.sorted { a, _ in a.id == currentUserId }
+        // Signed-in user first, everyone else in the order the server gave.
+        //
+        // This was `users.sorted { a, _ in a.id == currentUserId }`, which is
+        // NOT a strict weak ordering: it ignores its right operand, so it
+        // answers `true` for `(a, a)` whenever `a` is the current user, which
+        // breaks irreflexivity. `sorted(by:)` documents its output as
+        // unspecified for such a predicate — the current user was not reliably
+        // first, and the relative order of the others was arbitrary and free to
+        // shift between two evaluations of this very property. A move-to-front
+        // states the intent directly, is O(n), and is stable for the rest, so
+        // the grid stops reshuffling under the focus engine.
+        guard let currentIndex = users.firstIndex(where: { $0.id == currentUserId }) else {
+            return users
+        }
+        var ordered = users
+        let current = ordered.remove(at: currentIndex)
+        ordered.insert(current, at: 0)
+        return ordered
     }
 
     var tvProfileSection: some View {

--- a/Shared/ViewModels/LibrarySearchRanker.swift
+++ b/Shared/ViewModels/LibrarySearchRanker.swift
@@ -100,8 +100,14 @@ enum LibrarySearchRanker {
         }
 
         guard !queryWords.isEmpty else { return 0 }
-        let titleWords = Set(normalized.split(separator: " ").map(String.init))
-        let present = queryWords.filter { titleWords.contains($0) || normalized.contains($0) }
+        // Substring test only: `normalized` is its own words joined by single
+        // spaces, so a whole-word hit is *always* also a substring hit — a
+        // word-set membership check could never accept anything this doesn't.
+        // Building that set cost a split + a String allocation + a hash per
+        // title word, on every candidate and for both title fields, i.e. the
+        // per-keystroke bulk of ranking, for a branch that never changed the
+        // answer.
+        let present = queryWords.filter { normalized.contains($0) }
         guard !present.isEmpty else { return 0 }
 
         // Tier 2 — every query word present but separated; Tier 3 — only some.


### PR DESCRIPTION
Trois commits : suppression de code mort, deux optimisations, un correctif.

---

## 1. `refactor(nettoyage)` — code mort

Balayage statique des 257 fichiers Swift : chaque déclaration — fonctions, types, cas d'énumération, propriétés à tous les niveaux d'accès, clés de localisation — recoupée avec ses références sur tout le corpus, **tests inclus**.

### Supprimé (7 symboles, zéro référence nulle part)

| Symbole | Pourquoi il est mort |
|---|---|
| `MediaDetailScreen.actionButtonSpacing` | constante de mise en page orpheline |
| `MenuSettingsScreen.enabledCount` | le plafond de 5 onglets passe par `MenuConfigStore` |
| `AppState.imageServerURL` | tout passe par `imageBuilder` |
| `MetadataEditorViewModel.pendingPersonDelete` | l'onglet Casting appelle `deletePerson(at:)` directement, sans étape de confirmation |
| `AdminUserDetailViewModel.resetPasswordAtNextLogin` | l'écran appelle `resetPassword(...)`, qui force déjà le drapeau serveur |
| `SettingsScreen.userInitial` | résidu de la fusion dans `UserAvatar`, qui calcule son initiale lui-même |
| clé `app.name` (fr + en) | parité conservée : 795 / 795 |

### Conservés délibérément, bien que sans appelant

- `CinemaFont.bodyLarge` / `dynamicBodyLarge` — catalogués dans `docs/design-system/typography.md`, vocabulaire délibéré de l'échelle typographique. Retirer un barreau pousserait le prochain appelant vers un `.system(size: 19)` nu, que le design system interdit.
- `getPlaylistItems` / `movePlaylistItem` / `removeFromPlaylist` — API v1 sans UI, documentée comme telle.
- `syncPlayStop` — tranche SyncPlay, sous kill-switch.
- `getLatestMedia` — `HomeViewModelTests` vérifie qu'il n'est **pas** appelé : c'est la garde anti-régression de `mergeRecentlyAdded`. Le supprimer supprimerait la garde.
- `getItemUserData` — appelé en interne par `fetchUserData` (invisible depuis `Shared/`).

---

## 2. Optimisations

### `LibrarySearchRanker.score` — un `Set` logiquement subsumé

```swift
let titleWords = Set(normalized.split(separator: " ").map(String.init))
let present = queryWords.filter { titleWords.contains($0) || normalized.contains($0) }
```

`normalized` étant ses propres mots joints par des espaces simples, un mot entier du titre est **toujours** aussi une sous-chaîne de `normalized` — la première branche ne pouvait rien accepter que la seconde n'accepte déjà. Elle coûtait un `split`, une allocation de `String` et un hachage **par mot du titre**, sur chaque candidat et pour les deux champs de titre (`name` et `originalTitle`) : l'essentiel du travail de classement à chaque frappe débouncée, et sur la résolution d'entités Siri qui partage le même chemin. Les tiers documentés dans CLAUDE.md sont inchangés.

### `SettingsScreen+iOS.profileHeader` — lecture keychain dupliquée

`username` n'est pas une valeur stockée : chaque accès fait un `SecItemCopyMatching` vers securityd, puis instancie un `JSONDecoder` et décode la session. L'en-tête le payait **deux fois par passe de body** — une fois pour le libellé, une fois de plus dans `profileAvatar` qui le relisait pour son propre compte. `profileAvatar` prend désormais le nom en paramètre.

---

## 3. `fix` — prédicat de tri invalide (tvOS)

`SettingsTVProfileSection.displayUsers` triait avec :

```swift
users.sorted { a, _ in a.id == currentUserId }
```

Ce prédicat **ignore son opérande droit** : il répond `true` pour `(a, a)` dès que `a` est l'utilisateur courant, ce qui viole l'irréflexivité. `sorted(by:)` documente sa sortie comme **non spécifiée** pour un prédicat qui n'est pas un ordre faible strict — l'utilisateur courant n'était donc pas placé en premier de façon fiable, et l'ordre relatif des autres était arbitraire, libre de changer d'une évaluation de cette propriété calculée à l'autre. Sur tvOS elle est relue à chaque passe de body et rendue dans un `LazyVGrid` focusable, où un ordre instable déplace les cartes sous le moteur de focus.

Remplacé par un déplacement en tête explicite : O(n), stable pour les autres profils, et qui dit ce qu'il veut dire.

**Portée réelle** : la branche de repli ne construit qu'un seul utilisateur, et un tableau de taille ≤ 1 est insensible au prédicat — le défaut ne se manifestait donc que pour les comptes voyant plusieurs utilisateurs serveur (admins).

**Seule occurrence de cette classe de défaut** : les trois autres `sorted` à deux opérandes nommés (`RemotePlayTarget`, `ServerRegistry`, `MediaSourceQuality`) sont des ordres totaux documentés, et celui d'`AdminDevicesViewModel` est un `>` sur `Date`.

---

## Pistes écartées, et pourquoi

- **`do/catch { errorMessage = loc.userFacingMessage(for: error) }` ×19** dans les view models Admin : duplication réelle, mais c'est la gestion d'erreur idiomatique de Swift. La factoriser sur 19 sites, c'est de l'indirection sans gain comportemental.
- **Cache sur `KeychainService.getUserSession()`** : gain plus large, mais `KeychainService` est instancié en plusieurs endroits et la cohérence du cache traverserait les chemins multi-serveur (`applyActiveServer`, `completeSession`, `UserSwitchSheet`, `logout`, `clearAll`). Risque de cohérence non testable ici, dans une classe liée à l'authentification — écarté au profit du correctif au site d'appel.
- **Imports inutilisés** : l'heuristique par mention textuelle signale ~180 fichiers, presque tous faux positifs (un import Swift fournit des types, pas des occurrences de texte). Non exploitable sans compilateur.
- **Chemins déjà optimisés, vérifiés sans rien trouver** : `CinemaScale.factor` (déjà mémoïsé), `getOrCreateDeviceID` (déjà mis en cache sous verrou), `paintPosition` / `writeTimeLabels` (déjà à double garde), le fan-out de l'API (déjà mis en cache, coalescé, découpé en lots), `PosterCard` / `LibraryPosterCard` (propres, `contentShape` en place).

---

## Vérification

`project.pbxproj` intact — aucun fichier ajouté ni supprimé, donc pas de `xcodegen generate` nécessaire et l'étape « Verify committed project.pbxproj » ne doit pas broncher.

⚠️ **Pas de chaîne Swift dans le conteneur** (Linux, pas de Xcode) : ni compilation ni suite de tests en local. J'ai compensé en restreignant chaque suppression aux symboles à zéro référence prouvée sur tout le corpus, et en rendant les changements de logique préservateurs du comportement par construction — à l'exception assumée du prédicat de tri, dont l'ancien comportement était par définition non spécifié. **La CI est la première vraie compilation.**